### PR TITLE
fix: patch 3 critical CVEs in backend dependencies

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -24,6 +24,9 @@
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <springdoc.version>2.3.0</springdoc.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
+        <!-- CVE fixes: override versions managed by Spring Boot parent -->
+        <postgresql.version>42.7.2</postgresql.version>
+        <tomcat.version>10.1.35</tomcat.version>
     </properties>
 
     <dependencies>
@@ -132,7 +135,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>2.9.2</version>
+            <version>3.2.2</version>
         </dependency>
 
         <!-- PDF report generation -->

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,6 +27,7 @@
         <!-- CVE fixes: override versions managed by Spring Boot parent -->
         <postgresql.version>42.7.2</postgresql.version>
         <tomcat.version>10.1.35</tomcat.version>
+        <tika.version>3.2.2</tika.version>
     </properties>
 
     <dependencies>
@@ -135,7 +136,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>3.2.2</version>
+            <version>${tika.version}</version>
         </dependency>
 
         <!-- PDF report generation -->


### PR DESCRIPTION
## Summary

Patches 3 critical CVEs identified by the Trivy image scan.

| CVE | Dependency | Before | After |
|---|---|---|---|
| CVE-2024-1597 | `org.postgresql:postgresql` | 42.6.0 | 42.7.2 |
| CVE-2025-24813 | `tomcat-embed-core` | 10.1.17 | 10.1.35 |
| CVE-2025-66516 | `org.apache.tika:tika-core` | 2.9.2 | 3.2.2 |

`postgresql` and `tomcat-embed-core` are managed by the Spring Boot parent BOM so they are patched via property overrides (`<postgresql.version>` and `<tomcat.version>`) in `pom.xml`. `tika-core` is pinned explicitly and bumped directly.

Tika 3.x is a major version bump — usage was verified to only use stable core APIs (`Tika`, `MimeType`, `MimeTypeException`, `MimeTypes`) that are unchanged across 2.x → 3.x.

## Test plan

- [ ] `mvn dependency:resolve` passes cleanly
- [ ] Re-run Trivy scan and confirm the 3 CVEs are no longer reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)