### PR TITLE
feat: network topology node significance redesign

### DIFF
--- a/frontend/src/components/network/NetworkGraph/ClusterNode.tsx
+++ b/frontend/src/components/network/NetworkGraph/ClusterNode.tsx
@@ -1,0 +1,108 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+
+export interface ClusterFlowNodeData extends Record<string, unknown> {
+  label: string;
+  clusterId: string;
+  memberCount: number;
+  statsText: string;
+  hasAnomaly: boolean;
+  roleBreakdown: { client: number; server: number; both: number; unknown: number };
+  /** Called when the user clicks the expand button. */
+  onExpand: (clusterId: string) => void;
+  /** Which file(s) this cluster appears in — set only in compare mode. */
+  sources?: string[];
+  primarySource?: string;
+}
+
+export function ClusterNode({ data }: NodeProps) {
+  const {
+    label,
+    clusterId,
+    memberCount,
+    statsText,
+    hasAnomaly,
+    roleBreakdown,
+    onExpand,
+    sources,
+    primarySource,
+  } = data as ClusterFlowNodeData;
+
+  const isSecondaryOnly =
+    sources?.length === 1 && primarySource !== undefined && sources[0] !== primarySource;
+  const isShared = sources !== undefined && sources.length >= 2;
+
+  const total = memberCount || 1;
+  const clientPct = ((roleBreakdown?.client ?? 0) / total) * 100;
+  const serverPct = ((roleBreakdown?.server ?? 0) / total) * 100;
+  const bothPct = ((roleBreakdown?.both ?? 0) / total) * 100;
+  const unknownPct = 100 - clientPct - serverPct - bothPct;
+
+  return (
+    <div
+      className={`network-flow-cluster-node${hasAnomaly ? ' has-anomaly' : ''}`}
+      style={{
+        opacity: isSecondaryOnly ? 0.8 : 1,
+        borderStyle: isSecondaryOnly ? 'dashed' : 'dashed', // always dashed for clusters
+        borderColor: hasAnomaly ? '#e74c3c' : '#7f8c8d',
+      }}
+    >
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="network-flow-handle"
+        style={{ top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}
+      />
+      <Handle
+        type="source"
+        position={Position.Top}
+        className="network-flow-handle"
+        style={{ top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}
+      />
+
+      <button
+        className="network-flow-cluster-expand"
+        title="Expand cluster"
+        onClick={e => {
+          e.stopPropagation();
+          onExpand(clusterId);
+        }}
+      >
+        <i className="bi bi-arrows-angle-expand" />
+      </button>
+
+      <div className="network-flow-cluster-header">
+        {hasAnomaly && (
+          <i
+            className="bi bi-exclamation-triangle-fill me-1"
+            style={{ color: '#e74c3c', fontSize: 10 }}
+          />
+        )}
+        {label}
+        {isShared && (
+          <i
+            className="bi bi-layers-fill ms-1"
+            style={{ fontSize: 9, color: '#6c757d', opacity: 0.85 }}
+          />
+        )}
+      </div>
+
+      <div className="network-flow-cluster-stats">{statsText}</div>
+
+      {/* Role mini-bar */}
+      <div className="network-flow-cluster-rolebar" title="Role breakdown: client / server / both / unknown">
+        {clientPct > 0 && (
+          <div style={{ width: `${clientPct}%`, background: '#3498db' }} title={`${roleBreakdown?.client ?? 0} clients`} />
+        )}
+        {serverPct > 0 && (
+          <div style={{ width: `${serverPct}%`, background: '#2ecc71' }} title={`${roleBreakdown?.server ?? 0} servers`} />
+        )}
+        {bothPct > 0 && (
+          <div style={{ width: `${bothPct}%`, background: '#9b59b6' }} title={`${roleBreakdown?.both ?? 0} both`} />
+        )}
+        {unknownPct > 0 && (
+          <div style={{ width: `${unknownPct}%`, background: '#95a5a6' }} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.css
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.css
@@ -144,3 +144,85 @@
   background: #0d6efd;
   color: #fff;
 }
+
+/* ── Hover highlight — dim non-neighbors ───────────────────────────────── */
+.react-flow__node.nf-dimmed {
+  opacity: 0.12;
+  transition: opacity 0.15s;
+}
+
+.react-flow__edge.nf-dimmed {
+  opacity: 0.08;
+  transition: opacity 0.15s;
+}
+
+/* Non-dimmed nodes/edges get a smooth transition back */
+.react-flow__node,
+.react-flow__edge {
+  transition: opacity 0.15s;
+}
+
+/* ── Cluster node ───────────────────────────────────────────────────────── */
+.network-flow-cluster-node {
+  border-radius: 10px;
+  border: 2px dashed #7f8c8d;
+  background: var(--tp-surface, #fff);
+  padding: 8px 10px;
+  min-width: 140px;
+  width: 140px;
+  position: relative;
+  font-size: 11px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgb(0 0 0 / 12%);
+  transition: box-shadow 0.15s;
+}
+
+.network-flow-cluster-node:hover {
+  box-shadow: 0 4px 12px rgb(0 0 0 / 22%);
+}
+
+.network-flow-cluster-node.has-anomaly {
+  border-color: #e74c3c;
+}
+
+.network-flow-cluster-header {
+  font-family: monospace;
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--tp-text, #212529);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 16px; /* room for expand button */
+}
+
+.network-flow-cluster-stats {
+  color: var(--tp-text-muted, #6c757d);
+  margin-top: 3px;
+  white-space: nowrap;
+}
+
+.network-flow-cluster-rolebar {
+  display: flex;
+  height: 4px;
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 5px;
+}
+
+.network-flow-cluster-expand {
+  position: absolute;
+  top: 5px;
+  right: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--tp-text-muted, #6c757d);
+  line-height: 1;
+}
+
+.network-flow-cluster-expand:hover {
+  color: var(--tp-text, #212529);
+}

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.css
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.css
@@ -145,6 +145,52 @@
   color: #fff;
 }
 
+/* ── Hidden neighbor tooltip ────────────────────────────────────────────── */
+.nf-hidden-tooltip {
+  position: absolute;
+  z-index: 30;
+  background: var(--tp-surface, #fff);
+  border: 1px solid var(--tp-border, #dee2e6);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+  padding: 8px 10px;
+  font-size: 11px;
+  pointer-events: none;
+  max-width: 220px;
+}
+
+.nf-hidden-tooltip-title {
+  font-weight: 600;
+  color: var(--tp-text-muted, #6c757d);
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+.nf-hidden-tooltip-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.nf-hidden-tooltip-list li {
+  font-family: monospace;
+  color: var(--tp-text, #212529);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nf-hidden-tooltip-more {
+  color: var(--tp-text-muted, #6c757d) !important;
+  font-family: inherit !important;
+  font-style: italic;
+}
+
 /* ── Hover highlight — dim non-neighbors ───────────────────────────────── */
 .react-flow__node.nf-dimmed {
   opacity: 0.12;

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -22,6 +22,7 @@ import {
 import '@xyflow/react/dist/style.css';
 import ELK from 'elkjs';
 import type { GraphNode, GraphEdge } from '@/features/network/types';
+import { ClusterNode, type ClusterFlowNodeData } from './ClusterNode';
 import { getProtocolColor, NODE_TYPE_COLORS } from '@/features/network/constants';
 import { deviceTypeColor } from '@/utils/deviceType';
 import { useStore } from '@/store';
@@ -35,6 +36,8 @@ interface NetworkGraphProps {
   nodes: GraphNode[];
   edges: GraphEdge[];
   onNodeClick?: (node: GraphNode) => void;
+  /** Called when the user clicks the expand button on a cluster node. */
+  onClusterClick?: (clusterId: string) => void;
   layoutType?: 'forceDirected2d' | 'hierarchicalTd';
   onLayoutChange?: (layout: 'forceDirected2d' | 'hierarchicalTd') => void;
   /** Called once after ELK layout completes and ReactFlow has painted. */
@@ -72,6 +75,8 @@ interface FlowEdgeData extends Record<string, unknown> {
 
 const NODE_WIDTH = 56;
 const NODE_HEIGHT = 56;
+const CLUSTER_WIDTH = 140;
+const CLUSTER_HEIGHT = 90;
 
 const elk = new ELK();
 
@@ -230,34 +235,67 @@ async function computeLayout(
   nodes: GraphNode[],
   edges: GraphEdge[],
   layoutType: 'forceDirected2d' | 'hierarchicalTd',
-  primarySource?: string
+  primarySource?: string,
+  onClusterClick?: (clusterId: string) => void
 ): Promise<{ nodes: Node[]; edges: Edge[] }> {
-  const dedupedEdges = deduplicateEdges(edges);
+  // Drop edges whose source or target doesn't exist in the node list.
+  // This guards against stale edges after clustering or filtering — ELK will
+  // error on edges that reference unknown node IDs.
+  const nodeIdSet = new Set(nodes.map(n => n.id));
+  const validEdges = edges.filter(e => nodeIdSet.has(e.source) && nodeIdSet.has(e.target));
+  const dedupedEdges = deduplicateEdges(validEdges);
   const offsetMap = assignEdgeOffsets(dedupedEdges);
 
   const graph = await elk.layout({
     id: 'root',
     layoutOptions: ELK_OPTIONS[layoutType],
-    children: nodes.map(n => ({ id: n.id, width: NODE_WIDTH, height: NODE_HEIGHT })),
+    children: nodes.map(n => ({
+      id: n.id,
+      width: n.data.isCluster ? CLUSTER_WIDTH : NODE_WIDTH,
+      height: n.data.isCluster ? CLUSTER_HEIGHT : NODE_HEIGHT,
+    })),
     edges: dedupedEdges.map(e => ({ id: e.id, sources: [e.source], targets: [e.target] })),
   });
 
   const posMap = new Map((graph.children ?? []).map(n => [n.id, { x: n.x ?? 0, y: n.y ?? 0 }]));
 
-  const rfNodes: Node[] = nodes.map(n => ({
-    id: n.id,
-    type: 'networkNode',
-    position: posMap.get(n.id) ?? { x: 0, y: 0 },
-    data: {
-      label: n.label,
-      color: getNodeColor(n.data),
-      icon: getNodeIcon(n.data),
-      sources: n.data.sources,
-      primarySource,
-    },
-    width: NODE_WIDTH,
-    height: NODE_HEIGHT,
-  }));
+  const rfNodes: Node[] = nodes.map(n => {
+    if (n.data.isCluster) {
+      const clusterData: ClusterFlowNodeData = {
+        label: n.label,
+        clusterId: n.data.clusterId!,
+        memberCount: n.data.memberCount ?? 0,
+        statsText: n.data.hostname ?? '',
+        hasAnomaly: n.data.isAnomaly,
+        roleBreakdown: n.data.roleBreakdown ?? { client: 0, server: 0, both: 0, unknown: 0 },
+        onExpand: onClusterClick ?? (() => {}),
+        sources: n.data.sources,
+        primarySource,
+      };
+      return {
+        id: n.id,
+        type: 'clusterNode',
+        position: posMap.get(n.id) ?? { x: 0, y: 0 },
+        data: clusterData,
+        width: CLUSTER_WIDTH,
+        height: CLUSTER_HEIGHT,
+      };
+    }
+    return {
+      id: n.id,
+      type: 'networkNode',
+      position: posMap.get(n.id) ?? { x: 0, y: 0 },
+      data: {
+        label: n.label,
+        color: getNodeColor(n.data),
+        icon: getNodeIcon(n.data),
+        sources: n.data.sources,
+        primarySource,
+      },
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+    };
+  });
 
   const rfEdges: Edge[] = dedupedEdges.map(e => {
     const color = getProtocolColor(e.data.protocol);
@@ -393,7 +431,7 @@ function NetworkEdge({ id, sourceX, sourceY, targetX, targetY, data, style }: Ed
 // Stable type maps
 // ---------------------------------------------------------------------------
 
-const nodeTypes: NodeTypes = { networkNode: NetworkNode };
+const nodeTypes: NodeTypes = { networkNode: NetworkNode, clusterNode: ClusterNode };
 const edgeTypes: EdgeTypes = { networkEdge: NetworkEdge };
 
 // ---------------------------------------------------------------------------
@@ -404,6 +442,7 @@ export const NetworkGraph = memo(function NetworkGraph({
   nodes,
   edges,
   onNodeClick,
+  onClusterClick,
   layoutType = 'forceDirected2d',
   onLayoutChange,
   onLayoutComplete,
@@ -424,6 +463,7 @@ export const NetworkGraph = memo(function NetworkGraph({
     themeMode === 'dark' || (themeMode === 'system' && sysDark);
   const [rfNodes, setRfNodes] = useState<Node[]>([]);
   const [rfEdges, setRfEdges] = useState<Edge[]>([]);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) => setRfNodes(nds => applyNodeChanges(changes, nds)),
@@ -451,7 +491,7 @@ export const NetworkGraph = memo(function NetworkGraph({
     }
 
     setLayouting(true);
-    computeLayout(visibleNodes, edges, layoutType, primarySource)
+    computeLayout(visibleNodes, edges, layoutType, primarySource, onClusterClick)
       .then(({ nodes: n, edges: e }) => {
         if (!active) return;
         setRfNodes(n);
@@ -467,7 +507,7 @@ export const NetworkGraph = memo(function NetworkGraph({
     return () => {
       active = false;
     };
-  }, [visibleNodes, edges, layoutType, primarySource]);
+  }, [visibleNodes, edges, layoutType, primarySource, onClusterClick]);
 
   // Signal the caller once the layout has been computed and painted.
   // Works for both the normal case (rfNodes set after ELK) and the empty-data
@@ -486,11 +526,54 @@ export const NetworkGraph = memo(function NetworkGraph({
 
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {
+      // Cluster nodes handle their own expand click via the button in ClusterNode
       if (!onNodeClick) return;
       const original = nodes.find(n => n.id === node.id);
-      if (original) onNodeClick(original);
+      if (original && !original.data.isCluster) onNodeClick(original);
     },
     [nodes, onNodeClick]
+  );
+
+  const handleNodeMouseEnter = useCallback((_: React.MouseEvent, node: Node) => {
+    setHoveredNodeId(node.id);
+  }, []);
+
+  const handleNodeMouseLeave = useCallback(() => {
+    setHoveredNodeId(null);
+  }, []);
+
+  // When a node is hovered, dim all nodes/edges not connected to it.
+  const { dimmedNodeIds, dimmedEdgeIds } = useMemo(() => {
+    if (!hoveredNodeId) return { dimmedNodeIds: new Set<string>(), dimmedEdgeIds: new Set<string>() };
+    const connectedEdgeIds = new Set<string>();
+    const neighborIds = new Set<string>([hoveredNodeId]);
+    rfEdges.forEach(e => {
+      if (e.source === hoveredNodeId || e.target === hoveredNodeId) {
+        connectedEdgeIds.add(e.id);
+        neighborIds.add(e.source);
+        neighborIds.add(e.target);
+      }
+    });
+    const dimNodes = new Set(rfNodes.map(n => n.id).filter(id => !neighborIds.has(id)));
+    const dimEdges = new Set(rfEdges.map(e => e.id).filter(id => !connectedEdgeIds.has(id)));
+    return { dimmedNodeIds: dimNodes, dimmedEdgeIds: dimEdges };
+  }, [hoveredNodeId, rfNodes, rfEdges]);
+
+  // Apply/remove "dimmed" className without recomputing layout.
+  const displayNodes = useMemo(
+    () =>
+      hoveredNodeId
+        ? rfNodes.map(n => ({ ...n, className: dimmedNodeIds.has(n.id) ? 'nf-dimmed' : '' }))
+        : rfNodes,
+    [hoveredNodeId, rfNodes, dimmedNodeIds]
+  );
+
+  const displayEdges = useMemo(
+    () =>
+      hoveredNodeId
+        ? rfEdges.map(e => ({ ...e, className: dimmedEdgeIds.has(e.id) ? 'nf-dimmed' : '' }))
+        : rfEdges,
+    [hoveredNodeId, rfEdges, dimmedEdgeIds]
   );
 
   if (nodes.length === 0) {
@@ -512,13 +595,15 @@ export const NetworkGraph = memo(function NetworkGraph({
         </div>
       )}
       <ReactFlow
-        nodes={rfNodes}
-        edges={rfEdges}
+        nodes={displayNodes}
+        edges={displayEdges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         onNodeClick={handleNodeClick}
+        onNodeMouseEnter={handleNodeMouseEnter}
+        onNodeMouseLeave={handleNodeMouseLeave}
         fitView
         fitViewOptions={{ padding: 0.15 }}
         nodesConnectable={false}

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -48,6 +48,10 @@ interface NetworkGraphProps {
    * a dashed style to visually distinguish them.
    */
   primarySource?: string;
+  /** Hidden nodes (not rendered due to significance cap). */
+  hiddenNodesList?: GraphNode[];
+  /** Edges connecting a visible node to a hidden node. */
+  crossEdges?: GraphEdge[];
 }
 
 interface FlowNodeData extends Record<string, unknown> {
@@ -98,11 +102,9 @@ const SPECIFIC_NODE_TYPES = new Set([
 
 function getNodeColor(nodeData: {
   role: string;
-  isAnomaly: boolean;
   nodeType?: string;
   deviceType?: string;
 }): string {
-  if (nodeData.isAnomaly) return NODE_TYPE_COLORS['anomaly'];
   if (nodeData.nodeType && SPECIFIC_NODE_TYPES.has(nodeData.nodeType))
     return NODE_TYPE_COLORS[nodeData.nodeType];
   if (nodeData.deviceType && nodeData.deviceType !== 'UNKNOWN')
@@ -130,11 +132,9 @@ const NODE_ICONS: Record<string, string> = {
   'ntp-server': 'bi-clock',
   'database-server': 'bi-database',
   client: 'bi-laptop',
-  anomaly: 'bi-exclamation-triangle-fill',
 };
 
-function getNodeIcon(nodeData: { nodeType?: string; isAnomaly: boolean }): string {
-  if (nodeData.isAnomaly) return NODE_ICONS['anomaly'];
+function getNodeIcon(nodeData: { nodeType?: string }): string {
   return NODE_ICONS[nodeData.nodeType ?? ''] ?? 'bi-pc-display';
 }
 
@@ -266,7 +266,7 @@ async function computeLayout(
         clusterId: n.data.clusterId!,
         memberCount: n.data.memberCount ?? 0,
         statsText: n.data.hostname ?? '',
-        hasAnomaly: n.data.isAnomaly,
+        hasAnomaly: false,
         roleBreakdown: n.data.roleBreakdown ?? { client: 0, server: 0, both: 0, unknown: 0 },
         onExpand: onClusterClick ?? (() => {}),
         sources: n.data.sources,
@@ -447,6 +447,8 @@ export const NetworkGraph = memo(function NetworkGraph({
   onLayoutChange,
   onLayoutComplete,
   primarySource,
+  hiddenNodesList = [],
+  crossEdges = [],
 }: NetworkGraphProps) {
   const themeMode = useStore(s => s.themeMode);
   const [sysDark, setSysDark] = useState(
@@ -464,6 +466,8 @@ export const NetworkGraph = memo(function NetworkGraph({
   const [rfNodes, setRfNodes] = useState<Node[]>([]);
   const [rfEdges, setRfEdges] = useState<Edge[]>([]);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) => setRfNodes(nds => applyNodeChanges(changes, nds)),
@@ -534,12 +538,17 @@ export const NetworkGraph = memo(function NetworkGraph({
     [nodes, onNodeClick]
   );
 
-  const handleNodeMouseEnter = useCallback((_: React.MouseEvent, node: Node) => {
+  const handleNodeMouseEnter = useCallback((event: React.MouseEvent, node: Node) => {
     setHoveredNodeId(node.id);
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (rect) {
+      setTooltipPos({ x: event.clientX - rect.left + 12, y: event.clientY - rect.top + 12 });
+    }
   }, []);
 
   const handleNodeMouseLeave = useCallback(() => {
     setHoveredNodeId(null);
+    setTooltipPos(null);
   }, []);
 
   // When a node is hovered, dim all nodes/edges not connected to it.
@@ -558,6 +567,26 @@ export const NetworkGraph = memo(function NetworkGraph({
     const dimEdges = new Set(rfEdges.map(e => e.id).filter(id => !connectedEdgeIds.has(id)));
     return { dimmedNodeIds: dimNodes, dimmedEdgeIds: dimEdges };
   }, [hoveredNodeId, rfNodes, rfEdges]);
+
+  // Build a lookup map for hidden nodes by ID
+  const hiddenNodeMap = useMemo(
+    () => new Map(hiddenNodesList.map(n => [n.id, n])),
+    [hiddenNodesList]
+  );
+
+  // When hovering, find hidden neighbors via cross-edges
+  const hiddenNeighbors = useMemo<GraphNode[]>(() => {
+    if (!hoveredNodeId || crossEdges.length === 0) return [];
+    const neighborIds = new Set<string>();
+    for (const e of crossEdges) {
+      if (e.source === hoveredNodeId) neighborIds.add(e.target);
+      else if (e.target === hoveredNodeId) neighborIds.add(e.source);
+    }
+    console.debug('[HiddenTooltip] hoveredNode:', hoveredNodeId, 'crossEdges:', crossEdges.length, 'hiddenNodes:', hiddenNodesList.length, 'neighborIds:', [...neighborIds]);
+    return [...neighborIds]
+      .map(id => hiddenNodeMap.get(id))
+      .filter((n): n is GraphNode => n !== undefined);
+  }, [hoveredNodeId, crossEdges, hiddenNodeMap, hiddenNodesList.length]);
 
   // Apply/remove "dimmed" className without recomputing layout.
   const displayNodes = useMemo(
@@ -587,7 +616,30 @@ export const NetworkGraph = memo(function NetworkGraph({
   }
 
   return (
-    <div className="network-graph-container">
+    <div className="network-graph-container" ref={containerRef}>
+      {tooltipPos && hiddenNeighbors.length > 0 && (
+        <div
+          className="nf-hidden-tooltip"
+          style={{ left: tooltipPos.x, top: tooltipPos.y }}
+        >
+          <div className="nf-hidden-tooltip-title">
+            Hidden neighbors ({hiddenNeighbors.length})
+          </div>
+          <ul className="nf-hidden-tooltip-list">
+            {hiddenNeighbors.slice(0, 10).map(n => (
+              <li key={n.id}>
+                {n.data.ip}
+                {n.data.hostname ? ` (${n.data.hostname})` : ''}
+              </li>
+            ))}
+            {hiddenNeighbors.length > 10 && (
+              <li className="nf-hidden-tooltip-more">
+                +{hiddenNeighbors.length - 10} more
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
       {layouting && (
         <div className="network-graph-layouting">
           <div className="spinner-border spinner-border-sm text-secondary me-2" role="status" />

--- a/frontend/src/components/network/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/components/network/NodeDetails/NodeDetails.tsx
@@ -211,13 +211,6 @@ export function NodeDetails({ node, edges, fileId, onClose }: NodeDetailsProps) 
               </div>
             </div>
 
-            {node.data.isAnomaly && (
-              <div className="alert alert-danger py-2 mb-3">
-                <i className="bi bi-exclamation-triangle me-2"></i>
-                <strong>Anomaly Detected</strong>
-              </div>
-            )}
-
             {/* Protocols */}
             <div className="mb-3">
               <h6 className="border-bottom pb-1 mb-2">Protocols</h6>

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -189,7 +189,7 @@ export const FileList = () => {
                     </p>
                     <p className="mb-0">
                       <i className="bi bi-diagram-3 me-1 text-primary"></i>
-                      Select <strong>two or more</strong> files using the checkboxes, then click <strong>Compare selected</strong> for cross-PCAP topology analysis.
+                      Select <strong>two or more</strong> files using the checkboxes, then click <strong>Multi-Analysis</strong> for cross-PCAP topology analysis.
                     </p>
                   </div>
                 </div>
@@ -208,7 +208,7 @@ export const FileList = () => {
                   }}
                 >
                   <i className="bi bi-diagram-3 me-1"></i>
-                  Compare selected ({selectedForCompare.size})
+                  Multi-Analysis ({selectedForCompare.size})
                 </button>
               )}
               <button

--- a/frontend/src/features/network/hooks/useNetworkData.ts
+++ b/frontend/src/features/network/hooks/useNetworkData.ts
@@ -1,16 +1,21 @@
 import { useState, useEffect } from 'react';
 import { conversationService } from '@/features/conversation/services/conversationService';
 import { networkService } from '../services/networkService';
-import type { NetworkGraphData, GraphNode, GraphEdge, NetworkStats } from '../types';
+import type { GraphNode, GraphEdge, NetworkStats } from '../types';
 
 export const MAX_DIAGRAM_NODES = 50;
 import type { AnalysisSummary } from '@/types';
 
-interface UseNetworkDataReturn extends NetworkGraphData {
+interface UseNetworkDataReturn {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  stats: NetworkStats;
   loading: boolean;
   error: string | null;
   refetch: () => void;
   hiddenNodes: number;
+  hiddenNodesList: GraphNode[];
+  crossEdges: GraphEdge[];
 }
 
 export const CONVERSATION_LIMIT_ENABLED =
@@ -32,6 +37,8 @@ export function useNetworkData(
   const [nodes, setNodes] = useState<GraphNode[]>([]);
   const [edges, setEdges] = useState<GraphEdge[]>([]);
   const [hiddenNodes, setHiddenNodes] = useState(0);
+  const [hiddenNodesList, setHiddenNodesList] = useState<GraphNode[]>([]);
+  const [crossEdges, setCrossEdges] = useState<GraphEdge[]>([]);
   const [stats, setStats] = useState<NetworkStats>({
     totalNodes: 0,
     totalEdges: 0,
@@ -95,6 +102,8 @@ export function useNetworkData(
       setNodes(graphData.nodes);
       setEdges(graphData.edges);
       setHiddenNodes(graphData.hiddenNodes ?? 0);
+      setHiddenNodesList(graphData.hiddenNodesList ?? []);
+      setCrossEdges(graphData.crossEdges ?? []);
       setStats({
         ...graphData.stats,
         isLimited: graphData.isLimited,
@@ -123,5 +132,7 @@ export function useNetworkData(
     error,
     refetch: fetchData,
     hiddenNodes,
+    hiddenNodesList,
+    crossEdges,
   };
 }

--- a/frontend/src/features/network/hooks/useNetworkData.ts
+++ b/frontend/src/features/network/hooks/useNetworkData.ts
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { conversationService } from '@/features/conversation/services/conversationService';
 import { networkService } from '../services/networkService';
 import type { GraphNode, GraphEdge, NetworkStats } from '../types';
+import type { Conversation, HostClassification } from '@/types';
 
 export const MAX_DIAGRAM_NODES = 50;
 import type { AnalysisSummary } from '@/types';
@@ -23,10 +24,12 @@ export const CONVERSATION_LIMIT_ENABLED =
 const MAX_CONVERSATIONS = 500;
 
 /**
- * Custom hook for fetching and transforming network data into graph format
- * Follows the same pattern as useAnalysisData
- * @param fileId - The file ID to fetch conversations for
- * @param analysisSummary - Optional analysis summary for anomaly detection
+ * Custom hook for fetching and transforming network data into graph format.
+ *
+ * Fetch and transform are intentionally split:
+ *  - Raw conversations + host classifications are fetched once per fileId change.
+ *  - buildNetworkGraph (pure transformation) re-runs client-side whenever
+ *    maxNodes or analysisSummary changes, avoiding redundant network requests.
  */
 export function useNetworkData(
   fileId: string,
@@ -34,6 +37,11 @@ export function useNetworkData(
   maxNodes: number = MAX_DIAGRAM_NODES
 ): UseNetworkDataReturn {
   const maxConversations = CONVERSATION_LIMIT_ENABLED ? MAX_CONVERSATIONS : Infinity;
+
+  // Raw data cached after the initial fetch — transform re-runs without re-fetching
+  const conversationsRef = useRef<Conversation[]>([]);
+  const hostClassificationsRef = useRef<HostClassification[] | undefined>(undefined);
+
   const [nodes, setNodes] = useState<GraphNode[]>([]);
   const [edges, setEdges] = useState<GraphEdge[]>([]);
   const [hiddenNodes, setHiddenNodes] = useState(0);
@@ -49,6 +57,34 @@ export function useNetworkData(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  /** Apply buildNetworkGraph to the currently cached raw data. */
+  const applyTransform = (
+    conversations: Conversation[],
+    hostClassifications: HostClassification[] | undefined,
+    summary: AnalysisSummary | undefined,
+    limit: number
+  ) => {
+    const graphData = networkService.buildNetworkGraph(
+      conversations,
+      summary,
+      maxConversations,
+      hostClassifications,
+      limit
+    );
+    setNodes(graphData.nodes);
+    setEdges(graphData.edges);
+    setHiddenNodes(graphData.hiddenNodes ?? 0);
+    setHiddenNodesList(graphData.hiddenNodesList ?? []);
+    setCrossEdges(graphData.crossEdges ?? []);
+    setStats({
+      ...graphData.stats,
+      isLimited: graphData.isLimited,
+      totalConversations: graphData.totalConversations,
+      displayedConversations: graphData.displayedConversations,
+    });
+  };
+
+  /** Full fetch + transform — runs when fileId changes. */
   const fetchData = async () => {
     if (!fileId) {
       setLoading(false);
@@ -59,57 +95,40 @@ export function useNetworkData(
       setLoading(true);
       setError(null);
 
-      // Fetch conversations from API
-      // For network visualization, fetch all conversations (use large page size)
-      const response = await conversationService.getConversations(fileId, {
-        ip: '',
-        port: '',
-        payloadContains: '',
-        protocols: [],
-        l7Protocols: [],
-        apps: [],
-        categories: [],
-        hasRisks: false,
-        fileTypes: [],
-        riskTypes: [],
-        customSignatures: [],
-        deviceTypes: [],
-        countries: [],
-        sortBy: '',
-        sortDir: 'asc',
-        page: 1,
-        pageSize: 10000,
-      });
+      const [response] = await Promise.all([
+        conversationService.getConversations(fileId, {
+          ip: '',
+          port: '',
+          payloadContains: '',
+          protocols: [],
+          l7Protocols: [],
+          apps: [],
+          categories: [],
+          hasRisks: false,
+          fileTypes: [],
+          riskTypes: [],
+          customSignatures: [],
+          deviceTypes: [],
+          countries: [],
+          sortBy: '',
+          sortDir: 'asc',
+          page: 1,
+          pageSize: 10000,
+        }),
+      ]);
       const conversations = response.data;
 
-      // Fetch host classifications in parallel with conversation fetch (best-effort)
-      let hostClassifications;
+      let hostClassifications: HostClassification[] | undefined;
       try {
         hostClassifications = await conversationService.getHostClassifications(fileId);
       } catch {
         // If the endpoint isn't available (e.g. older analysis), silently skip
       }
 
-      // Transform to graph data with conversation limit and node significance cap
-      const graphData = networkService.buildNetworkGraph(
-        conversations,
-        analysisSummary,
-        maxConversations,
-        hostClassifications,
-        maxNodes
-      );
+      conversationsRef.current = conversations;
+      hostClassificationsRef.current = hostClassifications;
 
-      setNodes(graphData.nodes);
-      setEdges(graphData.edges);
-      setHiddenNodes(graphData.hiddenNodes ?? 0);
-      setHiddenNodesList(graphData.hiddenNodesList ?? []);
-      setCrossEdges(graphData.crossEdges ?? []);
-      setStats({
-        ...graphData.stats,
-        isLimited: graphData.isLimited,
-        totalConversations: graphData.totalConversations,
-        displayedConversations: graphData.displayedConversations,
-      });
+      applyTransform(conversations, hostClassifications, analysisSummary, maxNodes);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to load network data';
       setError(errorMessage);
@@ -119,10 +138,23 @@ export function useNetworkData(
     }
   };
 
+  // Re-fetch only when the file changes
   useEffect(() => {
     fetchData();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fileId, maxNodes]);
+  }, [fileId]);
+
+  // Re-transform (no network request) when maxNodes or analysisSummary changes
+  useEffect(() => {
+    if (conversationsRef.current.length === 0) return;
+    applyTransform(
+      conversationsRef.current,
+      hostClassificationsRef.current,
+      analysisSummary,
+      maxNodes
+    );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [maxNodes, analysisSummary]);
 
   return {
     nodes,

--- a/frontend/src/features/network/hooks/useNetworkData.ts
+++ b/frontend/src/features/network/hooks/useNetworkData.ts
@@ -2,12 +2,15 @@ import { useState, useEffect } from 'react';
 import { conversationService } from '@/features/conversation/services/conversationService';
 import { networkService } from '../services/networkService';
 import type { NetworkGraphData, GraphNode, GraphEdge, NetworkStats } from '../types';
+
+export const MAX_DIAGRAM_NODES = 50;
 import type { AnalysisSummary } from '@/types';
 
 interface UseNetworkDataReturn extends NetworkGraphData {
   loading: boolean;
   error: string | null;
   refetch: () => void;
+  hiddenNodes: number;
 }
 
 export const CONVERSATION_LIMIT_ENABLED =
@@ -22,11 +25,13 @@ const MAX_CONVERSATIONS = 500;
  */
 export function useNetworkData(
   fileId: string,
-  analysisSummary?: AnalysisSummary
+  analysisSummary?: AnalysisSummary,
+  maxNodes: number = MAX_DIAGRAM_NODES
 ): UseNetworkDataReturn {
   const maxConversations = CONVERSATION_LIMIT_ENABLED ? MAX_CONVERSATIONS : Infinity;
   const [nodes, setNodes] = useState<GraphNode[]>([]);
   const [edges, setEdges] = useState<GraphEdge[]>([]);
+  const [hiddenNodes, setHiddenNodes] = useState(0);
   const [stats, setStats] = useState<NetworkStats>({
     totalNodes: 0,
     totalEdges: 0,
@@ -78,16 +83,18 @@ export function useNetworkData(
         // If the endpoint isn't available (e.g. older analysis), silently skip
       }
 
-      // Transform to graph data with conversation limit
+      // Transform to graph data with conversation limit and node significance cap
       const graphData = networkService.buildNetworkGraph(
         conversations,
         analysisSummary,
         maxConversations,
-        hostClassifications
+        hostClassifications,
+        maxNodes
       );
 
       setNodes(graphData.nodes);
       setEdges(graphData.edges);
+      setHiddenNodes(graphData.hiddenNodes ?? 0);
       setStats({
         ...graphData.stats,
         isLimited: graphData.isLimited,
@@ -105,7 +112,8 @@ export function useNetworkData(
 
   useEffect(() => {
     fetchData();
-  }, [fileId]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fileId, maxNodes]);
 
   return {
     nodes,
@@ -114,5 +122,6 @@ export function useNetworkData(
     loading,
     error,
     refetch: fetchData,
+    hiddenNodes,
   };
 }

--- a/frontend/src/features/network/services/clusterService.ts
+++ b/frontend/src/features/network/services/clusterService.ts
@@ -1,0 +1,263 @@
+import type { GraphNode, GraphEdge, NodeData } from '@/features/network/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NEVER_CLUSTER_PREFIXES = ['127.', '169.254.', '224.', '239.', 'ff0', 'fe80'];
+
+function isNeverClustered(ip: string): boolean {
+  return NEVER_CLUSTER_PREFIXES.some(p => ip.startsWith(p));
+}
+
+/** Returns the /24 candidate key for an IPv4 address. */
+function slash24Key(ip: string): string {
+  const parts = ip.split('.');
+  return `cluster:${parts[0]}.${parts[1]}.${parts[2]}.0/24`;
+}
+
+/** Returns the /16 fallback key for an IPv4 address. */
+function slash16Key(ip: string): string {
+  const parts = ip.split('.');
+  return `cluster:${parts[0]}.${parts[1]}.0.0/16`;
+}
+
+/**
+ * Computes the effective cluster key for every node using a two-pass strategy:
+ *
+ * Pass 1 — group all eligible IPv4 nodes by /24.
+ * Pass 2 — any /24 group with only 1 member is "promoted" to /16, so scattered
+ *           IPs (e.g. 250 unique /24s) still get grouped rather than left as
+ *           individual nodes.  /16 groups with only 1 member pass through unchanged.
+ *
+ * IPv6 nodes always group by their first 4 colon-delimited groups (/64-ish).
+ * L2/loopback/multicast nodes return null (never clustered).
+ */
+function buildClusterKeyMap(nodes: GraphNode[]): Map<string, string> {
+  const keyMap = new Map<string, string>(); // nodeId → final clusterId
+
+  // ── IPv6 and ineligible nodes ──
+  const eligible: GraphNode[] = [];
+  for (const node of nodes) {
+    if (node.data.isL2) continue;
+    const ip = node.data.ip;
+    if (!ip || isNeverClustered(ip)) continue;
+
+    if (ip.includes(':')) {
+      const groups = ip.split(':');
+      keyMap.set(node.id, `cluster:${groups.slice(0, 4).join(':')}::/64`);
+      continue;
+    }
+
+    const parts = ip.split('.');
+    if (parts.length !== 4) continue;
+    eligible.push(node);
+  }
+
+  // ── Pass 1: count /24 members ──
+  const slash24Count = new Map<string, number>();
+  for (const node of eligible) {
+    const k = slash24Key(node.data.ip);
+    slash24Count.set(k, (slash24Count.get(k) ?? 0) + 1);
+  }
+
+  // ── Pass 2: assign final key (/24 if ≥2 members, else /16) ──
+  for (const node of eligible) {
+    const k24 = slash24Key(node.data.ip);
+    if ((slash24Count.get(k24) ?? 0) >= 2) {
+      keyMap.set(node.id, k24);
+    } else {
+      // Promote to /16 — scattered IPs in the same /16 will group together
+      keyMap.set(node.id, slash16Key(node.data.ip));
+    }
+  }
+
+  return keyMap;
+}
+
+function subnetLabel(clusterId: string): string {
+  const inner = clusterId.replace(/^cluster:/, '');
+  if (inner.endsWith('/24')) return inner.replace(/\.0\/24$/, '.x');
+  if (inner.endsWith('/16')) return inner.replace(/\.0\.0\/16$/, '.x.x');
+  // IPv6
+  return inner.replace(/:\/64$/, ':…');
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function applySubnetClustering(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  expandedClusters: Set<string>
+): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  // ── Step 1: assign each node to a cluster key ────────────────────────────
+  const nodeToCluster = buildClusterKeyMap(nodes); // nodeId → clusterId
+  const clusterToMembers = new Map<string, GraphNode[]>(); // clusterId → members
+
+  for (const node of nodes) {
+    const key = nodeToCluster.get(node.id);
+    if (!key) continue; // never clustered — L2, loopback, etc.
+    const members = clusterToMembers.get(key) ?? [];
+    members.push(node);
+    clusterToMembers.set(key, members);
+  }
+
+  // ── Step 2: decide which clusters are active (collapsed) ─────────────────
+  // A cluster is active when it has 2+ members AND is not expanded
+  const activeClusters = new Set<string>();
+  for (const [id, members] of clusterToMembers) {
+    if (members.length >= 2 && !expandedClusters.has(id)) {
+      activeClusters.add(id);
+    }
+  }
+
+  // For non-active clusters, their members pass through individually
+  // Build a set of node IDs that are inside active clusters
+  const clusteredNodeIds = new Set<string>();
+  for (const [clusterId, members] of clusterToMembers) {
+    if (activeClusters.has(clusterId)) {
+      members.forEach(n => clusteredNodeIds.add(n.id));
+    }
+  }
+
+  // ── Step 3: build output nodes ───────────────────────────────────────────
+  const outputNodes: GraphNode[] = [];
+
+  // Pass-through: unclustered nodes and members of expanded/single clusters
+  for (const node of nodes) {
+    if (!clusteredNodeIds.has(node.id)) {
+      outputNodes.push(node);
+    }
+  }
+
+  // Collect intra-cluster edge protocols for dominant protocol calculation
+  const clusterIntraProtocols = new Map<string, Map<string, number>>(); // clusterId → proto → count
+
+  for (const edge of edges) {
+    const sc = nodeToCluster.get(edge.source);
+    const tc = nodeToCluster.get(edge.target);
+    if (sc && tc && sc === tc && activeClusters.has(sc)) {
+      const protoMap = clusterIntraProtocols.get(sc) ?? new Map<string, number>();
+      const proto = edge.data.appName ?? edge.data.protocol;
+      protoMap.set(proto, (protoMap.get(proto) ?? 0) + edge.data.packetCount);
+      clusterIntraProtocols.set(sc, protoMap);
+    }
+  }
+
+  // Synthetic cluster nodes
+  for (const clusterId of activeClusters) {
+    const members = clusterToMembers.get(clusterId)!;
+
+    let totalBytes = 0;
+    let totalConnections = 0;
+    const roleBreakdown = { client: 0, server: 0, both: 0, unknown: 0 };
+    let hasAnomaly = false;
+    const allSources = new Set<string>();
+
+    for (const m of members) {
+      totalBytes += m.data.totalBytes;
+      totalConnections += m.data.connections;
+      roleBreakdown[m.data.role as keyof typeof roleBreakdown] =
+        (roleBreakdown[m.data.role as keyof typeof roleBreakdown] ?? 0) + 1;
+      if (m.data.isAnomaly) hasAnomaly = true;
+      m.data.sources?.forEach(s => allSources.add(s));
+    }
+
+    // Top 3 dominant protocols from intra-cluster edges
+    const protoMap = clusterIntraProtocols.get(clusterId);
+    const dominantProtocols = protoMap
+      ? [...protoMap.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 3)
+          .map(([p]) => p)
+      : [];
+
+    const label = subnetLabel(clusterId);
+    const statsText = `${members.length} nodes · ${formatBytes(totalBytes)}`;
+
+    const clusterData: NodeData = {
+      ip: clusterId, // synthetic — not a real IP
+      packetsSent: 0,
+      packetsReceived: 0,
+      bytesSent: 0,
+      bytesReceived: 0,
+      totalBytes,
+      role: 'unknown',
+      protocols: dominantProtocols,
+      connections: totalConnections,
+      isAnomaly: hasAnomaly,
+      nodeType: 'unknown',
+      nodeTypeEvidence: { dominantPort: null, connectionCount: 0, distinctPeers: 0 },
+      sources: allSources.size > 0 ? [...allSources] : undefined,
+      // Cluster-specific
+      isCluster: true,
+      clusterId,
+      memberCount: members.length,
+      memberIds: members.map(m => m.id),
+      roleBreakdown,
+      dominantProtocols,
+      // Reuse hostname as stats display text
+      hostname: statsText,
+    };
+
+    outputNodes.push({ id: clusterId, label, data: clusterData });
+  }
+
+  // ── Step 4: remap and aggregate edges ────────────────────────────────────
+  // resolvedId: if node is in active cluster → clusterId, else node.id
+  const resolve = (nodeId: string): string => {
+    const cid = nodeToCluster.get(nodeId);
+    return cid && activeClusters.has(cid) ? cid : nodeId;
+  };
+
+  // Aggregate by (resolvedSource, resolvedTarget, protocol)
+  const edgeAgg = new Map<
+    string,
+    { edge: GraphEdge; packetCount: number; totalBytes: number }
+  >();
+
+  for (const edge of edges) {
+    const rs = resolve(edge.source);
+    const rt = resolve(edge.target);
+
+    // Drop intra-cluster edges
+    if (rs === rt) continue;
+
+    const proto = (edge.data.appName ?? edge.data.protocol).toLowerCase();
+    const key = `${rs}\0${rt}\0${proto}`;
+
+    const existing = edgeAgg.get(key);
+    if (existing) {
+      existing.packetCount += edge.data.packetCount;
+      existing.totalBytes += edge.data.totalBytes;
+    } else {
+      edgeAgg.set(key, {
+        edge: { ...edge, id: key, source: rs, target: rt },
+        packetCount: edge.data.packetCount,
+        totalBytes: edge.data.totalBytes,
+      });
+    }
+  }
+
+  const outputEdges: GraphEdge[] = [...edgeAgg.values()].map(({ edge, packetCount, totalBytes }) => {
+    const raw = edge.data.appName ?? edge.data.protocol;
+    const displayName = raw.charAt(0).toUpperCase() + raw.slice(1);
+    return {
+      ...edge,
+      label: `${displayName} (${packetCount.toLocaleString()})`,
+      data: { ...edge.data, packetCount, totalBytes },
+    };
+  });
+
+  return { nodes: outputNodes, edges: outputEdges };
+}

--- a/frontend/src/features/network/services/clusterService.ts
+++ b/frontend/src/features/network/services/clusterService.ts
@@ -161,7 +161,6 @@ export function applySubnetClustering(
     let totalBytes = 0;
     let totalConnections = 0;
     const roleBreakdown = { client: 0, server: 0, both: 0, unknown: 0 };
-    let hasAnomaly = false;
     const allSources = new Set<string>();
 
     for (const m of members) {
@@ -169,7 +168,6 @@ export function applySubnetClustering(
       totalConnections += m.data.connections;
       roleBreakdown[m.data.role as keyof typeof roleBreakdown] =
         (roleBreakdown[m.data.role as keyof typeof roleBreakdown] ?? 0) + 1;
-      if (m.data.isAnomaly) hasAnomaly = true;
       m.data.sources?.forEach(s => allSources.add(s));
     }
 
@@ -195,7 +193,6 @@ export function applySubnetClustering(
       role: 'unknown',
       protocols: dominantProtocols,
       connections: totalConnections,
-      isAnomaly: hasAnomaly,
       nodeType: 'unknown',
       nodeTypeEvidence: { dominantPort: null, connectionCount: 0, distinctPeers: 0 },
       sources: allSources.size > 0 ? [...allSources] : undefined,

--- a/frontend/src/features/network/services/mergeGraphs.ts
+++ b/frontend/src/features/network/services/mergeGraphs.ts
@@ -68,7 +68,6 @@ export function mergeGraphs(
             totalBytes: existing.data.totalBytes + node.data.totalBytes,
             connections: existing.data.connections + node.data.connections,
             protocols: [...new Set([...existing.data.protocols, ...node.data.protocols])],
-            isAnomaly: existing.data.isAnomaly || node.data.isAnomaly,
             sources: [...(existing.data.sources ?? []), label],
           },
         });

--- a/frontend/src/features/network/services/networkService.ts
+++ b/frontend/src/features/network/services/networkService.ts
@@ -116,7 +116,6 @@ function createNode(ip: string, hostname?: string, mac?: string): GraphNode {
       role: 'unknown',
       protocols: [],
       connections: 0,
-      isAnomaly: false,
       nodeType: isL2 ? 'l2-device' : 'unknown',
       nodeTypeEvidence: { dominantPort: null, connectionCount: 0, distinctPeers: 0 },
     },
@@ -237,75 +236,33 @@ function finalizeNodeRole(node: GraphNode, srcPort: number, dstPort: number) {
 /**
  * Mark nodes involved in anomalies
  */
-function markAnomalies(nodeMap: NodeMap, analysisSummary?: AnalysisSummary) {
-  if (!analysisSummary?.fiveWs?.why?.anomalies) {
-    return;
-  }
-
-  const anomalies = analysisSummary.fiveWs.why.anomalies;
-
-  // Extract IPs from suspicious activity
-  const suspiciousActivity = analysisSummary.fiveWs.why.suspiciousActivity || [];
-  const suspiciousIps = new Set<string>();
-
-  suspiciousActivity.forEach(activity => {
-    if (activity.source?.ip) {
-      suspiciousIps.add(activity.source.ip);
-    }
-    if (activity.destination?.ip) {
-      suspiciousIps.add(activity.destination.ip);
-    }
-  });
-
-  // Mark nodes as anomalies
-  suspiciousIps.forEach(ip => {
-    if (nodeMap[ip]) {
-      nodeMap[ip].data.isAnomaly = true;
-    }
-  });
-
-  // Also check if anomaly descriptions mention IPs
-  anomalies.forEach(anomaly => {
-    if (anomaly.severity === 'high' || anomaly.severity === 'critical') {
-      // Try to extract IP addresses from description
-      const ipRegex = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
-      const matches = anomaly.description.match(ipRegex);
-      if (matches) {
-        matches.forEach(ip => {
-          if (nodeMap[ip]) {
-            nodeMap[ip].data.isAnomaly = true;
-          }
-        });
-      }
-    }
-  });
-}
-
 /**
  * Select the most significant nodes to render in the topology diagram.
  *
- * Significance score (0–1 base + anomaly bonus):
+ * Significance score (0–1):
  *   0.5 × (totalBytes / maxBytes)         — traffic dominance
  *   0.3 × (nodeHasRisk ? 1 : 0)           — connected to a risky edge
  *   0.2 × (connections / maxConnections)  — structural hub-ness
- *   1.0 × (isAnomaly ? 1 : 0)             — anomaly bonus (ensures inclusion)
  *
- * Anomaly nodes are always included regardless of limit.
  * Returns the selected nodes and the count of nodes that were hidden.
  */
 function selectSignificantNodes(
   nodes: GraphNode[],
   edges: GraphEdge[],
   limit: number
-): { significantNodes: GraphNode[]; hiddenCount: number } {
+): { significantNodes: GraphNode[]; hiddenCount: number; hiddenNodesList: GraphNode[]; crossEdges: GraphEdge[] } {
   if (nodes.length <= limit) {
-    return { significantNodes: nodes, hiddenCount: 0 };
+    return { significantNodes: nodes, hiddenCount: 0, hiddenNodesList: [], crossEdges: [] };
   }
 
-  // Build per-node risk flag from edges
+  // Build per-node risk flag from edges — includes nDPI flow risks and custom rule matches
   const nodeHasRisk = new Map<string, boolean>();
   for (const e of edges) {
-    if (e.data.hasRisks || (e.data.flowRisks?.length ?? 0) > 0) {
+    if (
+      e.data.hasRisks ||
+      (e.data.flowRisks?.length ?? 0) > 0 ||
+      (e.data.customSignatures?.length ?? 0) > 0
+    ) {
       nodeHasRisk.set(e.source, true);
       nodeHasRisk.set(e.target, true);
     }
@@ -320,14 +277,21 @@ function selectSignificantNodes(
     score:
       0.5 * (n.data.totalBytes / maxBytes) +
       0.3 * (nodeHasRisk.get(n.id) ? 1 : 0) +
-      0.2 * (n.data.connections / maxConns) +
-      1.0 * (n.data.isAnomaly ? 1 : 0),
+      0.2 * (n.data.connections / maxConns),
   }));
 
   scored.sort((a, b) => b.score - a.score);
 
   const significantNodes = scored.slice(0, limit).map(s => s.node);
-  return { significantNodes, hiddenCount: nodes.length - significantNodes.length };
+  const sigNodeIds = new Set(significantNodes.map(n => n.id));
+  const hiddenNodesList = nodes.filter(n => !sigNodeIds.has(n.id));
+
+  // Cross-edges: exactly one endpoint is hidden (visible ↔ hidden connections)
+  const crossEdges = edges.filter(
+    e => sigNodeIds.has(e.source) !== sigNodeIds.has(e.target)
+  );
+
+  return { significantNodes, hiddenCount: hiddenNodesList.length, hiddenNodesList, crossEdges };
 }
 
 /**
@@ -434,20 +398,15 @@ export function buildNetworkGraph(
     });
   }
 
-  // Mark anomalies if analysis data is available
-  if (analysisSummary) {
-    markAnomalies(nodeMap, analysisSummary);
-  }
-
   // Apply significance-based node cap: keep the top-N most significant nodes
   // and drop edges where either endpoint was hidden.
   const allNodes = Array.from(Object.values(nodeMap));
   const allEdges = edges;
 
-  const { significantNodes, hiddenCount } =
+  const { significantNodes, hiddenCount, hiddenNodesList, crossEdges } =
     maxNodes > 0
       ? selectSignificantNodes(allNodes, allEdges, maxNodes)
-      : { significantNodes: allNodes, hiddenCount: 0 };
+      : { significantNodes: allNodes, hiddenCount: 0, hiddenNodesList: [], crossEdges: [] };
 
   const sigNodeIds = new Set(significantNodes.map(n => n.id));
   const significantEdges = allEdges.filter(
@@ -470,6 +429,8 @@ export function buildNetworkGraph(
     totalConversations: conversations.length,
     displayedConversations: limitedConversations.length,
     hiddenNodes: hiddenCount,
+    hiddenNodesList,
+    crossEdges,
   };
 }
 

--- a/frontend/src/features/network/services/networkService.ts
+++ b/frontend/src/features/network/services/networkService.ts
@@ -234,9 +234,6 @@ function finalizeNodeRole(node: GraphNode, srcPort: number, dstPort: number) {
 }
 
 /**
- * Mark nodes involved in anomalies
- */
-/**
  * Select the most significant nodes to render in the topology diagram.
  *
  * Significance score (0–1):
@@ -269,8 +266,8 @@ function selectSignificantNodes(
   }
 
   // Normalisation denominators (avoid division by zero)
-  const maxBytes = Math.max(1, ...nodes.map(n => n.data.totalBytes));
-  const maxConns = Math.max(1, ...nodes.map(n => n.data.connections));
+  const maxBytes = nodes.reduce((max, n) => Math.max(max, n.data.totalBytes), 1);
+  const maxConns = nodes.reduce((max, n) => Math.max(max, n.data.connections), 1);
 
   const scored = nodes.map(n => ({
     node: n,

--- a/frontend/src/features/network/services/networkService.ts
+++ b/frontend/src/features/network/services/networkService.ts
@@ -282,17 +282,68 @@ function markAnomalies(nodeMap: NodeMap, analysisSummary?: AnalysisSummary) {
 }
 
 /**
+ * Select the most significant nodes to render in the topology diagram.
+ *
+ * Significance score (0–1 base + anomaly bonus):
+ *   0.5 × (totalBytes / maxBytes)         — traffic dominance
+ *   0.3 × (nodeHasRisk ? 1 : 0)           — connected to a risky edge
+ *   0.2 × (connections / maxConnections)  — structural hub-ness
+ *   1.0 × (isAnomaly ? 1 : 0)             — anomaly bonus (ensures inclusion)
+ *
+ * Anomaly nodes are always included regardless of limit.
+ * Returns the selected nodes and the count of nodes that were hidden.
+ */
+function selectSignificantNodes(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  limit: number
+): { significantNodes: GraphNode[]; hiddenCount: number } {
+  if (nodes.length <= limit) {
+    return { significantNodes: nodes, hiddenCount: 0 };
+  }
+
+  // Build per-node risk flag from edges
+  const nodeHasRisk = new Map<string, boolean>();
+  for (const e of edges) {
+    if (e.data.hasRisks || (e.data.flowRisks?.length ?? 0) > 0) {
+      nodeHasRisk.set(e.source, true);
+      nodeHasRisk.set(e.target, true);
+    }
+  }
+
+  // Normalisation denominators (avoid division by zero)
+  const maxBytes = Math.max(1, ...nodes.map(n => n.data.totalBytes));
+  const maxConns = Math.max(1, ...nodes.map(n => n.data.connections));
+
+  const scored = nodes.map(n => ({
+    node: n,
+    score:
+      0.5 * (n.data.totalBytes / maxBytes) +
+      0.3 * (nodeHasRisk.get(n.id) ? 1 : 0) +
+      0.2 * (n.data.connections / maxConns) +
+      1.0 * (n.data.isAnomaly ? 1 : 0),
+  }));
+
+  scored.sort((a, b) => b.score - a.score);
+
+  const significantNodes = scored.slice(0, limit).map(s => s.node);
+  return { significantNodes, hiddenCount: nodes.length - significantNodes.length };
+}
+
+/**
  * Transform conversations into graph nodes and edges
  * @param conversations - Array of conversations to visualize
  * @param analysisSummary - Optional analysis summary for anomaly detection
  * @param maxConversations - Maximum number of conversations to render (default: 500)
  * @param hostClassifications - Optional per-IP device classifications from the backend
+ * @param maxNodes - Maximum number of nodes to render (default: 50, 0 = no limit)
  */
 export function buildNetworkGraph(
   conversations: Conversation[],
   analysisSummary?: AnalysisSummary,
   maxConversations: number = 500,
-  hostClassifications?: HostClassification[]
+  hostClassifications?: HostClassification[],
+  maxNodes: number = 50
 ): NetworkGraphData {
   const nodeMap: NodeMap = {};
   const edges: GraphEdge[] = [];
@@ -388,21 +439,37 @@ export function buildNetworkGraph(
     markAnomalies(nodeMap, analysisSummary);
   }
 
+  // Apply significance-based node cap: keep the top-N most significant nodes
+  // and drop edges where either endpoint was hidden.
+  const allNodes = Array.from(Object.values(nodeMap));
+  const allEdges = edges;
+
+  const { significantNodes, hiddenCount } =
+    maxNodes > 0
+      ? selectSignificantNodes(allNodes, allEdges, maxNodes)
+      : { significantNodes: allNodes, hiddenCount: 0 };
+
+  const sigNodeIds = new Set(significantNodes.map(n => n.id));
+  const significantEdges = allEdges.filter(
+    e => sigNodeIds.has(e.source) && sigNodeIds.has(e.target)
+  );
+
   // Calculate statistics, then override packet/byte totals with the authoritative
   // figures from the analysis summary when available. The per-conversation sum
   // misses non-flow traffic (ARP, ICMP, malformed frames, etc.).
-  const stats = calculateNetworkStats(nodeMap, edges);
+  const stats = calculateNetworkStats(nodeMap, significantEdges);
   if (analysisSummary?.totalPackets != null) {
     stats.totalPackets = analysisSummary.totalPackets;
   }
 
   return {
-    nodes: Array.from(Object.values(nodeMap)),
-    edges,
+    nodes: significantNodes,
+    edges: significantEdges,
     stats,
     isLimited: conversations.length > maxConversations,
     totalConversations: conversations.length,
     displayedConversations: limitedConversations.length,
+    hiddenNodes: hiddenCount,
   };
 }
 

--- a/frontend/src/features/network/types/index.ts
+++ b/frontend/src/features/network/types/index.ts
@@ -54,6 +54,19 @@ export interface NodeData {
   ttl?: number;
   /** Which file(s) this node appears in — set only in compare mode. */
   sources?: string[];
+  // ── Cluster fields — only set on synthetic cluster nodes ─────────────────
+  /** True when this node represents a collapsed /24 subnet cluster. */
+  isCluster?: boolean;
+  /** Cluster identifier, e.g. "cluster:192.168.1.0/24". */
+  clusterId?: string;
+  /** Number of real nodes inside this cluster. */
+  memberCount?: number;
+  /** IDs of the real nodes inside this cluster. */
+  memberIds?: string[];
+  /** Breakdown of roles among cluster members. */
+  roleBreakdown?: { client: number; server: number; both: number; unknown: number };
+  /** Top protocols seen on edges between cluster members. */
+  dominantProtocols?: string[];
 }
 
 export interface GraphEdge {
@@ -93,6 +106,8 @@ export interface NetworkGraphData {
   isLimited?: boolean;
   totalConversations?: number;
   displayedConversations?: number;
+  /** Number of nodes hidden by the significance filter (0 when all nodes are shown). */
+  hiddenNodes?: number;
 }
 
 export interface NetworkStats {

--- a/frontend/src/features/network/types/index.ts
+++ b/frontend/src/features/network/types/index.ts
@@ -41,7 +41,6 @@ export interface NodeData {
   role: 'client' | 'server' | 'both' | 'unknown';
   protocols: string[];
   connections: number;
-  isAnomaly: boolean;
   nodeType: NodeType;
   nodeTypeEvidence: NodeTypeEvidence;
   /** Device type from backend classification (e.g. ROUTER, MOBILE, SERVER). */
@@ -108,6 +107,10 @@ export interface NetworkGraphData {
   displayedConversations?: number;
   /** Number of nodes hidden by the significance filter (0 when all nodes are shown). */
   hiddenNodes?: number;
+  /** The actual hidden node objects (not rendered due to significance cap). */
+  hiddenNodesList?: GraphNode[];
+  /** Edges where exactly one endpoint is a hidden node (cross-boundary edges). */
+  crossEdges?: GraphEdge[];
 }
 
 export interface NetworkStats {

--- a/frontend/src/pages/Compare/ComparePage.tsx
+++ b/frontend/src/pages/Compare/ComparePage.tsx
@@ -155,7 +155,6 @@ export const ComparePage = () => {
   const presentNodeTypes = useMemo(() => {
     const types = new Set<string>();
     mergedNodes.forEach(n => {
-      if (n.data.isAnomaly) types.add('anomaly');
       types.add(n.data.nodeType);
     });
     return types;
@@ -294,7 +293,7 @@ export const ComparePage = () => {
             activeNodeFilters.some(key => {
               if (key.startsWith('nt:')) {
                 const nt = key.slice(3);
-                return nt === 'anomaly' ? n.data.isAnomaly : n.data.nodeType === nt;
+                return n.data.nodeType === nt;
               }
               if (key.startsWith('dt:')) return n.data.deviceType === key.slice(3);
               return false;

--- a/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
+++ b/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useRef, useEffect, type Dispatch, type SetStateAction } from 'react';
 import { useOutletContext } from 'react-router-dom';
+import { Modal } from '@govtechsg/sgds-react';
 import type { AnalysisData } from '@/types';
 import type { GraphNode } from '@/features/network/types';
 import {
@@ -43,8 +44,10 @@ function formatBytes(bytes: number): string {
 export const NetworkDiagramPage = () => {
   const { fileId, data } = useOutletContext<AnalysisOutletContext>();
   const [nodeLimit, setNodeLimit] = useState(MAX_DIAGRAM_NODES);
-  const [sliderOpen, setSliderOpen] = useState(false);
-  const { nodes, edges, stats, loading, error, refetch, hiddenNodes } = useNetworkData(
+  // Draft value for the custom node count input — only applied on Enter/blur
+  const [customInput, setCustomInput] = useState('');
+  const [showSignificanceModal, setShowSignificanceModal] = useState(false);
+  const { nodes, edges, stats, loading, error, refetch, hiddenNodes, hiddenNodesList, crossEdges } = useNetworkData(
     fileId,
     data,
     nodeLimit
@@ -118,7 +121,6 @@ export const NetworkDiagramPage = () => {
   const presentNodeTypes = useMemo(() => {
     const types = new Set<string>();
     nodes.forEach(n => {
-      if (n.data.isAnomaly) types.add('anomaly');
       types.add(n.data.nodeType);
     });
     return types;
@@ -260,7 +262,7 @@ export const NetworkDiagramPage = () => {
             activeNodeFilters.some(key => {
               if (key.startsWith('nt:')) {
                 const nt = key.slice(3);
-                return nt === 'anomaly' ? n.data.isAnomaly : n.data.nodeType === nt;
+                return n.data.nodeType === nt;
               }
               if (key.startsWith('dt:')) return n.data.deviceType === key.slice(3);
               return false;
@@ -410,36 +412,69 @@ export const NetworkDiagramPage = () => {
         </div>
       </div>
 
-      {hiddenNodes > 0 && (
-        <div className="alert alert-info mb-3">
-          <i className="bi bi-info-circle me-2"></i>
-          Showing the <strong>{nodeLimit} most significant nodes</strong> ({hiddenNodes} hidden by
-          significance filter). All conversations are available in the Conversations tab.{' '}
-          <button
-            className="btn btn-link btn-sm p-0"
-            onClick={() => setSliderOpen(s => !s)}
-          >
-            {sliderOpen ? 'Hide slider \u25b2' : 'Show more \u25bc'}
-          </button>
-          {sliderOpen && (
-            <div className="mt-2 d-flex align-items-center gap-2">
-              <span className="text-muted small">10</span>
-              <input
-                type="range"
-                min={10}
-                max={200}
-                step={10}
-                value={nodeLimit}
-                onChange={e => setNodeLimit(Number(e.target.value))}
-                className="form-range"
-                style={{ width: 160 }}
-              />
-              <span className="text-muted small">200</span>
-              <span className="badge bg-secondary ms-1">{nodeLimit} nodes</span>
+      {hiddenNodes > 0 && (() => {
+        const totalNodes = stats.totalNodes;
+        const presets = [25, 50, 100, 200].filter(p => p < totalNodes);
+        const applyCustom = () => {
+          const n = parseInt(customInput, 10);
+          if (!isNaN(n) && n > 0) setNodeLimit(Math.min(n, totalNodes));
+          setCustomInput('');
+        };
+        return (
+          <div className="alert alert-info mb-3">
+            <div className="d-flex align-items-start gap-2 flex-wrap">
+              <button
+                className="btn btn-link p-0 border-0 mt-1 flex-shrink-0"
+                style={{ lineHeight: 1 }}
+                title="How is significance determined?"
+                onClick={() => setShowSignificanceModal(true)}
+              >
+                <i className="bi bi-info-circle"></i>
+              </button>
+              <div className="flex-grow-1">
+                <div>
+                  Showing the <strong>{nodeLimit} most significant nodes</strong>
+                  {' '}({hiddenNodes} hidden). Ranked by traffic volume, risk signals, and connectivity.
+                </div>
+                <div className="d-flex align-items-center gap-2 mt-2 flex-wrap">
+                  <span className="text-muted small fw-semibold me-1">Show:</span>
+                  {presets.map(p => (
+                    <button
+                      key={p}
+                      className={`btn btn-sm ${nodeLimit === p ? 'btn-info' : 'btn-outline-secondary'}`}
+                      style={{ minWidth: 52 }}
+                      onClick={() => setNodeLimit(p)}
+                    >
+                      Top {p}
+                    </button>
+                  ))}
+                  <button
+                    className={`btn btn-sm ${nodeLimit >= totalNodes ? 'btn-info' : 'btn-outline-secondary'}`}
+                    style={{ minWidth: 52 }}
+                    onClick={() => setNodeLimit(totalNodes)}
+                  >
+                    All {totalNodes}
+                  </button>
+                  <span className="text-muted small ms-2 me-1">or</span>
+                  <div className="input-group input-group-sm" style={{ width: 120 }}>
+                    <input
+                      type="number"
+                      className="form-control form-control-sm"
+                      placeholder="Custom…"
+                      min={1}
+                      max={totalNodes}
+                      value={customInput}
+                      onChange={e => setCustomInput(e.target.value)}
+                      onKeyDown={e => e.key === 'Enter' && applyCustom()}
+                      onBlur={applyCustom}
+                    />
+                  </div>
+                </div>
+              </div>
             </div>
-          )}
-        </div>
-      )}
+          </div>
+        );
+      })()}
 
       {/* Row 2: Legend & Filters */}
       <div className="mb-3">
@@ -511,6 +546,8 @@ export const NetworkDiagramPage = () => {
                 key={layoutType}
                 nodes={filteredNodes}
                 edges={filteredEdges}
+                hiddenNodesList={hiddenNodesList}
+                crossEdges={crossEdges}
                 onNodeClick={node => setSelectedNode(node)}
                 layoutType={layoutType}
                 onLayoutChange={setLayoutType}
@@ -528,6 +565,50 @@ export const NetworkDiagramPage = () => {
           onClose={() => setSelectedNode(null)}
         />
       )}
+
+      <Modal show={showSignificanceModal} onHide={() => setShowSignificanceModal(false)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title>How node significance is determined</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-muted small mb-3">
+            When a PCAP has more nodes than the current display limit, TracePcap ranks every host
+            by a significance score and shows only the top-ranked ones. The score is a weighted sum
+            of three signals:
+          </p>
+          <table className="table table-sm table-bordered mb-3">
+            <thead>
+              <tr>
+                <th>Signal</th>
+                <th style={{ width: 70 }}>Weight</th>
+                <th>What it measures</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><i className="bi bi-graph-up me-1 text-primary"></i>Traffic volume</td>
+                <td>50%</td>
+                <td>Bytes transferred relative to the busiest node in the capture</td>
+              </tr>
+              <tr>
+                <td><i className="bi bi-shield-exclamation me-1 text-danger"></i>Risk signals</td>
+                <td>30%</td>
+                <td>Whether any conversation involving this host has a flagged <strong>flow risk</strong> (nDPI risk flags) or a <strong>custom rule</strong> match</td>
+              </tr>
+              <tr>
+                <td><i className="bi bi-diagram-2 me-1 text-success"></i>Connectivity</td>
+                <td>20%</td>
+                <td>Number of distinct peers relative to the most-connected node</td>
+              </tr>
+            </tbody>
+          </table>
+        </Modal.Body>
+        <Modal.Footer>
+          <button className="btn btn-secondary" onClick={() => setShowSignificanceModal(false)}>
+            Close
+          </button>
+        </Modal.Footer>
+      </Modal>
     </div>
   );
 };

--- a/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
+++ b/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
@@ -5,6 +5,7 @@ import type { GraphNode } from '@/features/network/types';
 import {
   useNetworkData,
   CONVERSATION_LIMIT_ENABLED,
+  MAX_DIAGRAM_NODES,
 } from '@/features/network/hooks/useNetworkData';
 import { NetworkGraph } from '@components/network/NetworkGraph';
 import { NetworkControls } from '@components/network/NetworkControls';
@@ -41,7 +42,13 @@ function formatBytes(bytes: number): string {
 
 export const NetworkDiagramPage = () => {
   const { fileId, data } = useOutletContext<AnalysisOutletContext>();
-  const { nodes, edges, stats, loading, error, refetch } = useNetworkData(fileId, data);
+  const [nodeLimit, setNodeLimit] = useState(MAX_DIAGRAM_NODES);
+  const [sliderOpen, setSliderOpen] = useState(false);
+  const { nodes, edges, stats, loading, error, refetch, hiddenNodes } = useNetworkData(
+    fileId,
+    data,
+    nodeLimit
+  );
 
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   // Edge legend / protocol filter
@@ -402,6 +409,37 @@ export const NetworkDiagramPage = () => {
           </div>
         </div>
       </div>
+
+      {hiddenNodes > 0 && (
+        <div className="alert alert-info mb-3">
+          <i className="bi bi-info-circle me-2"></i>
+          Showing the <strong>{nodeLimit} most significant nodes</strong> ({hiddenNodes} hidden by
+          significance filter). All conversations are available in the Conversations tab.{' '}
+          <button
+            className="btn btn-link btn-sm p-0"
+            onClick={() => setSliderOpen(s => !s)}
+          >
+            {sliderOpen ? 'Hide slider \u25b2' : 'Show more \u25bc'}
+          </button>
+          {sliderOpen && (
+            <div className="mt-2 d-flex align-items-center gap-2">
+              <span className="text-muted small">10</span>
+              <input
+                type="range"
+                min={10}
+                max={200}
+                step={10}
+                value={nodeLimit}
+                onChange={e => setNodeLimit(Number(e.target.value))}
+                className="form-range"
+                style={{ width: 160 }}
+              />
+              <span className="text-muted small">200</span>
+              <span className="badge bg-secondary ms-1">{nodeLimit} nodes</span>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Row 2: Legend & Filters */}
       <div className="mb-3">

--- a/sample-files/gen_large.py
+++ b/sample-files/gen_large.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Generate a large synthetic PCAP with 5000+ distinct TCP connections.
+
+Run:  python3 gen_large.py
+Output:  large_5k_connections.pcap  (target: <40 MB, >5000 flows)
+
+Strategy: minimal TCP handshake (SYN/SYN-ACK/ACK) per flow plus a small
+application payload so each flow is ~5 packets / ~500 bytes on disk.
+5 000 flows × 500 B ≈ 2.5 MB — well under the 40 MB budget, so we inflate
+with an HTTP-ish payload to produce realistic-looking traffic.
+
+Varied dimensions:
+  - 250 client IPs spread across 5 /24 subnets (192.168.1-5.x)
+  - 250 server IPs spread across 10 /24 subnets (10.0.1-10.x)
+  - 20 dst ports    (common service ports)
+  - Unique src port per flow
+"""
+
+import os
+import sys
+import struct
+import random
+
+try:
+    from scapy.all import wrpcap
+    from scapy.layers.l2 import Ether
+    from scapy.layers.inet import IP, TCP, UDP, ICMP
+    from scapy.layers.dns import DNS, DNSQR, DNSRR
+    from scapy.packet import Raw
+except ImportError:
+    sys.exit("scapy not found — run:  pip install scapy")
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+OUTPUT     = os.path.join(SCRIPT_DIR, "large_5k_connections.pcap")
+
+TARGET_FLOWS = 5_200   # slightly above 5 000 to give headroom
+SEED         = 42
+random.seed(SEED)
+
+# ── address pools ─────────────────────────────────────────────────────────────
+# 250 client IPs across 5 /24 subnets: 192.168.1.x – 192.168.5.x (50 hosts each)
+CLIENT_IPS = [f"192.168.{b}.{h}" for b in range(1, 6) for h in range(1, 51)]  # 250 IPs
+
+# 250 server IPs across 10 /24 subnets: 10.0.{1..10}.x (25 hosts each)
+# This ensures /24 clustering groups them into 10 clusters instead of 250 singletons
+SERVER_IPS = [f"10.0.{b}.{h}" for b in range(1, 11) for h in range(1, 26)]  # 250 IPs
+
+DST_PORTS = [
+    80, 443, 8080, 8443,        # HTTP/HTTPS
+    22, 23, 21, 25, 587,        # SSH, Telnet, FTP, SMTP
+    53, 110, 143, 993, 995,     # DNS, POP3, IMAP, secure variants
+    3306, 5432, 6379, 27017,    # MySQL, Postgres, Redis, Mongo
+    3389, 5900,                  # RDP, VNC
+]
+
+CLIENT_MAC = "aa:bb:cc:dd:ee:01"
+SERVER_MAC = "aa:bb:cc:dd:ee:02"
+
+
+MSS = 1460  # max segment size for splitting large payloads
+
+def tcp_flow(src_ip, dst_ip, sport, dport, payload: bytes = b"") -> list:
+    """TCP flow: SYN / SYN-ACK / ACK, then segmented data transfer."""
+    eth_c = Ether(src=CLIENT_MAC, dst=SERVER_MAC)
+    eth_s = Ether(src=SERVER_MAC, dst=CLIENT_MAC)
+
+    seq_c, seq_s = 1000, 5000
+    pkts = [
+        eth_c / IP(src=src_ip, dst=dst_ip) / TCP(sport=sport, dport=dport, flags="S",  seq=seq_c),
+        eth_s / IP(src=dst_ip, dst=src_ip) / TCP(sport=dport, dport=sport, flags="SA", seq=seq_s, ack=seq_c + 1),
+        eth_c / IP(src=src_ip, dst=dst_ip) / TCP(sport=sport, dport=dport, flags="A",  seq=seq_c + 1, ack=seq_s + 1),
+    ]
+    if payload:
+        # Split payload into MSS-sized segments
+        offset = 0
+        seq = seq_c + 1
+        while offset < len(payload):
+            chunk = payload[offset:offset + MSS]
+            last  = (offset + MSS) >= len(payload)
+            flags = "PA" if last else "A"
+            pkts.append(
+                eth_c / IP(src=src_ip, dst=dst_ip)
+                / TCP(sport=sport, dport=dport, flags=flags, seq=seq, ack=seq_s + 1)
+                / Raw(chunk)
+            )
+            seq    += len(chunk)
+            offset += len(chunk)
+        # Final server ACK
+        pkts.append(
+            eth_s / IP(src=dst_ip, dst=src_ip)
+            / TCP(sport=dport, dport=sport, flags="A", seq=seq_s + 1, ack=seq)
+        )
+    return pkts
+
+
+def udp_flow(src_ip, dst_ip, sport, dport, payload: bytes) -> list:
+    """Simple UDP request/response pair."""
+    eth_c = Ether(src=CLIENT_MAC, dst=SERVER_MAC)
+    eth_s = Ether(src=SERVER_MAC, dst=CLIENT_MAC)
+    return [
+        eth_c / IP(src=src_ip, dst=dst_ip) / UDP(sport=sport, dport=dport) / Raw(payload),
+        eth_s / IP(src=dst_ip, dst=src_ip) / UDP(sport=dport, dport=sport) / Raw(b"\x00" * 20),
+    ]
+
+
+def http_get(host: str, path: str = "/") -> bytes:
+    # Pad with fake query params and headers to bulk up the payload realistically
+    padding = f"X-Request-ID: {'a' * 64}\r\nX-Trace-ID: {'b' * 64}\r\n"
+    body = "x" * 9400   # simulate a moderate JSON/form body (~9.5 KB)
+    return (
+        f"POST {path} HTTP/1.1\r\nHost: {host}\r\nUser-Agent: TestClient/1.0\r\n"
+        f"Accept: application/json\r\nContent-Type: application/json\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        f"{padding}"
+        f"Connection: close\r\n\r\n{body}"
+    ).encode()
+
+
+def dns_query(name: str) -> bytes:
+    return bytes(DNS(rd=1, qd=DNSQR(qname=name, qtype="A")))
+
+
+# ── generate flows ────────────────────────────────────────────────────────────
+packets = []
+sport_counter = 1025   # monotonically increasing source port
+
+print(f"Generating {TARGET_FLOWS} flows …")
+
+for i in range(TARGET_FLOWS):
+    src_ip  = random.choice(CLIENT_IPS)
+    dst_ip  = random.choice(SERVER_IPS)
+    dport   = random.choice(DST_PORTS)
+    sport   = sport_counter
+    sport_counter += 1
+    if sport_counter > 65000:
+        sport_counter = 1025
+
+    if dport == 53:
+        # DNS over UDP
+        name = f"host{i}.example{random.randint(0,99)}.com"
+        packets += udp_flow(src_ip, dst_ip, sport, 53, dns_query(name))
+    elif dport in (443, 8443, 993, 995):
+        # TLS-ish: TCP handshake + minimal TLS ClientHello marker
+        payload = b"\x16\x03\x01" + struct.pack("!H", 32) + bytes(32)  # fake TLS record
+        packets += tcp_flow(src_ip, dst_ip, sport, dport, payload)
+    else:
+        # HTTP-ish plain TCP
+        host = f"srv{random.randint(0,99)}.internal"
+        path = f"/api/resource/{i}"
+        packets += tcp_flow(src_ip, dst_ip, sport, dport, http_get(host, path))
+
+    if (i + 1) % 500 == 0:
+        print(f"  {i + 1}/{TARGET_FLOWS} flows ({len(packets)} packets so far) …")
+
+# ── write output ──────────────────────────────────────────────────────────────
+print(f"\nWriting {len(packets)} packets to {OUTPUT} …")
+wrpcap(OUTPUT, packets)
+
+size_mb = os.path.getsize(OUTPUT) / 1_048_576
+print(f"Done.  File size: {size_mb:.1f} MB   Flows: {TARGET_FLOWS}   Packets: {len(packets)}")
+
+if size_mb > 40:
+    print("WARNING: file exceeds 40 MB target!")
+else:
+    print("OK: within 40 MB budget.")


### PR DESCRIPTION
## Summary

- **Node limit UX redesign**: replaced the slider (which reloaded on every drag step) with preset buttons (Top 25 / Top 50 / Top 100 / Top 200 / All N) and a custom number input that only applies on Enter or blur. The "All" button shows the actual total node count from the data.
- **Significance info modal**: the ⓘ icon in the hidden-nodes banner now opens a modal explaining the scoring formula — traffic volume (50%), risk signals (30%), connectivity (20%).
- **Risk signal improvement**: custom rule matches (`customSignatures`) now contribute to the risk signal in addition to nDPI flow risks.
- **Remove anomaly boosting**: `isAnomaly` and `markAnomalies()` removed entirely — the feature depended on a backend endpoint (`/api/analysis/{fileId}/five-ws`) that does not yet exist.
- **Hover highlight**: hovering a node dims all non-neighbor nodes and edges (0.08–0.12 opacity, 0.15s transition). Infrastructure for a hidden-neighbor tooltip is plumbed through the data pipeline (`crossEdges`, `hiddenNodesList`).
- **Rename button**: "Compare selected" → "Multi-Analysis" on the upload card.

## Test plan

- [ ] Upload a small PCAP (e.g. `discord.pcap`) — no hidden-nodes banner shown, all nodes render
- [ ] Upload `large_5k_connections.pcap` — banner appears with preset buttons; clicking Top 25 / Top 50 / All renders correctly without intermediate reloads
- [ ] Custom input: type a number and press Enter — graph updates once
- [ ] Click the ⓘ icon — significance modal opens with correct scoring table
- [ ] Hover a node — non-neighbors dim smoothly; move away — everything restores
- [ ] Upload card: multi-select two files and confirm button reads "Multi-Analysis (2)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)