### PR TITLE
fix: conversation filter and detail UI improvements

### DIFF
--- a/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
+++ b/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
@@ -29,13 +29,7 @@ function countryFlag(code: string): string {
 }
 
 function isPrivateIp(ip: string): boolean {
-  return (
-    /^10\./.test(ip) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(ip) ||
-    /^192\.168\./.test(ip) ||
-    /^127\./.test(ip) ||
-    /^169\.254\./.test(ip)
-  );
+  return /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|169\.254\.|f[cd][0-9a-f]{2}:|fe80:)/i.test(ip);
 }
 
 function GeoInfoRows({ geo, label, ip }: { geo?: ConversationGeoInfo; label: string; ip: string }) {

--- a/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
+++ b/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
@@ -669,8 +669,7 @@ export function ConversationFilterPanel({
                     onDeselectAll={() => onFiltersChange({ countries: [] })}
                   />
                   <div className="d-flex flex-wrap gap-1 mt-1">
-                    {countryOptions.filter(option => option.split('|')[0]).map(option => {
-                      const [code, name] = option.split('|');
+                    {countryOptions.map(o => o.split('|')).filter(([code]) => code).map(([code, name]) => {
                       const selected = (filters.countries ?? []).includes(code);
                       return (
                         <button
@@ -697,7 +696,7 @@ export function ConversationFilterPanel({
                     <InfoPopover
                       id="info-devicetype"
                       title="Device Type"
-                      body="Filter by the classified device type of hosts in each conversation. Device types are inferred from traffic patterns and port usage. Hover over a device type badge in the conversation details to see the confidence score and evidence."
+                      body="Filter by the classified device type of hosts in each conversation. Device types are inferred from traffic patterns and port usage. Click on a device type badge in the conversation details to see the confidence score and evidence."
                     />
                   }
                   onSelectAll={() => onFiltersChange({ deviceTypes: [...DEVICE_TYPES] })}
@@ -712,7 +711,7 @@ export function ConversationFilterPanel({
                         key={dt}
                         type="button"
                         className={`badge rounded-pill border-0 filter-pill ${selected ? 'active' : ''}`}
-                        style={selected ? { backgroundColor: bg, color: '#fff' } : undefined}
+                        style={selected ? { backgroundColor: bg, color: getTextColor(bg) } : undefined}
                         onClick={() => toggle('deviceTypes', dt, filters.deviceTypes ?? [])}
                       >
                         {deviceTypeLabel(dt)}


### PR DESCRIPTION
## Summary
- Remove icons from Country and Device Type filter section headers
- Align Country/Device Type badge styles with other filter pills; fix empty country badge
- Add InfoPopover to Device Type filter with hint about confidence/evidence hover
- Show "Internal" label for private IPs with no geo data in conversation detail
- Remove emoji icons from device type badges everywhere

## Test plan
- [ ] Open conversation filter panel — Country and Device Type headers have no icon
- [ ] Country and Device Type pills match the style of other filter pills when unselected
- [ ] No empty/blank badge appears in the Country filter
- [ ] Device Type filter tooltip mentions hovering for confidence/evidence
- [ ] In conversation detail, source IP shows "Internal" when it is a private/RFC1918 address
- [ ] Device type badges in detail and filter show label only, no emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)