### PR TITLE
feat: add GHCR publish and Trivy image scan workflows

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,80 @@
+name: Publish to GHCR
+
+on:
+  # Triggers minor version ( vX.Y.Z-ShortHash )
+  push:
+    branches:
+      - main
+  # Triggers major version ( vX.Y.Z )
+  release:
+    types: [created]
+
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - name: tracepcap-backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+          - name: tracepcap-nginx
+            context: .
+            dockerfile: ./nginx/Dockerfile
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+
+          # Convert repository owner to lowercase for Docker image naming
+          REPO_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "REPO_OWNER_LOWER=$REPO_OWNER_LOWER" >> $GITHUB_ENV
+
+          # Use the input tag or default to 'latest'
+          TAG="${{ github.event.inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="latest"
+          fi
+          echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
+
+          # Also create a tag with the commit SHA
+          echo "SHA_TAG=${TAG}-${SHORT_SHA}" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/${{ env.REPO_OWNER_LOWER }}/${{ matrix.name }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ env.REPO_OWNER_LOWER }}/${{ matrix.name }}:${{ env.SHA_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Log out of GitHub Container Registry
+        if: always()
+        run: docker logout ghcr.io

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,77 @@
+name: Trivy Image Scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to scan (default: latest)"
+        required: false
+        default: "latest"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      actions: read           # required for SARIF upload in private repos
+      security-events: write  # required for SARIF upload to Security tab
+
+    strategy:
+      matrix:
+        include:
+          - name: tracepcap-backend
+          - name: tracepcap-nginx
+
+    steps:
+      - name: Resolve image reference
+        run: |
+          REPO_OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${REPO_OWNER_LOWER}/${{ matrix.name }}:${{ github.event.inputs.image_tag }}"
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy scan (SARIF)
+        # Note: severity filtering is ignored in SARIF mode — all severities are
+        # included in the SARIF file; use the Security tab UI to filter by severity.
+        uses: aquasecurity/trivy-action@v0.35.0
+        with:
+          image-ref: ${{ env.IMAGE }}
+          format: sarif
+          output: trivy-${{ matrix.name }}.sarif
+          ignore-unfixed: true
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        continue-on-error: true  # silently skip if Advanced Security is not enabled
+        with:
+          sarif_file: trivy-${{ matrix.name }}.sarif
+          category: trivy-${{ matrix.name }}
+
+      - name: Run Trivy scan (table summary)
+        uses: aquasecurity/trivy-action@v0.35.0
+        with:
+          image-ref: ${{ env.IMAGE }}
+          format: table
+          output: trivy-${{ matrix.name }}-summary.txt
+          severity: CRITICAL,HIGH,MEDIUM
+          ignore-unfixed: true
+
+      - name: Write results to job summary
+        if: always()
+        run: |
+          echo "## Trivy Scan — \`${{ matrix.name }}:${{ github.event.inputs.image_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat trivy-${{ matrix.name }}-summary.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Log out of GitHub Container Registry
+        if: always()
+        run: docker logout ghcr.io


### PR DESCRIPTION
## Summary

- **publish-ghcr.yml**: builds and pushes `tracepcap-backend` and `tracepcap-nginx` to GHCR on push to `main`, new release, or manual dispatch; tags images with `latest` and `latest-<short-sha>`; GHA layer caching enabled
- **trivy-scan.yml**: manual-dispatch workflow scanning both images for unfixed CRITICAL/HIGH/MEDIUM CVEs; results uploaded to the GitHub Security tab (SARIF) and printed as a table in the job summary

## Notes

- SARIF severity filtering is not supported by `trivy-action` — all severities are included in the SARIF upload; use the Security tab UI to filter. The table summary in the job summary correctly filters to CRITICAL/HIGH/MEDIUM only.
- `continue-on-error: true` on the SARIF upload step so the workflow doesn't fail if Advanced Security is not enabled (not an issue for this public repo).

## Test plan

- [ ] Merge to `main` and confirm publish-ghcr.yml triggers and both images appear in GHCR packages
- [ ] Manually trigger trivy-scan.yml and verify results appear in the Security tab and job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)