### PR TITLE
feat: add cross-PCAP comparison with joint topology diagram

### DIFF
--- a/frontend/src/assets/styles/index.css
+++ b/frontend/src/assets/styles/index.css
@@ -158,6 +158,7 @@ body {
 .home-page,
 .upload-page,
 .analysis-page,
+.network-diagram-page,
 .not-found-page {
   max-width: 1200px;
   margin: 0 auto;

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -85,6 +85,8 @@ interface NetworkControlsProps {
   onHasRisksOnlyChange: (val: boolean) => void;
   activeFilterCount: number;
   onClearAllFilters: () => void;
+  /** Whether the panel starts collapsed. Defaults to false (expanded). */
+  defaultCollapsed?: boolean;
 }
 
 function edgeLegendLabel(key: string): string {
@@ -153,8 +155,9 @@ export function NetworkControls({
   onHasRisksOnlyChange,
   activeFilterCount,
   onClearAllFilters,
+  defaultCollapsed = false,
 }: NetworkControlsProps) {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(!defaultCollapsed);
   const [showColorInfo, setShowColorInfo] = useState(false);
   const [ipInput, setIpInput] = useState(ipFilter);
   const [portInput, setPortInput] = useState(portFilter);

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -39,17 +39,31 @@ interface NetworkGraphProps {
   onLayoutChange?: (layout: 'forceDirected2d' | 'hierarchicalTd') => void;
   /** Called once after ELK layout completes and ReactFlow has painted. */
   onLayoutComplete?: () => void;
+  /**
+   * In compare mode, the label of the "primary" (File A) source.
+   * Nodes/edges exclusive to the secondary source (File B) are rendered with
+   * a dashed style to visually distinguish them.
+   */
+  primarySource?: string;
 }
 
 interface FlowNodeData extends Record<string, unknown> {
   label: string;
   color: string;
   icon: string;
+  /** Which file(s) this node appears in — set only in compare mode. */
+  sources?: string[];
+  /** Label of the primary (File A) source — used to determine dashed styling. */
+  primarySource?: string;
 }
 
 interface FlowEdgeData extends Record<string, unknown> {
   label: string;
   offset: number; // perpendicular pixel offset for parallel edges
+  /** Which file(s) this edge appears in — set only in compare mode. */
+  sources?: string[];
+  /** Label of the primary (File A) source — used to determine dashed styling. */
+  primarySource?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -215,7 +229,8 @@ const ELK_OPTIONS: Record<string, Record<string, string>> = {
 async function computeLayout(
   nodes: GraphNode[],
   edges: GraphEdge[],
-  layoutType: 'forceDirected2d' | 'hierarchicalTd'
+  layoutType: 'forceDirected2d' | 'hierarchicalTd',
+  primarySource?: string
 ): Promise<{ nodes: Node[]; edges: Edge[] }> {
   const dedupedEdges = deduplicateEdges(edges);
   const offsetMap = assignEdgeOffsets(dedupedEdges);
@@ -237,6 +252,8 @@ async function computeLayout(
       label: n.label,
       color: getNodeColor(n.data),
       icon: getNodeIcon(n.data),
+      sources: n.data.sources,
+      primarySource,
     },
     width: NODE_WIDTH,
     height: NODE_HEIGHT,
@@ -244,15 +261,17 @@ async function computeLayout(
 
   const rfEdges: Edge[] = dedupedEdges.map(e => {
     const color = getProtocolColor(e.data.protocol);
+    const sources = e.data.sources;
+    const isShared = sources && sources.length >= 2;
     return {
       id: e.id,
       source: e.source,
       target: e.target,
       type: 'networkEdge',
-      data: { label: e.label, offset: offsetMap.get(e.id) ?? 0 },
+      data: { label: e.label, offset: offsetMap.get(e.id) ?? 0, sources, primarySource },
       style: {
         stroke: color,
-        strokeWidth: 1.5,
+        strokeWidth: isShared ? 2.5 : 1.5,
       },
     };
   });
@@ -265,9 +284,19 @@ async function computeLayout(
 // ---------------------------------------------------------------------------
 
 function NetworkNode({ data }: NodeProps) {
-  const { label, color, icon } = data as FlowNodeData;
+  const { label, color, icon, sources, primarySource } = data as FlowNodeData;
+  const isSecondaryOnly =
+    sources?.length === 1 && primarySource !== undefined && sources[0] !== primarySource;
+  const isShared = sources !== undefined && sources.length >= 2;
   return (
-    <div className="network-flow-node" style={{ borderColor: color }}>
+    <div
+      className="network-flow-node"
+      style={{
+        borderColor: color,
+        borderStyle: isSecondaryOnly ? 'dashed' : 'solid',
+        opacity: isSecondaryOnly ? 0.8 : 1,
+      }}
+    >
       <Handle
         type="target"
         position={Position.Top}
@@ -284,6 +313,19 @@ function NetworkNode({ data }: NodeProps) {
         <i className={`bi ${icon}`} />
       </div>
       <span className="network-flow-label">{label}</span>
+      {isShared && (
+        <i
+          className="bi bi-layers-fill"
+          style={{
+            position: 'absolute',
+            bottom: 2,
+            right: 2,
+            fontSize: '0.6rem',
+            color,
+            opacity: 0.85,
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -293,7 +335,12 @@ function NetworkNode({ data }: NodeProps) {
 // ---------------------------------------------------------------------------
 
 function NetworkEdge({ id, sourceX, sourceY, targetX, targetY, data, style }: EdgeProps) {
-  const { label, offset } = (data ?? { label: '', offset: 0 }) as FlowEdgeData;
+  const { label, offset, sources, primarySource } = (data ?? { label: '', offset: 0 }) as FlowEdgeData;
+  const isSecondaryOnly =
+    sources?.length === 1 && primarySource !== undefined && sources[0] !== primarySource;
+  const edgeStyle = isSecondaryOnly
+    ? { ...style, strokeDasharray: '6 3' }
+    : style;
 
   // Use a canonical direction for the perpendicular so that A→B and B→A
   // both receive the same perpendicular unit vector.
@@ -322,7 +369,7 @@ function NetworkEdge({ id, sourceX, sourceY, targetX, targetY, data, style }: Ed
 
   return (
     <>
-      <BaseEdge id={id} path={edgePath} style={style} />
+      <BaseEdge id={id} path={edgePath} style={edgeStyle} />
       <polygon
         points="-6,-3.5 6,0 -6,3.5"
         transform={`translate(${arrowX},${arrowY}) rotate(${angle})`}
@@ -360,6 +407,7 @@ export const NetworkGraph = memo(function NetworkGraph({
   layoutType = 'forceDirected2d',
   onLayoutChange,
   onLayoutComplete,
+  primarySource,
 }: NetworkGraphProps) {
   const themeMode = useStore(s => s.themeMode);
   const [sysDark, setSysDark] = useState(
@@ -403,7 +451,7 @@ export const NetworkGraph = memo(function NetworkGraph({
     }
 
     setLayouting(true);
-    computeLayout(visibleNodes, edges, layoutType)
+    computeLayout(visibleNodes, edges, layoutType, primarySource)
       .then(({ nodes: n, edges: e }) => {
         if (!active) return;
         setRfNodes(n);
@@ -419,7 +467,7 @@ export const NetworkGraph = memo(function NetworkGraph({
     return () => {
       active = false;
     };
-  }, [visibleNodes, edges, layoutType]);
+  }, [visibleNodes, edges, layoutType, primarySource]);
 
   // Signal the caller once the layout has been computed and painted.
   // Works for both the normal case (rfNodes set after ELK) and the empty-data

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { isAxiosError } from 'axios';
 import { Card, Modal } from '@govtechsg/sgds-react';
 import { AlertCircle } from 'lucide-react';
@@ -22,6 +22,28 @@ export const FileList = () => {
   const [loading, setLoading] = useState(true);
   const [pendingDeleteFile, setPendingDeleteFile] = useState<FileMetadata | null>(null);
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+  const [selectedForCompare, setSelectedForCompare] = useState<Set<string>>(new Set());
+  const [showInfo, setShowInfo] = useState(false);
+  const infoRef = useRef<HTMLDivElement>(null);
+
+  // Close info popover when clicking outside
+  useEffect(() => {
+    if (!showInfo) return;
+    const handler = (e: MouseEvent) => {
+      if (infoRef.current && !infoRef.current.contains(e.target as Node)) {
+        setShowInfo(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showInfo]);
+
+  const toggleCompareSelect = (fileId: string) =>
+    setSelectedForCompare(prev => {
+      const next = new Set(prev);
+      next.has(fileId) ? next.delete(fileId) : next.add(fileId);
+      return next;
+    });
 
   const fetchFiles = async () => {
     try {
@@ -80,19 +102,70 @@ export const FileList = () => {
     <>
       <Card className="file-list-card mt-4">
         <Card.Header className="d-flex justify-content-between align-items-center">
-          <h5 className="mb-0">
-            <i className="bi bi-folder2-open me-2"></i>
-            All Uploads
-          </h5>
+          <div className="d-flex align-items-center gap-1">
+            <h5 className="mb-0">
+              <i className="bi bi-folder2-open me-2"></i>
+              All Uploads
+            </h5>
+            <div ref={infoRef} style={{ position: 'relative' }}>
+              <button
+                type="button"
+                className="btn btn-link p-0 text-muted"
+                style={{ lineHeight: 1 }}
+                onClick={() => setShowInfo(v => !v)}
+                aria-label="About file actions"
+              >
+                <i className="bi bi-info-circle" style={{ fontSize: '0.85rem' }}></i>
+              </button>
+              {showInfo && (
+                <div
+                  className="card shadow"
+                  style={{
+                    position: 'absolute',
+                    top: '1.6rem',
+                    left: 0,
+                    zIndex: 100,
+                    width: '260px',
+                    fontSize: '0.82rem',
+                  }}
+                >
+                  <div className="card-body py-2 px-3">
+                    <p className="mb-1">
+                      <i className="bi bi-graph-up me-1 text-primary"></i>
+                      Click <strong>Analyze</strong> on any file to open its individual analysis.
+                    </p>
+                    <p className="mb-0">
+                      <i className="bi bi-diagram-3 me-1 text-primary"></i>
+                      Select <strong>two or more</strong> files using the checkboxes, then click <strong>Compare selected</strong> for cross-PCAP topology analysis.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
           {files.length > 0 && (
-            <button
-              type="button"
-              className="btn btn-outline-danger btn-sm"
-              onClick={() => setConfirmDeleteAll(true)}
-            >
-              <i className="bi bi-trash me-1"></i>
-              Delete all
-            </button>
+            <div className="d-flex gap-2">
+              {selectedForCompare.size >= 2 && (
+                <button
+                  type="button"
+                  className="btn btn-outline-primary btn-sm"
+                  onClick={() =>
+                    navigate(`/compare?files=${[...selectedForCompare].join(',')}`)
+                  }
+                >
+                  <i className="bi bi-diagram-3 me-1"></i>
+                  Compare selected ({selectedForCompare.size})
+                </button>
+              )}
+              <button
+                type="button"
+                className="btn btn-outline-danger btn-sm"
+                onClick={() => setConfirmDeleteAll(true)}
+              >
+                <i className="bi bi-trash me-1"></i>
+                Delete all
+              </button>
+            </div>
           )}
         </Card.Header>
         <Card.Body className="p-0">
@@ -117,12 +190,22 @@ export const FileList = () => {
               {files.map(file => (
                 <div
                   key={file.fileId}
-                  className="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
-                  style={{ cursor: 'pointer' }}
-                  onClick={() => navigate(`/analysis/${file.fileId}`)}
+                  className="list-group-item d-flex justify-content-between align-items-center"
                 >
                   <div className="flex-grow-1">
                     <div className="d-flex align-items-center gap-2">
+                      <input
+                        type="checkbox"
+                        className="form-check-input mt-0 flex-shrink-0"
+                        checked={selectedForCompare.has(file.fileId)}
+                        disabled={file.status.toLowerCase() !== 'completed'}
+                        title={
+                          file.status.toLowerCase() !== 'completed'
+                            ? 'File must be fully processed to compare'
+                            : 'Select for comparison'
+                        }
+                        onChange={() => toggleCompareSelect(file.fileId)}
+                      />
                       <i
                         className="bi bi-file-earmark-binary text-primary"
                         style={{ fontSize: '1.2rem' }}
@@ -147,20 +230,14 @@ export const FileList = () => {
                   <div className="d-flex gap-2 align-items-center">
                     <button
                       className="btn btn-outline-primary btn-sm"
-                      onClick={e => {
-                        e.stopPropagation();
-                        navigate(`/analysis/${file.fileId}`);
-                      }}
+                      onClick={() => navigate(`/analysis/${file.fileId}`)}
                     >
                       <i className="bi bi-graph-up me-1"></i>
                       Analyze
                     </button>
                     <button
                       className="btn btn-link btn-sm p-0 text-danger"
-                      onClick={e => {
-                        e.stopPropagation();
-                        setPendingDeleteFile(file);
-                      }}
+                      onClick={() => setPendingDeleteFile(file)}
                       title="Delete this file"
                     >
                       <i className="bi bi-trash"></i>

--- a/frontend/src/features/network/hooks/useCompareData.ts
+++ b/frontend/src/features/network/hooks/useCompareData.ts
@@ -1,0 +1,122 @@
+import { useState, useEffect } from 'react';
+import { conversationService } from '@/features/conversation/services/conversationService';
+import { networkService } from '../services/networkService';
+import { mergeGraphs } from '../services/mergeGraphs';
+import type { GraphNode, GraphEdge } from '../types';
+
+const MAX_CONVERSATIONS = 500;
+
+export interface CompareStats {
+  totalNodes: number;
+  totalEdges: number;
+  totalPackets: number;
+  totalBytes: number;
+}
+
+export interface FileStats {
+  label: string;
+  stats: CompareStats;
+}
+
+export interface UseCompareDataReturn {
+  mergedNodes: GraphNode[];
+  mergedEdges: GraphEdge[];
+  perFileStats: FileStats[];
+  labels: string[];
+  loading: boolean;
+  error: string | null;
+}
+
+async function fetchGraphForFile(fileId: string) {
+  const [response, hostClassifications] = await Promise.all([
+    conversationService.getConversations(fileId, {
+      ip: '',
+      port: '',
+      payloadContains: '',
+      protocols: [],
+      l7Protocols: [],
+      apps: [],
+      categories: [],
+      hasRisks: false,
+      fileTypes: [],
+      riskTypes: [],
+      customSignatures: [],
+      deviceTypes: [],
+      countries: [],
+      sortBy: '',
+      sortDir: 'asc',
+      page: 1,
+      pageSize: 10000,
+    }),
+    conversationService.getHostClassifications(fileId).catch(() => undefined),
+  ]);
+
+  return networkService.buildNetworkGraph(
+    response.data,
+    undefined,
+    MAX_CONVERSATIONS,
+    hostClassifications
+  );
+}
+
+export function useCompareData(
+  fileIds: string[],
+  labels: string[]
+): UseCompareDataReturn {
+  const [mergedNodes, setMergedNodes] = useState<GraphNode[]>([]);
+  const [mergedEdges, setMergedEdges] = useState<GraphEdge[]>([]);
+  const [perFileStats, setPerFileStats] = useState<FileStats[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Stable keys to avoid re-fetching on every render
+  const fileIdsKey = fileIds.join(',');
+  const labelsKey = labels.join(',');
+
+  useEffect(() => {
+    let active = true;
+
+    const run = async () => {
+      // Wait until labels are resolved — empty labels means filenames haven't loaded yet
+      if (labels.length === 0) return;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const graphs = await Promise.all(fileIds.map(id => fetchGraphForFile(id)));
+
+        if (!active) return;
+
+        const merged = mergeGraphs(graphs, labels);
+
+        setMergedNodes(merged.nodes);
+        setMergedEdges(merged.edges);
+        setPerFileStats(
+          graphs.map((g, i) => ({
+            label: labels[i],
+            stats: {
+              totalNodes: g.stats.totalNodes,
+              totalEdges: g.stats.totalEdges,
+              totalPackets: g.stats.totalPackets,
+              totalBytes: g.stats.totalBytes,
+            },
+          }))
+        );
+      } catch (err) {
+        if (!active) return;
+        setError(err instanceof Error ? err.message : 'Failed to load comparison data');
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    run();
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileIdsKey, labelsKey]);
+
+  return { mergedNodes, mergedEdges, perFileStats, labels, loading, error };
+}

--- a/frontend/src/features/network/services/mergeGraphs.ts
+++ b/frontend/src/features/network/services/mergeGraphs.ts
@@ -1,0 +1,153 @@
+import type { GraphNode, GraphEdge, NetworkGraphData } from '../types';
+
+/**
+ * Returns true when two nodes represent the same physical host.
+ *
+ * IP match is required. If both nodes have a MAC address, they must also
+ * match — a MAC mismatch means the IP was reused (e.g. DHCP lease turnover)
+ * and the nodes should NOT be merged.
+ *
+ * L2-only nodes (identified by MAC, no real IP) are matched by their MAC id
+ * and never get the MAC-conflict split treatment.
+ */
+function isSameHost(a: GraphNode, b: GraphNode): boolean {
+  if (a.data.isL2 || b.data.isL2) return a.id === b.id;
+  const macA = a.data.mac?.toLowerCase();
+  const macB = b.data.mac?.toLowerCase();
+  if (macA && macB && macA !== macB) return false;
+  return true;
+}
+
+function edgeKey(e: GraphEdge): string {
+  const appOrProto = (e.data.appName ?? e.data.protocol).toLowerCase();
+  return `${e.source}\0${e.target}\0${appOrProto}`;
+}
+
+/**
+ * Merge N NetworkGraphData objects into a single unified graph for comparison.
+ *
+ * Nodes are matched by IP (node ID) with a MAC tiebreaker: if both nodes have
+ * a MAC address and they differ, the IP is treated as reused (e.g. DHCP lease
+ * turnover) and the nodes are kept separate rather than incorrectly merged.
+ *
+ * Edges are matched by the (source, target, appOrProtocol) triple — the same
+ * dedup key used in NetworkGraph's deduplicateEdges function.
+ *
+ * Each resulting node/edge carries a `sources` array indicating which file(s)
+ * it appears in, which drives the visual encoding in NetworkGraph.
+ */
+export function mergeGraphs(
+  graphs: NetworkGraphData[],
+  labels: string[]
+): NetworkGraphData {
+  const nodeMap = new Map<string, GraphNode>();
+  const edgeMap = new Map<string, GraphEdge>();
+
+  for (let i = 0; i < graphs.length; i++) {
+    const graph = graphs[i];
+    const label = labels[i];
+
+    // ── Per-file node ID remap (for MAC-conflict splits within this file) ────
+    // Maps this file's original node ID → the ID used in nodeMap.
+    const nodeIdRemap = new Map<string, string>();
+
+    // ── Nodes ────────────────────────────────────────────────────────────────
+    for (const node of graph.nodes) {
+      const existing = nodeMap.get(node.id);
+
+      if (existing && isSameHost(existing, node)) {
+        // Same host seen in a previous file — accumulate stats and add label
+        nodeMap.set(node.id, {
+          ...existing,
+          data: {
+            ...existing.data,
+            packetsSent: existing.data.packetsSent + node.data.packetsSent,
+            packetsReceived: existing.data.packetsReceived + node.data.packetsReceived,
+            bytesSent: existing.data.bytesSent + node.data.bytesSent,
+            bytesReceived: existing.data.bytesReceived + node.data.bytesReceived,
+            totalBytes: existing.data.totalBytes + node.data.totalBytes,
+            connections: existing.data.connections + node.data.connections,
+            protocols: [...new Set([...existing.data.protocols, ...node.data.protocols])],
+            isAnomaly: existing.data.isAnomaly || node.data.isAnomaly,
+            sources: [...(existing.data.sources ?? []), label],
+          },
+        });
+        nodeIdRemap.set(node.id, node.id);
+      } else if (existing) {
+        // Same IP but different MAC — IP was reused by a different host.
+        const remappedId = `${node.id}~${label}`;
+        nodeMap.set(remappedId, {
+          ...node,
+          id: remappedId,
+          data: { ...node.data, sources: [label] },
+        });
+        nodeIdRemap.set(node.id, remappedId);
+      } else {
+        // First time we see this node
+        nodeMap.set(node.id, {
+          ...node,
+          data: { ...node.data, sources: [label] },
+        });
+        nodeIdRemap.set(node.id, node.id);
+      }
+    }
+
+    // ── Edges ────────────────────────────────────────────────────────────────
+    for (const edge of graph.edges) {
+      const remappedEdge: GraphEdge = {
+        ...edge,
+        source: nodeIdRemap.get(edge.source) ?? edge.source,
+        target: nodeIdRemap.get(edge.target) ?? edge.target,
+      };
+      const key = edgeKey(remappedEdge);
+      const existing = edgeMap.get(key);
+
+      if (existing) {
+        const totalPackets = existing.data.packetCount + remappedEdge.data.packetCount;
+        const totalBytes = existing.data.totalBytes + remappedEdge.data.totalBytes;
+        const raw = existing.data.appName ?? existing.data.protocol;
+        const displayName = raw.charAt(0).toUpperCase() + raw.slice(1);
+        edgeMap.set(key, {
+          ...existing,
+          id: `${existing.id}|${remappedEdge.id}`,
+          label: `${displayName} (${totalPackets})`,
+          data: {
+            ...existing.data,
+            packetCount: totalPackets,
+            totalBytes,
+            sources: [...(existing.data.sources ?? []), label],
+          },
+        });
+      } else {
+        edgeMap.set(key, {
+          ...remappedEdge,
+          data: { ...remappedEdge.data, sources: [label] },
+        });
+      }
+    }
+  }
+
+  const mergedNodes = [...nodeMap.values()];
+  const mergedEdges = [...edgeMap.values()];
+
+  const protocolBreakdown: Record<string, number> = {};
+  for (const edge of mergedEdges) {
+    const proto = edge.data.protocol;
+    protocolBreakdown[proto] = (protocolBreakdown[proto] ?? 0) + edge.data.packetCount;
+  }
+
+  const totalPackets = graphs.reduce((s, g) => s + g.stats.totalPackets, 0);
+  const totalBytes = graphs.reduce((s, g) => s + g.stats.totalBytes, 0);
+
+  return {
+    nodes: mergedNodes,
+    edges: mergedEdges,
+    stats: {
+      totalNodes: mergedNodes.length,
+      totalEdges: mergedEdges.length,
+      totalPackets,
+      totalBytes,
+      protocolBreakdown,
+    },
+  };
+}

--- a/frontend/src/features/network/types/index.ts
+++ b/frontend/src/features/network/types/index.ts
@@ -52,6 +52,8 @@ export interface NodeData {
   manufacturer?: string;
   /** TTL observed for this host. */
   ttl?: number;
+  /** Which file(s) this node appears in — set only in compare mode. */
+  sources?: string[];
 }
 
 export interface GraphEdge {
@@ -80,6 +82,8 @@ export interface EdgeData {
   srcCountry?: string;
   dstCountry?: string;
   hasRisks?: boolean;
+  /** Which file(s) this edge appears in — set only in compare mode. */
+  sources?: string[];
 }
 
 export interface NetworkGraphData {

--- a/frontend/src/pages/Compare/ComparePage.tsx
+++ b/frontend/src/pages/Compare/ComparePage.tsx
@@ -68,15 +68,14 @@ export const ComparePage = () => {
 
   useEffect(() => {
     if (fileIds.length < 2) return;
-    apiClient
-      .get(API_ENDPOINTS.FILES_LIST, { params: { sort: 'uploadedAt,desc', size: 50 } })
-      .then(res => {
-        const list: { fileId: string; fileName: string }[] = res.data.content ?? [];
-        setFileNames(fileIds.map((id, i) => list.find(f => f.fileId === id)?.fileName ?? `File ${i + 1}`));
-      })
-      .catch(() => {
-        setFileNames(fileIds.map((_, i) => `File ${i + 1}`));
-      });
+    Promise.all(
+      fileIds.map((id, i) =>
+        apiClient
+          .get(API_ENDPOINTS.FILE_METADATA(id))
+          .then(res => res.data.fileName as string)
+          .catch(() => `File ${i + 1}`)
+      )
+    ).then(setFileNames);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fileIds.join(',')]);
 
@@ -581,7 +580,11 @@ export const ComparePage = () => {
         <NodeDetails
           node={selectedNode}
           edges={mergedEdges}
-          fileId={fileIds[0]}
+          fileId={
+            selectedNode.data.sources?.[0]
+              ? (fileIds[labels.indexOf(selectedNode.data.sources[0])] ?? fileIds[0])
+              : fileIds[0]
+          }
           onClose={() => setSelectedNode(null)}
         />
       )}

--- a/frontend/src/pages/Compare/ComparePage.tsx
+++ b/frontend/src/pages/Compare/ComparePage.tsx
@@ -1,0 +1,590 @@
+import { useState, useMemo, useRef, useEffect, type Dispatch, type SetStateAction } from 'react';
+import { useSearchParams, useNavigate, Link } from 'react-router-dom';
+import type { GraphNode } from '@/features/network/types';
+import { useCompareData } from '@/features/network/hooks/useCompareData';
+import { NetworkGraph } from '@components/network/NetworkGraph';
+import { NetworkControls } from '@components/network/NetworkControls';
+import { NodeDetails } from '@components/network/NodeDetails';
+import { LoadingSpinner } from '@components/common/LoadingSpinner';
+import { ErrorMessage } from '@components/common/ErrorMessage';
+import { apiClient } from '@/services/api/client';
+import { API_ENDPOINTS } from '@/services/api/endpoints';
+
+// ── Helpers (same as NetworkDiagramPage) ────────────────────────────────────
+
+function edgeMatchesLegendKey(proto: string, app: string, key: string): boolean {
+  if (key === 'HTTPS')
+    return proto === 'HTTPS' || app.includes('TLS') || app.includes('SSL') || app.includes('HTTPS');
+  if (key === 'ICMP') return proto === 'ICMP' || proto === 'ICMPV6';
+  if (key === 'STP') return proto === 'STP' || proto === 'RSTP';
+  return proto === key || app.includes(key);
+}
+
+function toggleSet(setter: Dispatch<SetStateAction<string[]>>) {
+  return (val: string) =>
+    setter(prev => (prev.includes(val) ? prev.filter(v => v !== val) : [...prev, val]));
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
+}
+
+// Distinct colours for up to ~8 files; cycles if more.
+const SOURCE_COLORS = [
+  '#0d6efd', // blue
+  '#6c757d', // grey
+  '#198754', // green
+  '#dc3545', // red
+  '#fd7e14', // orange
+  '#6f42c1', // purple
+  '#0dcaf0', // cyan
+  '#ffc107', // yellow
+];
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export const ComparePage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const fileIds = useMemo(() => {
+    const raw = searchParams.get('files') ?? '';
+    return raw.split(',').filter(Boolean);
+  }, [searchParams]);
+
+  // Redirect if fewer than 2 files
+  useEffect(() => {
+    if (fileIds.length < 2) navigate('/', { replace: true });
+  }, [fileIds, navigate]);
+
+  // Resolve file names from the file list before kicking off the compare fetch.
+  // We hold off passing labels to useCompareData until names are resolved so that
+  // the sources tags on nodes/edges match what the toggle buttons display.
+  const [fileNames, setFileNames] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    if (fileIds.length < 2) return;
+    apiClient
+      .get(API_ENDPOINTS.FILES_LIST, { params: { sort: 'uploadedAt,desc', size: 50 } })
+      .then(res => {
+        const list: { fileId: string; fileName: string }[] = res.data.content ?? [];
+        setFileNames(fileIds.map((id, i) => list.find(f => f.fileId === id)?.fileName ?? `File ${i + 1}`));
+      })
+      .catch(() => {
+        setFileNames(fileIds.map((_, i) => `File ${i + 1}`));
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileIds.join(',')]);
+
+  const { mergedNodes, mergedEdges, perFileStats, labels, loading, error } =
+    useCompareData(fileIds, fileNames ?? []);
+
+  // ── Hidden sources toggle ────────────────────────────────────────────────
+  const [hiddenSources, setHiddenSources] = useState<Set<string>>(new Set());
+
+  const toggleSource = (label: string) =>
+    setHiddenSources(prev => {
+      const next = new Set(prev);
+      next.has(label) ? next.delete(label) : next.add(label);
+      return next;
+    });
+
+  // ── Filter state (mirrors NetworkDiagramPage) ────────────────────────────
+  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  const [activeLegendProtocols, setActiveLegendProtocols] = useState<string[]>([]);
+  const [activeNodeFilters, setActiveNodeFilters] = useState<string[]>([]);
+  const [ipFilter, setIpFilter] = useState('');
+  const [portFilter, setPortFilter] = useState('');
+  const [activeAppFilters, setActiveAppFilters] = useState<string[]>([]);
+  const [activeL7Protocols, setActiveL7Protocols] = useState<string[]>([]);
+  const [activeCategories, setActiveCategories] = useState<string[]>([]);
+  const [activeRiskTypes, setActiveRiskTypes] = useState<string[]>([]);
+  const [activeCustomSigs, setActiveCustomSigs] = useState<string[]>([]);
+  const [activeFileTypes, setActiveFileTypes] = useState<string[]>([]);
+  const [activeCountries, setActiveCountries] = useState<string[]>([]);
+  const [hasRisksOnly, setHasRisksOnly] = useState(false);
+
+  const toggleLegendProtocol = toggleSet(setActiveLegendProtocols);
+  const toggleNodeFilter = toggleSet(setActiveNodeFilters);
+  const toggleAppFilter = toggleSet(setActiveAppFilters);
+  const toggleL7Protocol = toggleSet(setActiveL7Protocols);
+  const toggleCategory = toggleSet(setActiveCategories);
+  const toggleRiskType = toggleSet(setActiveRiskTypes);
+  const toggleCustomSig = toggleSet(setActiveCustomSigs);
+  const toggleFileType = toggleSet(setActiveFileTypes);
+  const toggleCountry = toggleSet(setActiveCountries);
+
+  const clearAllFilters = () => {
+    setActiveLegendProtocols([]);
+    setActiveNodeFilters([]);
+    setIpFilter('');
+    setPortFilter('');
+    setActiveAppFilters([]);
+    setActiveL7Protocols([]);
+    setActiveCategories([]);
+    setActiveRiskTypes([]);
+    setActiveCustomSigs([]);
+    setActiveFileTypes([]);
+    setActiveCountries([]);
+    setHasRisksOnly(false);
+  };
+
+  const [layoutType, setLayoutType] = useState<'forceDirected2d' | 'hierarchicalTd'>(
+    'forceDirected2d'
+  );
+
+  const graphCardRef = useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const onFsChange = () => setIsFullscreen(!!document.fullscreenElement);
+    document.addEventListener('fullscreenchange', onFsChange);
+    return () => document.removeEventListener('fullscreenchange', onFsChange);
+  }, []);
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) graphCardRef.current?.requestFullscreen();
+    else document.exitFullscreen();
+  };
+
+  // ── "Present" sets ───────────────────────────────────────────────────────
+
+  const presentNodeTypes = useMemo(() => {
+    const types = new Set<string>();
+    mergedNodes.forEach(n => {
+      if (n.data.isAnomaly) types.add('anomaly');
+      types.add(n.data.nodeType);
+    });
+    return types;
+  }, [mergedNodes]);
+
+  const presentDeviceTypes = useMemo(() => {
+    const types = new Set<string>();
+    mergedNodes.forEach(n => {
+      if (n.data.deviceType) types.add(n.data.deviceType);
+    });
+    return types;
+  }, [mergedNodes]);
+
+  const presentEdgeLegendKeys = useMemo(() => {
+    const keys = new Set<string>();
+    mergedEdges.forEach(edge => {
+      const proto = edge.data.protocol.toUpperCase();
+      const app = (edge.data.appName ?? '').toUpperCase();
+      ['HTTP', 'HTTPS', 'DNS', 'TCP', 'UDP', 'ICMP', 'ARP', 'STP', 'LLDP', 'CDP', 'EAPOL'].forEach(
+        key => {
+          if (edgeMatchesLegendKey(proto, app, key)) keys.add(key);
+        }
+      );
+    });
+    return keys;
+  }, [mergedEdges]);
+
+  const presentAppNames = useMemo(() => {
+    const names = new Set<string>();
+    mergedEdges.forEach(e => {
+      if (e.data.appName) names.add(e.data.appName);
+    });
+    return [...names].sort();
+  }, [mergedEdges]);
+
+  const presentL7Protocols = useMemo(() => {
+    const vals = new Set<string>();
+    mergedEdges.forEach(e => {
+      if (e.data.l7Protocol) vals.add(e.data.l7Protocol);
+    });
+    return [...vals].sort();
+  }, [mergedEdges]);
+
+  const presentCategories = useMemo(() => {
+    const vals = new Set<string>();
+    mergedEdges.forEach(e => {
+      if (e.data.category) vals.add(e.data.category);
+    });
+    return [...vals].sort();
+  }, [mergedEdges]);
+
+  const presentRiskTypes = useMemo(() => {
+    const vals = new Set<string>();
+    mergedEdges.forEach(e => e.data.flowRisks?.forEach(r => vals.add(r)));
+    return [...vals].sort();
+  }, [mergedEdges]);
+
+  const presentCustomSigs = useMemo(() => {
+    const vals = new Set<string>();
+    mergedEdges.forEach(e => e.data.customSignatures?.forEach(s => vals.add(s)));
+    return [...vals].sort();
+  }, [mergedEdges]);
+
+  const presentFileTypes = useMemo(() => {
+    const vals = new Set<string>();
+    mergedEdges.forEach(e => e.data.detectedFileTypes?.forEach(f => vals.add(f)));
+    return [...vals].sort();
+  }, [mergedEdges]);
+
+  const presentCountries = useMemo(() => {
+    const map = new Map<string, string>();
+    mergedEdges.forEach(e => {
+      if (e.data.srcCountry) map.set(e.data.srcCountry, e.data.srcCountry);
+      if (e.data.dstCountry) map.set(e.data.dstCountry, e.data.dstCountry);
+    });
+    return [...map.keys()].sort();
+  }, [mergedEdges]);
+
+  // ── Filter logic ─────────────────────────────────────────────────────────
+
+  const { filteredNodes, filteredEdges } = useMemo(() => {
+    let filtered = mergedEdges;
+
+    // Source (file) filter — hide edges belonging only to a hidden source
+    if (hiddenSources.size > 0) {
+      filtered = filtered.filter(e => {
+        const sources = e.data.sources;
+        if (!sources) return true;
+        return sources.some(s => !hiddenSources.has(s));
+      });
+    }
+
+    if (hasRisksOnly) filtered = filtered.filter(e => e.data.hasRisks);
+
+    if (activeLegendProtocols.length > 0) {
+      filtered = filtered.filter(edge => {
+        const proto = edge.data.protocol.toUpperCase();
+        const app = (edge.data.appName ?? '').toUpperCase();
+        return activeLegendProtocols.some(key => edgeMatchesLegendKey(proto, app, key));
+      });
+    }
+
+    if (activeAppFilters.length > 0)
+      filtered = filtered.filter(e => activeAppFilters.includes(e.data.appName ?? ''));
+
+    if (activeL7Protocols.length > 0)
+      filtered = filtered.filter(e => activeL7Protocols.includes(e.data.l7Protocol ?? ''));
+
+    if (activeCategories.length > 0)
+      filtered = filtered.filter(e => activeCategories.includes(e.data.category ?? ''));
+
+    if (activeRiskTypes.length > 0)
+      filtered = filtered.filter(e => activeRiskTypes.some(r => e.data.flowRisks?.includes(r)));
+
+    if (activeCustomSigs.length > 0)
+      filtered = filtered.filter(e =>
+        activeCustomSigs.some(s => e.data.customSignatures?.includes(s))
+      );
+
+    if (activeFileTypes.length > 0)
+      filtered = filtered.filter(e =>
+        activeFileTypes.some(f => e.data.detectedFileTypes?.includes(f))
+      );
+
+    if (activeCountries.length > 0)
+      filtered = filtered.filter(
+        e =>
+          activeCountries.includes(e.data.srcCountry ?? '') ||
+          activeCountries.includes(e.data.dstCountry ?? '')
+      );
+
+    if (activeNodeFilters.length > 0) {
+      const matchingIds = new Set(
+        mergedNodes
+          .filter(n =>
+            activeNodeFilters.some(key => {
+              if (key.startsWith('nt:')) {
+                const nt = key.slice(3);
+                return nt === 'anomaly' ? n.data.isAnomaly : n.data.nodeType === nt;
+              }
+              if (key.startsWith('dt:')) return n.data.deviceType === key.slice(3);
+              return false;
+            })
+          )
+          .map(n => n.id)
+      );
+      filtered = filtered.filter(e => matchingIds.has(e.source) || matchingIds.has(e.target));
+    }
+
+    if (portFilter) {
+      const portNum = parseInt(portFilter, 10);
+      if (!isNaN(portNum))
+        filtered = filtered.filter(e => e.data.srcPort === portNum || e.data.dstPort === portNum);
+    }
+
+    const hasActiveFilters =
+      activeLegendProtocols.length > 0 ||
+      activeNodeFilters.length > 0 ||
+      activeAppFilters.length > 0 ||
+      activeL7Protocols.length > 0 ||
+      activeCategories.length > 0 ||
+      activeRiskTypes.length > 0 ||
+      activeCustomSigs.length > 0 ||
+      activeFileTypes.length > 0 ||
+      activeCountries.length > 0 ||
+      hasRisksOnly ||
+      ipFilter.length > 0 ||
+      portFilter.length > 0 ||
+      hiddenSources.size > 0;
+
+    const ipLower = ipFilter.toLowerCase();
+    let visibleNodes = mergedNodes;
+    if (ipFilter) {
+      visibleNodes = mergedNodes.filter(
+        n =>
+          n.data.ip.toLowerCase().includes(ipLower) ||
+          (n.data.hostname ?? '').toLowerCase().includes(ipLower)
+      );
+    }
+
+    if (hasActiveFilters) {
+      const matchedByIp = new Set(visibleNodes.map(n => n.id));
+      if (ipFilter)
+        filtered = filtered.filter(e => matchedByIp.has(e.source) || matchedByIp.has(e.target));
+      const visibleNodeIds = new Set<string>();
+      filtered.forEach(e => {
+        visibleNodeIds.add(e.source);
+        visibleNodeIds.add(e.target);
+      });
+      visibleNodes = mergedNodes.filter(
+        n => visibleNodeIds.has(n.id) || (ipFilter && matchedByIp.has(n.id))
+      );
+    }
+
+    return { filteredNodes: visibleNodes, filteredEdges: filtered };
+  }, [
+    mergedNodes,
+    mergedEdges,
+    hiddenSources,
+    activeLegendProtocols,
+    activeNodeFilters,
+    activeAppFilters,
+    activeL7Protocols,
+    activeCategories,
+    activeRiskTypes,
+    activeCustomSigs,
+    activeFileTypes,
+    activeCountries,
+    hasRisksOnly,
+    ipFilter,
+    portFilter,
+  ]);
+
+  const activeFilterCount =
+    activeLegendProtocols.length +
+    activeNodeFilters.length +
+    activeAppFilters.length +
+    activeL7Protocols.length +
+    activeCategories.length +
+    activeRiskTypes.length +
+    activeCustomSigs.length +
+    activeFileTypes.length +
+    activeCountries.length +
+    (ipFilter ? 1 : 0) +
+    (portFilter ? 1 : 0) +
+    (hasRisksOnly ? 1 : 0);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  if (fileNames === null || loading) {
+    return <LoadingSpinner size="large" message="Building comparison topology…" fullPage />;
+  }
+
+  if (error) {
+    return <ErrorMessage title="Failed to Load Comparison Data" message={error} />;
+  }
+
+  const primaryLabel = labels[0] ?? '';
+
+  return (
+    <div className="network-diagram-page">
+      {/* Back link + header */}
+      <div className="d-flex align-items-center gap-3 mb-3">
+        <Link to="/" className="btn btn-link btn-sm p-0 text-muted text-decoration-none">
+          <i className="bi bi-arrow-left me-1" />
+          Back
+        </Link>
+        <h4 className="mb-0">
+          <i className="bi bi-diagram-3 me-2" />
+          Compare Topology
+        </h4>
+      </div>
+
+      {/* File labels row */}
+      <div className="d-flex align-items-center gap-2 mb-3 flex-wrap">
+        {labels.map((label, i) => (
+          <span key={label}>
+            <span
+              className="badge"
+              style={{ fontSize: '0.8rem', backgroundColor: SOURCE_COLORS[i % SOURCE_COLORS.length] }}
+            >
+              <i className="bi bi-file-earmark-binary me-1" />
+              {label}
+            </span>
+            {i < labels.length - 1 && <span className="text-muted small ms-2">vs</span>}
+          </span>
+        ))}
+      </div>
+
+      {/* Per-file stats — one column per file, wraps naturally */}
+      <div className="card mb-3">
+        <div className="card-header">
+          <strong>Comparison Overview</strong>
+        </div>
+        <div className="card-body py-2 px-3">
+          <div className="d-flex flex-wrap gap-3">
+            {perFileStats.map(({ label, stats }, i) => (
+              <div key={label} style={{ minWidth: 200 }}>
+                <div className="mb-2">
+                  <span
+                    className="badge"
+                    style={{ fontSize: '0.7rem', backgroundColor: SOURCE_COLORS[i % SOURCE_COLORS.length] }}
+                  >
+                    {label}
+                  </span>
+                </div>
+                <div className="d-flex gap-2 flex-wrap">
+                  {[
+                    { name: 'Nodes', value: stats.totalNodes.toLocaleString() },
+                    { name: 'Connections', value: stats.totalEdges.toLocaleString() },
+                    { name: 'Packets', value: stats.totalPackets.toLocaleString() },
+                    { name: 'Data', value: formatBytes(stats.totalBytes) },
+                  ].map(({ name, value }) => (
+                    <div key={name} className="text-center px-2 py-1 tp-stat-box rounded border">
+                      <div style={{ fontSize: '0.65rem', color: '#6c757d', textTransform: 'uppercase' }}>
+                        {name}
+                      </div>
+                      <div style={{ fontSize: '0.9rem', fontWeight: 600 }}>{value}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-2 text-muted small">
+            {filteredNodes.length} nodes · {filteredEdges.length} connections shown
+          </div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="mb-3">
+        <NetworkControls
+          activeLegendProtocols={activeLegendProtocols}
+          onLegendProtocolClick={toggleLegendProtocol}
+          onLegendProtocolClear={() => setActiveLegendProtocols([])}
+          activeNodeFilters={activeNodeFilters}
+          onNodeFilterClick={toggleNodeFilter}
+          onNodeFilterClear={() => setActiveNodeFilters([])}
+          presentNodeTypes={presentNodeTypes}
+          presentEdgeLegendKeys={presentEdgeLegendKeys}
+          presentDeviceTypes={presentDeviceTypes}
+          ipFilter={ipFilter}
+          onIpFilterChange={setIpFilter}
+          portFilter={portFilter}
+          onPortFilterChange={setPortFilter}
+          activeAppFilters={activeAppFilters}
+          onAppFilterClick={toggleAppFilter}
+          onAppFilterClear={() => setActiveAppFilters([])}
+          presentAppNames={presentAppNames}
+          activeL7Protocols={activeL7Protocols}
+          onL7ProtocolClick={toggleL7Protocol}
+          onL7ProtocolClear={() => setActiveL7Protocols([])}
+          presentL7Protocols={presentL7Protocols}
+          activeCategories={activeCategories}
+          onCategoryClick={toggleCategory}
+          onCategoryClear={() => setActiveCategories([])}
+          presentCategories={presentCategories}
+          activeRiskTypes={activeRiskTypes}
+          onRiskTypeClick={toggleRiskType}
+          onRiskTypeClear={() => setActiveRiskTypes([])}
+          presentRiskTypes={presentRiskTypes}
+          activeCustomSigs={activeCustomSigs}
+          onCustomSigClick={toggleCustomSig}
+          onCustomSigClear={() => setActiveCustomSigs([])}
+          presentCustomSigs={presentCustomSigs}
+          activeFileTypes={activeFileTypes}
+          onFileTypeClick={toggleFileType}
+          onFileTypeClear={() => setActiveFileTypes([])}
+          presentFileTypes={presentFileTypes}
+          activeCountries={activeCountries}
+          onCountryClick={toggleCountry}
+          onCountryClear={() => setActiveCountries([])}
+          presentCountries={presentCountries}
+          hasRisksOnly={hasRisksOnly}
+          onHasRisksOnlyChange={setHasRisksOnly}
+          activeFilterCount={activeFilterCount}
+          onClearAllFilters={clearAllFilters}
+          defaultCollapsed
+        />
+      </div>
+
+      {/* Source toggle pills */}
+      <div className="d-flex align-items-center gap-2 mb-3 flex-wrap">
+        <span className="small text-muted">Show:</span>
+        {labels.map((label, i) => {
+          const color = SOURCE_COLORS[i % SOURCE_COLORS.length];
+          const hidden = hiddenSources.has(label);
+          return (
+            <button
+              key={label}
+              className="btn btn-sm"
+              style={{
+                backgroundColor: hidden ? 'transparent' : color,
+                borderColor: color,
+                color: hidden ? color : '#fff',
+              }}
+              onClick={() => toggleSource(label)}
+              title={hidden ? `Show ${label}` : `Hide ${label}`}
+            >
+              <i className={`bi ${hidden ? 'bi-eye-slash' : 'bi-eye'} me-1`} />
+              {label}
+            </button>
+          );
+        })}
+        <span className="small text-muted ms-3">
+          <i className="bi bi-layers-fill me-1" />
+          Layered badge = present in multiple files
+        </span>
+      </div>
+
+      {/* Graph */}
+      <div className="row">
+        <div className="col-12">
+          <div className="card" ref={graphCardRef}>
+            <div className="card-header d-flex justify-content-between align-items-center">
+              <strong>Topology Diagram</strong>
+              <button
+                className="btn btn-link btn-sm p-0 text-muted"
+                onClick={toggleFullscreen}
+                title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+              >
+                <i className={`bi ${isFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'}`} />
+              </button>
+            </div>
+            <div className="card-body p-0 network-diagram-graph-body">
+              <NetworkGraph
+                key={layoutType}
+                nodes={filteredNodes}
+                edges={filteredEdges}
+                onNodeClick={node => setSelectedNode(node)}
+                layoutType={layoutType}
+                onLayoutChange={setLayoutType}
+                primarySource={primaryLabel}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {selectedNode && (
+        <NodeDetails
+          node={selectedNode}
+          edges={mergedEdges}
+          fileId={fileIds[0]}
+          onClose={() => setSelectedNode(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -8,6 +8,7 @@ import { StoryPage } from '@pages/Story';
 import { FilterGeneratorPage } from '@pages/FilterGenerator';
 import { NetworkDiagramPage } from '@pages/NetworkDiagram';
 import { ExtractedFilesPage } from '@pages/ExtractedFiles';
+import { ComparePage } from '@pages/Compare/ComparePage';
 import { NotFoundPage } from '@pages/NotFound';
 
 export const router = createBrowserRouter([
@@ -48,6 +49,10 @@ export const router = createBrowserRouter([
             element: <ExtractedFilesPage />,
           },
         ],
+      },
+      {
+        path: 'compare',
+        element: <ComparePage />,
       },
       {
         path: '*',


### PR DESCRIPTION
## Summary

- **New `/compare` route** — select 2+ PCAP files from the file library and view their network topologies merged into a single unified graph
- **Smart node merging** — nodes matched by IP with MAC-address tiebreaker; mismatched MACs (DHCP lease reuse) are kept as separate nodes rather than incorrectly merged
- **Source-aware rendering** — dashed edges/borders for nodes/edges exclusive to secondary files; `bi-layers` badge on nodes present in multiple files; per-file colour-coded toggle pills to show/hide individual captures
- **FileList UX improvements** — row click no longer navigates to analysis (use the Analyze button); checkboxes for multi-select with Compare selected button; info popover explaining both workflows
- **N-file support** — comparison works for 2+ files, not just pairs; stats bar shows one column per file and wraps naturally

## Test plan

- [ ] Upload 2+ PCAP files and wait for READY status
- [ ] Check 2 files → "Compare selected (2)" button appears in card header
- [ ] Navigate to `/compare?files=id1,id2` — merged topology renders
- [ ] Toggle File A / File B pills — exclusive nodes/edges hide correctly
- [ ] Verify dashed edges for secondary-only connections, solid+thick for shared
- [ ] Verify `bi-layers` badge appears on nodes present in both files
- [ ] Apply protocol/IP/port filters — confirm they work on merged graph
- [ ] Navigate to `/compare` with one file ID → redirects to `/`
- [ ] Click a file row in the library — confirm it no longer navigates
- [ ] Click the ⓘ info button next to "All Uploads" — confirm popover appears and dismisses on outside click
- [ ] Check that NetworkDiagramPage filter panel still opens expanded (unaffected by defaultCollapsed change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)