### PR TITLE
feat: Display duration in days when exceeding 48 hours

### DIFF
--- a/frontend/src/components/analysis/AnalysisSummary/AnalysisSummary.tsx
+++ b/frontend/src/components/analysis/AnalysisSummary/AnalysisSummary.tsx
@@ -24,6 +24,12 @@ export const AnalysisSummary = ({ summary }: AnalysisSummaryProps) => {
     const minutes = Math.floor(seconds / 60);
     const hours = Math.floor(minutes / 60);
 
+    // If more than 48 hours, show in days with 1 decimal place
+    if (hours > 48) {
+      const days = hours / 24;
+      return `${days.toFixed(1)} days`;
+    }
+
     if (hours > 0) return `${hours}h ${minutes % 60}m`;
     if (minutes > 0) return `${minutes}m ${seconds % 60}s`;
     return `${seconds}s`;


### PR DESCRIPTION
Update overview duration formatter to show days with 1 decimal place when duration exceeds 48 hours for better readability of long captures.

- Durations > 48h: Display as "X.X days"
- Durations <= 48h: Keep existing format (Xh Ym, Xm Ys, Xs)