### PR TITLE
fix: replace array_length with cardinality in InvestigationService

### DIFF
--- a/backend/src/main/java/com/tracepcap/story/service/InvestigationService.java
+++ b/backend/src/main/java/com/tracepcap/story/service/InvestigationService.java
@@ -102,10 +102,8 @@ public class InvestigationService {
       if (q.getMaxBytes() != null && byteFilterSafe) predicates.add(cb.lessThanOrEqualTo(root.get("totalBytes"), q.getMaxBytes()));
 
       if (Boolean.TRUE.equals(q.getHasRisks())) {
-        predicates.add(cb.isNotNull(root.get("flowRisks")));
-        // array_length(flow_risks, 1) IS NOT NULL means the array is non-empty
-        predicates.add(cb.isNotNull(
-            cb.function("array_length", Integer.class, root.get("flowRisks"), cb.literal(1))));
+        predicates.add(cb.greaterThan(
+            cb.function("cardinality", Integer.class, root.get("flowRisks")), 0));
       }
 
       if (Boolean.TRUE.equals(q.getHasTlsAnomaly())) {


### PR DESCRIPTION
## Problem

`cb.function("array_length", ..., cb.literal(1))` — Hibernate silently drops the second argument when building the SQL, so PostgreSQL receives `array_length(flow_risks)` (1 argument) instead of `array_length(flow_risks, 1)` (2 arguments). PostgreSQL requires exactly 2 arguments and throws an error.

This exception occurs inside `@Transactional generateStory()`. Even though it is caught, it marks the transaction rollback-only — so the subsequent commit throws `UnexpectedRollbackException`, which surfaces to the user as *"An unexpected error occurred"* when filtering conversations by risk.

## Fix

Replace with `cardinality(flow_risks) > 0`, which:
- Takes a single argument (no Hibernate argument-dropping issue)
- Handles `NULL` correctly — `cardinality(NULL) > 0` evaluates to `false` in PostgreSQL, so the separate `isNotNull` guard is no longer needed

## Test plan
- [ ] Filter conversations with **Has Risks** enabled — results should return correctly without error
- [ ] Filter with Has Risks disabled — no change in behaviour
- [ ] Verify no `UnexpectedRollbackException` in backend logs when generating a story after a risk filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)