### PR TITLE
fix: enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Normalize line endings on commit
+* text=auto
+
+# Force LF for shell scripts — CRLF breaks shebangs on Linux/macOS
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Normalize line endings on commit
 * text=auto
 
-# Force LF for shell scripts — CRLF breaks shebangs on Linux/macOS
+# Force LF for scripts with shebangs — CRLF breaks them on Linux/macOS
 *.sh text eol=lf
+*.py text eol=lf


### PR DESCRIPTION
## Summary
- Adds a `.gitattributes` file to the repo root
- Forces LF line endings for `*.sh` files on checkout, even on Windows
- Uses `text=auto` for all other files so Git normalises them appropriately

## Why
Windows Git clients default to CRLF on checkout, which breaks shebangs and script execution inside Docker containers when the repo is cloned on Windows.

## Test plan
- [ ] Clone repo on Windows and verify `*.sh` files have LF endings (`file backend/docker-entrypoint.sh` should report no CRLF)
- [ ] Confirm Docker containers still start correctly after a fresh clone on Linux/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)