### PR TITLE
feat: UI polish for legend, story cards, and delete confirmation

### DIFF
--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -161,47 +161,47 @@ export function NetworkControls({
             <div className="legend-title">Node Types</div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#f39c12' }}></span>
-              <i className="bi bi-globe2 me-1"></i>DNS Server
+              DNS Server
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#2ecc71' }}></span>
-              <i className="bi bi-server me-1"></i>Web Server
+              Web Server
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#1abc9c' }}></span>
-              <i className="bi bi-terminal me-1"></i>SSH Server
+              SSH Server
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#16a085' }}></span>
-              <i className="bi bi-folder-symlink me-1"></i>FTP Server
+              FTP Server
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#e91e63' }}></span>
-              <i className="bi bi-envelope me-1"></i>Mail Server
+              Mail Server
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#8e44ad' }}></span>
-              <i className="bi bi-diagram-3 me-1"></i>DHCP Server
+              DHCP Server
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#6c3483' }}></span>
-              <i className="bi bi-clock me-1"></i>NTP Server
+              NTP Server
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#e67e22' }}></span>
-              <i className="bi bi-database me-1"></i>Database Server
+              Database Server
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#d4ac0d' }}></span>
-              <i className="bi bi-router me-1"></i>Router / Gateway
+              Router / Gateway
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#3498db' }}></span>
-              <i className="bi bi-laptop me-1"></i>Client
+              Client
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#e74c3c' }}></span>
-              <i className="bi bi-exclamation-triangle me-1"></i>Anomaly
+              Anomaly
             </div>
             <div className="legend-item">
               <span className="legend-color" style={{ background: '#95a5a6' }}></span>

--- a/frontend/src/components/story/NarrativeView/NarrativeView.tsx
+++ b/frontend/src/components/story/NarrativeView/NarrativeView.tsx
@@ -28,8 +28,8 @@ export const NarrativeView = ({ sections }: NarrativeViewProps) => {
   return (
     <div className="narrative-view">
       {sections.map((section, index) => (
-        <div key={index} className={`card mb-3 ${getSectionClass(section.type)}`}>
-          <div className="card-header bg-white">
+        <div key={index} className={`card mb-3 overflow-hidden ${getSectionClass(section.type)}`}>
+          <div className="card-header bg-white rounded-top">
             <h5 className="mb-0 d-flex align-items-center">
               <i className={`bi ${getSectionIcon(section.type)} me-2`}></i>
               {section.title}

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { isAxiosError } from 'axios';
 import { Card } from '@govtechsg/sgds-react';
 import { AlertCircle } from 'lucide-react';
@@ -13,6 +13,16 @@ export const FileList = () => {
   const recentFiles = useStore(state => state.recentFiles);
   const removeRecentFile = useStore(state => state.removeRecentFile);
   const navigate = useNavigate();
+  const [pendingDeleteFile, setPendingDeleteFile] = useState<RecentFile | null>(null);
+
+  useEffect(() => {
+    if (!pendingDeleteFile) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setPendingDeleteFile(null);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [pendingDeleteFile]);
 
   // Validate files on mount - remove files that no longer exist on backend
   useEffect(() => {
@@ -65,75 +75,141 @@ export const FileList = () => {
     navigate(`/analysis/${file.id}`);
   };
 
-  const handleRemoveFile = (fileId: string, e: React.MouseEvent) => {
+  const handleDeleteClick = (file: RecentFile, e: React.MouseEvent) => {
     e.stopPropagation();
-    removeRecentFile(fileId);
+    setPendingDeleteFile(file);
+  };
+
+  const handleConfirmDelete = () => {
+    if (pendingDeleteFile) {
+      removeRecentFile(pendingDeleteFile.id);
+      setPendingDeleteFile(null);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setPendingDeleteFile(null);
   };
 
   return (
-    <Card className="file-list-card mt-4">
-      <Card.Header>
-        <h5 className="mb-0">
-          <i className="bi bi-clock-history me-2"></i>
-          Recent Uploads
-        </h5>
-      </Card.Header>
-      <Card.Body className="p-0">
-        {recentFiles.length === 0 ? (
-          <div className="text-center text-muted py-4">
-            <p className="mb-0">No recent uploads. Upload a PCAP file to get started!</p>
-          </div>
-        ) : (
-          <div className="list-group list-group-flush">
-            {recentFiles.map(file => (
-              <div
-                key={file.id}
-                className="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
-                style={{ cursor: 'pointer' }}
-                onClick={() => handleFileClick(file)}
-              >
-                <div className="flex-grow-1">
-                  <div className="d-flex align-items-center gap-2">
-                    <i
-                      className="bi bi-file-earmark-binary text-primary"
-                      style={{ fontSize: '1.2rem' }}
-                    ></i>
-                    <div>
-                      <div className="fw-medium">{file.name}</div>
-                      <small className="text-muted">
-                        {formatFileSize(file.size)} • {formatDate(file.uploadedAt)}
-                      </small>
+    <>
+      <Card className="file-list-card mt-4">
+        <Card.Header>
+          <h5 className="mb-0">
+            <i className="bi bi-clock-history me-2"></i>
+            Recent Uploads
+          </h5>
+        </Card.Header>
+        <Card.Body className="p-0">
+          {recentFiles.length === 0 ? (
+            <div className="text-center text-muted py-4">
+              <p className="mb-0">No recent uploads. Upload a PCAP file to get started!</p>
+            </div>
+          ) : (
+            <div className="list-group list-group-flush">
+              {recentFiles.map(file => (
+                <div
+                  key={file.id}
+                  className="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => handleFileClick(file)}
+                >
+                  <div className="flex-grow-1">
+                    <div className="d-flex align-items-center gap-2">
+                      <i
+                        className="bi bi-file-earmark-binary text-primary"
+                        style={{ fontSize: '1.2rem' }}
+                      ></i>
+                      <div>
+                        <div className="fw-medium">{file.name}</div>
+                        <small className="text-muted">
+                          {formatFileSize(file.size)} • {formatDate(file.uploadedAt)}
+                        </small>
+                      </div>
                     </div>
                   </div>
+                  <div className="d-flex gap-2 align-items-center">
+                    <button
+                      className="btn btn-outline-primary btn-sm"
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleFileClick(file);
+                      }}
+                    >
+                      <i className="bi bi-graph-up me-1"></i>
+                      Analyze
+                    </button>
+                    <button
+                      className="btn btn-link btn-sm p-0 text-danger"
+                      onClick={e => handleDeleteClick(file, e)}
+                      title="Delete this file"
+                    >
+                      <i className="bi bi-trash"></i>
+                    </button>
+                  </div>
                 </div>
-                <div className="d-flex gap-2 align-items-center">
+              ))}
+            </div>
+          )}
+          <div className="card-footer text-muted small">
+            <AlertCircle size={14} className="me-1" />
+            Files are automatically deleted after 12 hours
+          </div>
+        </Card.Body>
+      </Card>
+
+      {/* Delete confirmation modal */}
+      {pendingDeleteFile && (
+        <>
+          <div
+            className="modal fade show d-block"
+            tabIndex={-1}
+            role="dialog"
+            onClick={handleCancelDelete}
+          >
+            <div
+              className="modal-dialog modal-dialog-centered"
+              role="document"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="modal-content">
+                <div className="modal-header">
+                  <h5 className="modal-title">Delete File</h5>
                   <button
-                    className="btn btn-outline-primary btn-sm"
-                    onClick={e => {
-                      e.stopPropagation();
-                      handleFileClick(file);
-                    }}
+                    type="button"
+                    className="btn-close"
+                    onClick={handleCancelDelete}
+                    aria-label="Close"
+                  />
+                </div>
+                <div className="modal-body">
+                  <p className="mb-0">
+                    Are you sure you want to remove <strong>{pendingDeleteFile.name}</strong> from
+                    your recent uploads?
+                  </p>
+                </div>
+                <div className="modal-footer">
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary"
+                    onClick={handleCancelDelete}
                   >
-                    <i className="bi bi-graph-up me-1"></i>
-                    Analyze
+                    Cancel
                   </button>
                   <button
-                    className="btn btn-link btn-sm p-0 text-danger"
-                    onClick={e => handleRemoveFile(file.id, e)}
-                    title="Delete this file"
+                    type="button"
+                    className="btn btn-outline-danger"
+                    onClick={handleConfirmDelete}
                   >
-                    <i className="bi bi-trash"></i>
+                    Delete
                   </button>
                 </div>
               </div>
-            ))}
+            </div>
           </div>
-        )}
-        <div className="card-footer text-muted small">
-          <AlertCircle size={14} className="me-1" />
-          Files are automatically deleted after 12 hours
-        </div>
-      </Card.Body>
-    </Card>
+          <div className="modal-backdrop fade show" onClick={handleCancelDelete}></div>
+        </>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
## Summary
- Remove icons from network diagram legend node types (color swatches + labels only)
- Fix story page `card-header bg-white` top corner clipping with `overflow-hidden` and `rounded-top`
- Add delete confirmation modal to recent uploads with backdrop click, Esc key, and muted outline buttons

## Test plan
- [x] Network diagram legend shows only color swatches and labels, no icons
- [x] Story page card headers have properly rounded top corners with no border cutoff
- [x] Clicking delete on a recent upload shows the confirmation modal
- [x] Modal closes on Cancel, backdrop click, and Esc key
- [x] Confirming delete removes the file from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)