### PR TITLE
feat: multi-select UX improvements and permanent PCAP merge

### DIFF
--- a/backend/src/main/java/com/tracepcap/file/controller/FileController.java
+++ b/backend/src/main/java/com/tracepcap/file/controller/FileController.java
@@ -6,6 +6,7 @@ import com.tracepcap.file.dto.MergeFilesRequest;
 import com.tracepcap.file.service.FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.io.InputStream;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -108,12 +109,12 @@ public class FileController {
       summary = "Merge PCAP files",
       description = "Merge two or more PCAP files into a single new file and trigger analysis")
   public ResponseEntity<FileUploadResponse> mergeFiles(
-      @RequestBody MergeFilesRequest request,
+      @Valid @RequestBody MergeFilesRequest request,
       @RequestParam(value = "enableNdpi", defaultValue = "true") boolean enableNdpi,
       @RequestParam(value = "enableFileExtraction", defaultValue = "true")
           boolean enableFileExtraction) {
 
-    log.info("Received merge request for {} files", request.getFileIds().size());
+    log.info("Received merge request for {} files", request.getFileIds() != null ? request.getFileIds().size() : 0);
 
     FileUploadResponse response =
         fileService.mergeFiles(request.getFileIds(), request.getMergedFileName(), enableNdpi, enableFileExtraction);

--- a/backend/src/main/java/com/tracepcap/file/controller/FileController.java
+++ b/backend/src/main/java/com/tracepcap/file/controller/FileController.java
@@ -2,6 +2,7 @@ package com.tracepcap.file.controller;
 
 import com.tracepcap.file.dto.FileMetadataDto;
 import com.tracepcap.file.dto.FileUploadResponse;
+import com.tracepcap.file.dto.MergeFilesRequest;
 import com.tracepcap.file.service.FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -100,5 +101,23 @@ public class FileController {
     fileService.deleteFile(UUID.fromString(fileId));
 
     return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/merge")
+  @Operation(
+      summary = "Merge PCAP files",
+      description = "Merge two or more PCAP files into a single new file and trigger analysis")
+  public ResponseEntity<FileUploadResponse> mergeFiles(
+      @RequestBody MergeFilesRequest request,
+      @RequestParam(value = "enableNdpi", defaultValue = "true") boolean enableNdpi,
+      @RequestParam(value = "enableFileExtraction", defaultValue = "true")
+          boolean enableFileExtraction) {
+
+    log.info("Received merge request for {} files", request.getFileIds().size());
+
+    FileUploadResponse response =
+        fileService.mergeFiles(request.getFileIds(), request.getMergedFileName(), enableNdpi, enableFileExtraction);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 }

--- a/backend/src/main/java/com/tracepcap/file/dto/MergeFilesRequest.java
+++ b/backend/src/main/java/com/tracepcap/file/dto/MergeFilesRequest.java
@@ -1,5 +1,7 @@
 package com.tracepcap.file.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.UUID;
 import lombok.Data;
@@ -8,6 +10,8 @@ import lombok.Data;
 @Data
 public class MergeFilesRequest {
 
+  @NotEmpty(message = "At least two file IDs are required")
+  @Size(min = 2, message = "At least two file IDs are required")
   private List<UUID> fileIds;
 
   /** Optional user-supplied name for the merged file (without extension). */

--- a/backend/src/main/java/com/tracepcap/file/dto/MergeFilesRequest.java
+++ b/backend/src/main/java/com/tracepcap/file/dto/MergeFilesRequest.java
@@ -1,0 +1,15 @@
+package com.tracepcap.file.dto;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.Data;
+
+/** Request body for merging multiple PCAP files */
+@Data
+public class MergeFilesRequest {
+
+  private List<UUID> fileIds;
+
+  /** Optional user-supplied name for the merged file (without extension). */
+  private String mergedFileName;
+}

--- a/backend/src/main/java/com/tracepcap/file/service/FileService.java
+++ b/backend/src/main/java/com/tracepcap/file/service/FileService.java
@@ -4,6 +4,7 @@ import com.tracepcap.file.dto.FileMetadataDto;
 import com.tracepcap.file.dto.FileUploadResponse;
 import com.tracepcap.file.entity.FileEntity;
 import java.io.InputStream;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -67,4 +68,14 @@ public interface FileService {
    * @return file entity
    */
   FileEntity getFileById(UUID fileId);
+
+  /**
+   * Merge multiple PCAP files into a single new file and trigger analysis.
+   *
+   * @param fileIds ordered list of file IDs to merge
+   * @param enableNdpi whether to run nDPI on the merged file
+   * @param enableFileExtraction whether to run file extraction on the merged file
+   * @return upload response for the newly created merged file
+   */
+  FileUploadResponse mergeFiles(List<UUID> fileIds, String mergedFileName, boolean enableNdpi, boolean enableFileExtraction);
 }

--- a/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
+++ b/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
@@ -9,9 +9,13 @@ import com.tracepcap.file.entity.FileEntity;
 import com.tracepcap.file.event.FileUploadedEvent;
 import com.tracepcap.file.mapper.FileMapper;
 import com.tracepcap.file.repository.FileRepository;
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.List;
@@ -196,6 +200,147 @@ public class FileServiceImpl implements FileService {
   private String getFileExtension(String filename) {
     int lastDotIndex = filename.lastIndexOf('.');
     return lastDotIndex > 0 ? filename.substring(lastDotIndex) : "";
+  }
+
+  @Override
+  @Transactional
+  public FileUploadResponse mergeFiles(
+      List<UUID> fileIds, String mergedFileName, boolean enableNdpi, boolean enableFileExtraction) {
+    if (fileIds == null || fileIds.size() < 2) {
+      throw new InvalidFileException("At least two files are required for merging");
+    }
+
+    log.info("Starting PCAP merge for {} files: {}", fileIds.size(), fileIds);
+
+    List<File> tempInputs = new ArrayList<>();
+    File tempOutput = null;
+
+    try {
+      // Download each source file to a local temp file
+      for (UUID fileId : fileIds) {
+        FileEntity entity = getFileById(fileId);
+        File tmp = File.createTempFile("merge-input-" + fileId, ".pcap");
+        storageService.downloadFileToLocal(entity.getMinioPath(), tmp);
+        tempInputs.add(tmp);
+      }
+
+      // Build mergecap command
+      tempOutput = File.createTempFile("merge-output-", ".pcap");
+      List<String> cmd = new ArrayList<>();
+      cmd.add("mergecap");
+      cmd.add("-w");
+      cmd.add(tempOutput.getAbsolutePath());
+      for (File f : tempInputs) {
+        cmd.add(f.getAbsolutePath());
+      }
+
+      log.info("Running mergecap: {}", cmd);
+      Process process = new ProcessBuilder(cmd)
+          .redirectErrorStream(true)
+          .start();
+
+      String output = new String(process.getInputStream().readAllBytes());
+      int exitCode = process.waitFor();
+      if (exitCode != 0) {
+        throw new InvalidFileException("mergecap failed (exit " + exitCode + "): " + output);
+      }
+
+      // Compute hash of the merged file to detect duplicates
+      byte[] mergedBytes = Files.readAllBytes(tempOutput.toPath());
+      String fileHash = computeSha256FromBytes(mergedBytes);
+
+      Optional<FileEntity> existing =
+          fileRepository.findFirstByFileHashOrderByUploadedAtDesc(fileHash);
+      if (existing.isPresent()) {
+        throw new DuplicateFileException(existing.get().getId());
+      }
+
+      // Use caller-supplied name or auto-generate from source names
+      String mergedName = (mergedFileName != null && !mergedFileName.isBlank())
+          ? sanitizeMergedFileName(mergedFileName)
+          : buildAutoMergedName(fileIds);
+
+      // Upload merged file to MinIO
+      UUID newFileId = UUID.randomUUID();
+      String storedName = newFileId + ".pcap";
+      storageService.uploadBytes(mergedBytes, storedName, "application/vnd.tcpdump.pcap");
+
+      // Persist metadata
+      FileEntity fileEntity =
+          FileEntity.builder()
+              .id(newFileId)
+              .fileName(mergedName)
+              .fileSize((long) mergedBytes.length)
+              .minioPath(storedName)
+              .uploadedAt(LocalDateTime.now())
+              .status(FileEntity.FileStatus.PROCESSING)
+              .fileHash(fileHash)
+              .enableNdpi(enableNdpi)
+              .enableFileExtraction(enableFileExtraction)
+              .build();
+
+      fileEntity = fileRepository.save(fileEntity);
+      log.info("Merged PCAP saved: {} (ID: {})", mergedName, newFileId);
+
+      // Trigger async analysis
+      eventPublisher.publishEvent(new FileUploadedEvent(this, newFileId));
+
+      return fileMapper.toUploadResponse(fileEntity);
+
+    } catch (InvalidFileException | DuplicateFileException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to merge PCAP files", e);
+      throw new InvalidFileException("Failed to merge files: " + e.getMessage(), e);
+    } finally {
+      for (File f : tempInputs) {
+        try { Files.deleteIfExists(f.toPath()); } catch (IOException ignored) {}
+      }
+      if (tempOutput != null) {
+        try { Files.deleteIfExists(tempOutput.toPath()); } catch (IOException ignored) {}
+      }
+    }
+  }
+
+  private String buildAutoMergedName(List<UUID> fileIds) {
+    final int MAX_PART = 20;
+    final int MAX_SHOWN = 3;
+    List<String> parts = new ArrayList<>();
+    for (int i = 0; i < Math.min(MAX_SHOWN, fileIds.size()); i++) {
+      try {
+        String base = getFileById(fileIds.get(i)).getFileName().replaceFirst("\\.[^.]+$", "");
+        parts.add(base.length() > MAX_PART ? base.substring(0, MAX_PART) : base);
+      } catch (Exception ignored) {
+        parts.add(fileIds.get(i).toString().substring(0, 8));
+      }
+    }
+    String joined = String.join("+", parts);
+    if (fileIds.size() > MAX_SHOWN) {
+      joined += "+" + (fileIds.size() - MAX_SHOWN) + "_more";
+    }
+    return "merged_" + joined + ".pcap";
+  }
+
+  private String sanitizeMergedFileName(String name) {
+    // Strip any path separators and control characters, ensure .pcap extension
+    String safe = name.replaceAll("[/\\\\<>:\"|?*\\p{Cntrl}]", "_").trim();
+    if (safe.isBlank()) {
+      safe = "merged";
+    }
+    // Ensure it ends with .pcap
+    if (!safe.toLowerCase().endsWith(".pcap")) {
+      safe = safe + ".pcap";
+    }
+    return safe;
+  }
+
+  private String computeSha256FromBytes(byte[] data) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(data));
+    } catch (Exception e) {
+      throw new InvalidFileException("Could not compute hash of merged file", e);
+    }
   }
 
   /** Compute SHA-256 hex digest of the uploaded file using a streaming approach */

--- a/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
+++ b/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
@@ -9,11 +9,15 @@ import com.tracepcap.file.entity.FileEntity;
 import com.tracepcap.file.event.FileUploadedEvent;
 import com.tracepcap.file.mapper.FileMapper;
 import com.tracepcap.file.repository.FileRepository;
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.security.DigestInputStream;
 import java.security.MessageDigest;
+import java.util.concurrent.TimeUnit;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -239,15 +243,29 @@ public class FileServiceImpl implements FileService {
           .redirectErrorStream(true)
           .start();
 
-      String output = new String(process.getInputStream().readAllBytes());
-      int exitCode = process.waitFor();
+      // Drain stdout/stderr in a background thread to prevent blocking
+      final StringBuilder processOutput = new StringBuilder();
+      Thread drainThread = new Thread(() -> {
+        try {
+          processOutput.append(new String(process.getInputStream().readAllBytes()));
+        } catch (IOException ignored) {}
+      });
+      drainThread.setDaemon(true);
+      drainThread.start();
+
+      boolean finished = process.waitFor(5, TimeUnit.MINUTES);
+      drainThread.join(5000);
+      if (!finished) {
+        process.destroyForcibly();
+        throw new InvalidFileException("mergecap timed out after 5 minutes");
+      }
+      int exitCode = process.exitValue();
       if (exitCode != 0) {
-        throw new InvalidFileException("mergecap failed (exit " + exitCode + "): " + output);
+        throw new InvalidFileException("mergecap failed (exit " + exitCode + "): " + processOutput);
       }
 
-      // Compute hash of the merged file to detect duplicates
-      byte[] mergedBytes = Files.readAllBytes(tempOutput.toPath());
-      String fileHash = computeSha256FromBytes(mergedBytes);
+      // Compute hash by streaming the merged file (avoids loading it fully into memory)
+      String fileHash = computeSha256FromFile(tempOutput);
 
       Optional<FileEntity> existing =
           fileRepository.findFirstByFileHashOrderByUploadedAtDesc(fileHash);
@@ -260,17 +278,17 @@ public class FileServiceImpl implements FileService {
           ? sanitizeMergedFileName(mergedFileName)
           : buildAutoMergedName(fileIds);
 
-      // Upload merged file to MinIO
+      // Stream-upload the merged file to MinIO (avoids loading it fully into memory)
       UUID newFileId = UUID.randomUUID();
       String storedName = newFileId + ".pcap";
-      storageService.uploadBytes(mergedBytes, storedName, "application/vnd.tcpdump.pcap");
+      storageService.uploadFile(tempOutput, storedName, "application/vnd.tcpdump.pcap");
 
       // Persist metadata
       FileEntity fileEntity =
           FileEntity.builder()
               .id(newFileId)
               .fileName(mergedName)
-              .fileSize((long) mergedBytes.length)
+              .fileSize(tempOutput.length())
               .minioPath(storedName)
               .uploadedAt(LocalDateTime.now())
               .status(FileEntity.FileStatus.PROCESSING)
@@ -334,10 +352,14 @@ public class FileServiceImpl implements FileService {
     return safe;
   }
 
-  private String computeSha256FromBytes(byte[] data) {
+  private String computeSha256FromFile(File file) {
     try {
       MessageDigest digest = MessageDigest.getInstance("SHA-256");
-      return HexFormat.of().formatHex(digest.digest(data));
+      try (InputStream is = new DigestInputStream(new BufferedInputStream(new FileInputStream(file)), digest)) {
+        byte[] buf = new byte[8192];
+        while (is.read(buf) != -1) { /* drain to feed the digest */ }
+      }
+      return HexFormat.of().formatHex(digest.digest());
     } catch (Exception e) {
       throw new InvalidFileException("Could not compute hash of merged file", e);
     }

--- a/backend/src/main/java/com/tracepcap/file/service/StorageService.java
+++ b/backend/src/main/java/com/tracepcap/file/service/StorageService.java
@@ -64,4 +64,14 @@ public interface StorageService {
    * @return the storage path
    */
   String uploadBytes(byte[] data, String path, String contentType);
+
+  /**
+   * Upload a local file to storage via streaming (avoids loading the whole file into memory).
+   *
+   * @param source the local file to upload
+   * @param path the destination path in storage
+   * @param contentType MIME type of the content
+   * @return the storage path
+   */
+  String uploadFile(java.io.File source, String path, String contentType);
 }

--- a/backend/src/main/java/com/tracepcap/file/service/StorageServiceImpl.java
+++ b/backend/src/main/java/com/tracepcap/file/service/StorageServiceImpl.java
@@ -4,8 +4,10 @@ import com.tracepcap.common.exception.StorageException;
 import com.tracepcap.config.MinioConfig;
 import io.minio.*;
 import io.minio.http.Method;
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
@@ -131,6 +133,25 @@ public class StorageServiceImpl implements StorageService {
     } catch (Exception e) {
       log.error("Failed to upload bytes to path: {}", path, e);
       throw new StorageException("Failed to upload bytes to storage", e);
+    }
+  }
+
+  @Override
+  public String uploadFile(File source, String path, String contentType) {
+    try {
+      ensureBucketExists();
+      try (InputStream stream = new BufferedInputStream(new FileInputStream(source))) {
+        minioClient.putObject(
+            PutObjectArgs.builder().bucket(minioConfig.getBucket()).object(path).stream(
+                    stream, source.length(), -1)
+                .contentType(contentType != null ? contentType : "application/octet-stream")
+                .build());
+      }
+      log.info("Successfully streamed file to MinIO: {}", path);
+      return path;
+    } catch (Exception e) {
+      log.error("Failed to stream file to MinIO: {}", path, e);
+      throw new StorageException("Failed to upload file to storage", e);
     }
   }
 

--- a/frontend/src/components/upload/FileList/FileList.css
+++ b/frontend/src/components/upload/FileList/FileList.css
@@ -1,3 +1,9 @@
+/* Multi-select action modal buttons */
+.multiselect-action-btn:hover .text-muted,
+.multiselect-action-btn:hover small {
+  color: inherit !important;
+}
+
 /* File List Card Styles */
 .file-list-card {
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%);

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -8,6 +8,8 @@ import { API_ENDPOINTS } from '@/services/api/endpoints';
 import { parseDateTime } from '@/utils/dateUtils';
 import './FileList.css';
 
+type MultiSelectAction = 'analyze' | 'merge';
+
 interface FileMetadata {
   fileId: string;
   fileName: string;
@@ -24,6 +26,10 @@ export const FileList = () => {
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
   const [selectedForCompare, setSelectedForCompare] = useState<Set<string>>(new Set());
   const [showInfo, setShowInfo] = useState(false);
+  const [showMultiSelectModal, setShowMultiSelectModal] = useState(false);
+  const [merging, setMerging] = useState(false);
+  const [mergeError, setMergeError] = useState<string | null>(null);
+  const [mergedFileName, setMergedFileName] = useState('');
   const infoRef = useRef<HTMLDivElement>(null);
 
   // Close info popover when clicking outside
@@ -44,6 +50,53 @@ export const FileList = () => {
       next.has(fileId) ? next.delete(fileId) : next.add(fileId);
       return next;
     });
+
+  const buildAutoMergeName = (selectedIds: Set<string>): string => {
+    const MAX_PART = 20;
+    const MAX_SHOWN = 3;
+    const selected = files.filter(f => selectedIds.has(f.fileId));
+    const parts = selected.slice(0, MAX_SHOWN).map(f => {
+      const base = f.fileName.replace(/\.[^.]+$/, '');
+      return base.length > MAX_PART ? base.slice(0, MAX_PART) : base;
+    });
+    const suffix = selected.length > MAX_SHOWN ? `+${selected.length - MAX_SHOWN}_more` : '';
+    return `merged_${parts.join('+')}${suffix}`;
+  };
+
+  const handleRowClick = (fileId: string, status: string) => {
+    if (status.toLowerCase() !== 'completed') return;
+    toggleCompareSelect(fileId);
+  };
+
+  const handleMultiSelectAction = async (action: MultiSelectAction) => {
+    setShowMultiSelectModal(false);
+    if (action === 'analyze') {
+      navigate(`/compare?files=${[...selectedForCompare].join(',')}`);
+      return;
+    }
+
+    // Permanently merge
+    setMergeError(null);
+    setMerging(true);
+    try {
+      const name = mergedFileName.trim() || buildAutoMergeName(selectedForCompare);
+      const res = await apiClient.post(API_ENDPOINTS.FILES_MERGE, {
+        fileIds: [...selectedForCompare],
+        mergedFileName: name.endsWith('.pcap') ? name : `${name}.pcap`,
+      });
+      const newFileId: string = res.data.fileId;
+      setSelectedForCompare(new Set());
+      navigate(`/analysis/${newFileId}`);
+    } catch (err) {
+      const message =
+        isAxiosError(err) && err.response?.data?.message
+          ? err.response.data.message
+          : 'Failed to merge files. Please try again.';
+      setMergeError(message);
+    } finally {
+      setMerging(false);
+    }
+  };
 
   const fetchFiles = async () => {
     try {
@@ -149,9 +202,10 @@ export const FileList = () => {
                 <button
                   type="button"
                   className="btn btn-outline-primary btn-sm"
-                  onClick={() =>
-                    navigate(`/compare?files=${[...selectedForCompare].join(',')}`)
-                  }
+                  onClick={() => {
+                    setMergedFileName(buildAutoMergeName(selectedForCompare));
+                    setShowMultiSelectModal(true);
+                  }}
                 >
                   <i className="bi bi-diagram-3 me-1"></i>
                   Compare selected ({selectedForCompare.size})
@@ -191,6 +245,8 @@ export const FileList = () => {
                 <div
                   key={file.fileId}
                   className="list-group-item d-flex justify-content-between align-items-center"
+                  style={file.status.toLowerCase() === 'completed' ? { cursor: 'pointer' } : undefined}
+                  onClick={() => handleRowClick(file.fileId, file.status)}
                 >
                   <div className="flex-grow-1">
                     <div className="d-flex align-items-center gap-2">
@@ -205,6 +261,7 @@ export const FileList = () => {
                             : 'Select for comparison'
                         }
                         onChange={() => toggleCompareSelect(file.fileId)}
+                        onClick={e => e.stopPropagation()}
                       />
                       <i
                         className="bi bi-file-earmark-binary text-primary"
@@ -227,7 +284,7 @@ export const FileList = () => {
                       </div>
                     </div>
                   </div>
-                  <div className="d-flex gap-2 align-items-center">
+                  <div className="d-flex gap-2 align-items-center" onClick={e => e.stopPropagation()}>
                     <button
                       className="btn btn-outline-primary btn-sm"
                       onClick={() => navigate(`/analysis/${file.fileId}`)}
@@ -274,6 +331,83 @@ export const FileList = () => {
           </button>
           <button type="button" className="btn btn-outline-danger" onClick={handleConfirmDelete}>
             Delete
+          </button>
+        </Modal.Footer>
+      </Modal>
+
+      {/* Merge in-progress overlay */}
+      <Modal show={merging} onHide={() => {}} centered backdrop="static" keyboard={false}>
+        <Modal.Body className="text-center py-4">
+          <div className="spinner-border text-primary mb-3" role="status" aria-hidden="true" />
+          <p className="mb-0 fw-semibold">Merging files…</p>
+          <small className="text-muted">This may take a moment.</small>
+        </Modal.Body>
+      </Modal>
+
+      {/* Multi-select action modal */}
+      <Modal show={showMultiSelectModal} onHide={() => { setShowMultiSelectModal(false); setMergeError(null); }} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Analyze {selectedForCompare.size} Files</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {mergeError && (
+            <div className="alert alert-danger py-2 mb-3" role="alert">
+              <i className="bi bi-exclamation-triangle me-2"></i>
+              {mergeError}
+            </div>
+          )}
+          <p className="mb-3">How would you like to process the selected files?</p>
+          <div className="d-flex flex-column gap-3">
+            <button
+              type="button"
+              className="btn btn-outline-primary text-start p-3 multiselect-action-btn"
+              onClick={() => handleMultiSelectAction('analyze')}
+            >
+              <div className="fw-semibold mb-1">
+                <i className="bi bi-diagram-3 me-2"></i>
+                Analyze Together
+              </div>
+              <small className="text-muted">
+                View a joint topology diagram overlaying all selected files. The original files remain separate.
+              </small>
+            </button>
+            <div className="border rounded p-3" style={{ borderColor: '#6c757d' }}>
+              <div className="fw-semibold mb-1">
+                <i className="bi bi-layers me-2"></i>
+                Permanently Merge
+              </div>
+              <small className="text-muted d-block mb-2">
+                Combine all selected files into a single new PCAP file for unified analysis.
+              </small>
+              <div className="input-group input-group-sm mb-2" onClick={e => e.stopPropagation()}>
+                <input
+                  type="text"
+                  className="form-control"
+                  value={mergedFileName}
+                  onChange={e => setMergedFileName(e.target.value)}
+                  placeholder="merged file name"
+                  aria-label="Merged file name"
+                />
+                <span className="input-group-text">.pcap</span>
+              </div>
+              <button
+                type="button"
+                className="btn btn-secondary btn-sm w-100"
+                onClick={() => handleMultiSelectAction('merge')}
+                disabled={!mergedFileName.trim()}
+              >
+                Merge &amp; Analyze
+              </button>
+            </div>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <button
+            type="button"
+            className="btn btn-outline-secondary"
+            onClick={() => { setShowMultiSelectModal(false); setMergeError(null); }}
+          >
+            Cancel
           </button>
         </Modal.Footer>
       </Modal>

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -5,6 +5,7 @@ export const API_ENDPOINTS = {
   FILE_METADATA: (fileId: string) => `/files/${fileId}`,
   FILE_DELETE: (fileId: string) => `/files/${fileId}`,
   FILE_DOWNLOAD: (fileId: string) => `/files/${fileId}/download`,
+  FILES_MERGE: '/files/merge',
 
   // Analysis (Not yet implemented in backend)
   ANALYSIS_SUMMARY: (fileId: string) => `/analysis/${fileId}/summary`,


### PR DESCRIPTION
## Summary

- **Row click to select** — clicking any completed file row in the All Uploads card now toggles its checkbox (Analyze/Delete buttons stop propagation so they still work independently)
- **Action modal** — "Compare selected" now opens a modal asking how to process the files:
  - **Analyze Together** — navigates to the existing `/compare` joint topology view (no change to existing behaviour)
  - **Permanently Merge** — merges the PCAPs into one new file and navigates to its analysis page
- **Merge filename** — auto-generated as `merged_<name1>+<name2>+...` (max 3 parts × 20 chars, `+N_more` suffix for larger selections); fully editable by the user before confirming; `.pcap` extension enforced on both frontend and backend
- **Loading overlay** — a blocking spinner modal is shown during the merge operation; errors surface inline in the action modal
- **Hover fix** — description text inside action modal buttons now inherits the correct colour on hover in light mode

## Backend changes

- `MergeFilesRequest` DTO (`fileIds`, optional `mergedFileName`)
- `FileService#mergeFiles` + `FileServiceImpl` implementation: downloads sources from MinIO to temp files, runs `mergecap`, uploads result, saves `FileEntity`, publishes `FileUploadedEvent` to trigger the normal analysis pipeline; temp files always cleaned up
- `POST /api/files/merge` endpoint in `FileController`

## Test plan

- [ ] Select 2+ completed files and click **Compare selected**
- [ ] Choose **Analyze Together** → lands on `/compare` view
- [ ] Choose **Permanently Merge** → edit name, click Merge & Analyze → spinner appears → redirects to analysis of merged file
- [ ] Verify merged file appears in All Uploads with the chosen name
- [ ] Verify clicking a row (not the checkbox/buttons) toggles selection
- [ ] Verify action buttons (Analyze, Delete) still work without toggling the checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)