### PR TITLE
feat: show active filters and node-limit note on report diagram pages

### DIFF
--- a/backend/src/main/java/com/tracepcap/report/ReportRequest.java
+++ b/backend/src/main/java/com/tracepcap/report/ReportRequest.java
@@ -12,4 +12,6 @@ public class ReportRequest {
   private String hierarchicalImage;
   /** Human-readable labels for each active network-diagram filter, e.g. "Protocol: HTTPS". */
   private List<String> activeFilters;
+  /** Node-limit banner text when not all nodes are shown, e.g. "Showing the 50 most significant nodes (428 hidden)…". */
+  private String nodeLimitNote;
 }

--- a/backend/src/main/java/com/tracepcap/report/ReportService.java
+++ b/backend/src/main/java/com/tracepcap/report/ReportService.java
@@ -8,6 +8,8 @@ import com.lowagie.text.PageSize;
 import com.lowagie.text.Paragraph;
 import com.lowagie.text.Phrase;
 import com.lowagie.text.Rectangle;
+import com.lowagie.text.pdf.ColumnText;
+import com.lowagie.text.pdf.PdfContentByte;
 import com.lowagie.text.pdf.PdfPCell;
 import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfWriter;
@@ -118,7 +120,7 @@ public class ReportService {
 
     Document document = new Document(PageSize.A4, 40, 40, 60, 40);
     try {
-      PdfWriter.getInstance(document, out);
+      PdfWriter writer = PdfWriter.getInstance(document, out);
       document.open();
 
       // ── Sections ──────────────────────────────────────────────────────────
@@ -202,13 +204,15 @@ public class ReportService {
         addExtractedFiles(document, extractedFiles, sec++);
       }
 
-      if (request.getActiveFilters() != null && !request.getActiveFilters().isEmpty()) {
-        addNetworkDiagramFilters(document, request.getActiveFilters(), sec++);
-      }
-
-      addTopologyDiagram(document, request.getForceDirectedImage(), "Force-Directed Layout", sec++);
+      List<String> activeFilters =
+          request.getActiveFilters() != null ? request.getActiveFilters() : List.of();
+      String nodeLimitNote = request.getNodeLimitNote();
       addTopologyDiagram(
-          document, request.getHierarchicalImage(), "Hierarchical Layout (Top-Down)", sec++);
+          document, writer, request.getForceDirectedImage(), "Force-Directed Layout", sec++,
+          activeFilters, nodeLimitNote);
+      addTopologyDiagram(
+          document, writer, request.getHierarchicalImage(), "Hierarchical Layout (Top-Down)", sec++,
+          activeFilters, nodeLimitNote);
 
     } catch (Exception e) {
       log.error("PDF generation failed for file {}", fileId, e);
@@ -828,57 +832,177 @@ public class ReportService {
   // ══════════════════════════════════════════════════════════════════════════
 
   private void addTopologyDiagram(
-      Document doc, String base64Image, String layoutName, int sectionNum) throws Exception {
+      Document doc, PdfWriter writer, String base64Image, String layoutName, int sectionNum,
+      List<String> activeFilters, String nodeLimitNote)
+      throws Exception {
 
-    // Each topology diagram gets its own full landscape page.
-    // Use an explicit Rectangle rather than rotate() so the size is applied
-    // unambiguously regardless of the previous page's orientation.
-    Rectangle landscape = new Rectangle(PageSize.A4.getHeight(), PageSize.A4.getWidth());
-    doc.setPageSize(landscape);
+    // ── Page setup ────────────────────────────────────────────────────────────
+    // setPageSize only takes effect on the next newPage(). Calling newPage()
+    // twice guarantees the landscape size is active before we draw anything:
+    // the first call closes the previous page with its current size, the second
+    // opens a fresh page with the new landscape size.
+    float pageW = PageSize.A4.getHeight(); // 841.89 pt
+    float pageH = PageSize.A4.getWidth();  // 595.28 pt
+    doc.setPageSize(new Rectangle(pageW, pageH));
+    doc.setMargins(40, 40, 40, 40);
     doc.newPage();
+    // Verify the page size took effect; if the writer still reports portrait
+    // dimensions, force one more page turn.
+    if (writer.getPageSize().getHeight() < writer.getPageSize().getWidth() == false
+        && writer.getPageSize().getWidth() < pageW - 1f) {
+      doc.newPage();
+    }
 
-    // Compact title — avoids the ~50pt overhead of the banner-style section
-    // header so the image fits on the same page without shrinking.
+    // ── Constants ─────────────────────────────────────────────────────────────
+    final int   BADGE_COLS = 5;
+    final float MARGIN     = 40f;
+    final float TITLE_H    = 16f;  // 11pt font + leading
+    final float TITLE_GAP  = 6f;   // gap between title bottom and image top
+    final float FOOTER_GAP = 8f;   // gap between image bottom and topmost footer element
+
+    List<String> nonNullFilters =
+        (activeFilters != null)
+            ? activeFilters.stream().filter(f -> f != null)
+                .collect(java.util.stream.Collectors.toList())
+            : List.of();
+    boolean hasFilters  = !nonNullFilters.isEmpty();
+    boolean hasNodeNote = nodeLimitNote != null && !nodeLimitNote.isBlank();
+
+    float contentW = pageW - MARGIN * 2;
+
+    Font disclaimerFont = new Font(Font.HELVETICA, 7.5f, Font.ITALIC, new Color(120, 120, 120));
+    Font noteFont       = new Font(Font.HELVETICA, 7.5f, Font.ITALIC, new Color(80, 80, 80));
+
+    // ── Build badge chips table so getTotalHeight() is exact ─────────────────
+    // (disclaimer + note are built below as a single combined table)
+
+    // Badge chips (optional)
+    PdfPTable badges = null;
+    float badgesH = 0f;
+    if (hasFilters) {
+      Font labelFont = new Font(Font.HELVETICA, 7f, Font.BOLD,   new Color(30, 64, 175));
+      Font valueFont = new Font(Font.HELVETICA, 7f, Font.NORMAL, new Color(30, 41,  59));
+      Color chipBg   = new Color(219, 234, 254);
+      int cols = Math.min(nonNullFilters.size(), BADGE_COLS);
+      badges = new PdfPTable(cols);
+      badges.setTotalWidth(contentW);
+      for (String filter : nonNullFilters) {
+        int colon = filter.indexOf(':');
+        Phrase phrase = new Phrase();
+        if (colon > 0) {
+          phrase.add(new Phrase(filter.substring(0, colon + 1) + " ", labelFont));
+          phrase.add(new Phrase(filter.substring(colon + 1).trim(), valueFont));
+        } else {
+          phrase.add(new Phrase(filter, valueFont));
+        }
+        PdfPCell chip = new PdfPCell(phrase);
+        chip.setBackgroundColor(chipBg);
+        chip.setPaddingTop(2); chip.setPaddingBottom(2);
+        chip.setPaddingLeft(5); chip.setPaddingRight(5);
+        chip.setBorderColor(new Color(147, 197, 253));
+        chip.setBorderWidth(0.5f);
+        badges.addCell(chip);
+      }
+      int remainder = nonNullFilters.size() % cols;
+      if (remainder != 0) {
+        for (int p = remainder; p < cols; p++) {
+          PdfPCell empty = new PdfPCell(new Phrase(""));
+          empty.setBorder(Rectangle.NO_BORDER);
+          badges.addCell(empty);
+        }
+      }
+      badgesH = badges.getTotalHeight();
+    }
+
+    // ── Merge disclaimer + note into one table for exact combined height ───────
+    // Building them separately risks coordinate drift; one table guarantees
+    // the text block height is measured as a single unit.
+    PdfPTable textFooter = new PdfPTable(1);
+    textFooter.setTotalWidth(contentW);
+    if (hasNodeNote) {
+      PdfPCell noteCell2 = new PdfPCell(new Phrase(nodeLimitNote, noteFont));
+      noteCell2.setBorder(Rectangle.NO_BORDER);
+      noteCell2.setHorizontalAlignment(Element.ALIGN_CENTER);
+      noteCell2.setPaddingTop(0); noteCell2.setPaddingBottom(2);
+      textFooter.addCell(noteCell2);
+    }
+    PdfPCell discCell2 = new PdfPCell(new Phrase(
+        "Note: This diagram is automatically generated and may not render all connections accurately "
+            + "for large or complex network captures. For a complete view, consider taking a manual "
+            + "screenshot from the Network Diagram page.",
+        disclaimerFont));
+    discCell2.setBorder(Rectangle.NO_BORDER);
+    discCell2.setHorizontalAlignment(Element.ALIGN_CENTER);
+    discCell2.setPaddingTop(0); discCell2.setPaddingBottom(0);
+    textFooter.addCell(discCell2);
+    float textFooterH = textFooter.getTotalHeight();
+
+    // ── Exact footer height ───────────────────────────────────────────────────
+    float footerH = FOOTER_GAP + textFooterH + badgesH;
+
+    // ── Derive image slot ─────────────────────────────────────────────────────
+    float titleTop = pageH - MARGIN;
+    float imageTop = titleTop - TITLE_H - TITLE_GAP;
+    float imageBot = MARGIN + footerH;
+    float usableH  = imageTop - imageBot;
+
+    log.info("Topology diagram '{}': pageH={} footerH={} (textFooter={} badges={}) imageBot={} usableH={}",
+        layoutName, pageH, footerH, textFooterH, badgesH, imageBot, usableH);
+
+    // ── Draw title ────────────────────────────────────────────────────────────
+    PdfContentByte cb = writer.getDirectContent();
     Font titleFont = new Font(Font.HELVETICA, 11, Font.BOLD, C_HEADER_BG);
-    Paragraph title = new Paragraph(sectionNum + ". Network Topology — " + layoutName, titleFont);
-    title.setSpacingBefore(4);
-    title.setSpacingAfter(6);
-    doc.add(title);
+    ColumnText ctTitle = new ColumnText(cb);
+    ctTitle.setSimpleColumn(MARGIN, titleTop - TITLE_H, MARGIN + contentW, titleTop);
+    ctTitle.setAlignment(Element.ALIGN_LEFT);
+    ctTitle.addText(new Phrase(sectionNum + ". Network Topology \u2014 " + layoutName, titleFont));
+    ctTitle.go();
 
     if (base64Image == null || base64Image.isBlank()) {
-      doc.add(new Paragraph("Diagram image not provided.", cellFont()));
+      ColumnText ctErr = new ColumnText(cb);
+      ctErr.setSimpleColumn(MARGIN, imageBot, MARGIN + contentW, imageTop);
+      ctErr.addText(new Phrase("Diagram image not provided.", cellFont()));
+      ctErr.go();
+      doc.add(new Paragraph(" "));
       return;
     }
 
-    // Usable area: landscape height minus top+bottom margins (100), title (21),
-    // image spacingBefore (8), and disclaimer with its spacing (40).
-    float usableW = landscape.getWidth() - 80f;
-    float usableH = landscape.getHeight() - 100f - 21f - 8f - 40f;
-
+    // ── Draw image ────────────────────────────────────────────────────────────
     byte[] imageBytes;
     try {
       String data = base64Image.contains(",") ? base64Image.split(",")[1] : base64Image;
       imageBytes = Base64.getDecoder().decode(data);
     } catch (IllegalArgumentException e) {
       log.warn("Invalid base64 image data for layout: {}", layoutName);
-      doc.add(new Paragraph("Invalid diagram image data.", cellFont()));
+      ColumnText ctErr = new ColumnText(cb);
+      ctErr.setSimpleColumn(MARGIN, imageBot, MARGIN + contentW, imageTop);
+      ctErr.addText(new Phrase("Invalid diagram image data.", cellFont()));
+      ctErr.go();
+      doc.add(new Paragraph(" "));
       return;
     }
     Image img = Image.getInstance(imageBytes);
-    img.scaleToFit(usableW, usableH);
-    img.setAlignment(Image.ALIGN_CENTER);
-    img.setSpacingBefore(8);
-    doc.add(img);
+    img.scaleToFit(contentW, usableH);
+    float imgX = MARGIN + (contentW - img.getScaledWidth()) / 2f;
+    float imgY = imageTop - img.getScaledHeight();
+    img.setAbsolutePosition(imgX, imgY);
+    cb.addImage(img);
 
-    Font disclaimerFont = new Font(Font.HELVETICA, 7.5f, Font.ITALIC, new Color(120, 120, 120));
-    Paragraph disclaimer =
-        new Paragraph(
-            "Note: This diagram is automatically generated and may not render all connections accurately for large or complex network captures. "
-                + "For a complete view, consider taking a manual screenshot from the Network Diagram page.",
-            disclaimerFont);
-    disclaimer.setAlignment(Element.ALIGN_CENTER);
-    disclaimer.setSpacingBefore(6);
-    doc.add(disclaimer);
+    // ── Draw footer bottom-up — two elements, exact heights, no estimates ─────
+    float y = MARGIN;
+
+    // 1. Badge chips (bottom-most)
+    if (badges != null) {
+      badges.writeSelectedRows(0, -1, MARGIN, y + badgesH, cb);
+      y += badgesH;
+    }
+
+    // 2. Text block (node note + disclaimer) directly above badges
+    y += FOOTER_GAP;
+    textFooter.writeSelectedRows(0, -1, MARGIN, y + textFooterH, cb);
+
+    // Advance iText's flow cursor so the next section opens a new page.
+    doc.add(new Paragraph(" "));
   }
 
   // ══════════════════════════════════════════════════════════════════════════

--- a/backend/src/main/java/com/tracepcap/report/ReportService.java
+++ b/backend/src/main/java/com/tracepcap/report/ReportService.java
@@ -848,7 +848,7 @@ public class ReportService {
     doc.newPage();
     // Verify the page size took effect; if the writer still reports portrait
     // dimensions, force one more page turn.
-    if (writer.getPageSize().getHeight() < writer.getPageSize().getWidth() == false
+    if (writer.getPageSize().getHeight() >= writer.getPageSize().getWidth()
         && writer.getPageSize().getWidth() < pageW - 1f) {
       doc.newPage();
     }

--- a/frontend/src/features/network/constants.ts
+++ b/frontend/src/features/network/constants.ts
@@ -59,6 +59,31 @@ export const NODE_TYPE_LABELS: Record<string, string> = {
 };
 
 /**
+ * Converts a raw activeNodeFilters key (e.g. "nt:router", "dt:IOT") to a
+ * human-readable label using the existing display maps.
+ */
+export function nodeFilterLabel(key: string): string {
+  if (key.startsWith('nt:')) {
+    const type = key.slice(3);
+    return NODE_TYPE_LABELS[type] ?? type.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+  if (key.startsWith('dt:')) {
+    // Inline the deviceTypeLabel logic to avoid a circular import.
+    const dt = key.slice(3);
+    switch (dt) {
+      case 'ROUTER': return 'Router';
+      case 'MOBILE': return 'Mobile';
+      case 'LAPTOP_DESKTOP': return 'Laptop / Desktop';
+      case 'SERVER': return 'Server';
+      case 'IOT': return 'IoT Device';
+      case 'UNKNOWN': return 'Unknown';
+      default: return dt;
+    }
+  }
+  return key;
+}
+
+/**
  * Single source of truth for node type colors used in
  * NetworkGraph (node fill) and NetworkControls (legend).
  */

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -7,6 +7,7 @@ import { apiClient } from '@/services/api/client';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
 import { captureNetworkDiagrams } from '@/features/report/captureNetworkDiagrams';
 import { MAX_DIAGRAM_NODES } from '@/features/network/hooks/useNetworkData';
+import { nodeFilterLabel } from '@/features/network/constants';
 import type { GraphNode, GraphEdge } from '@/features/network/types';
 import type { AnalysisData } from '@/types';
 
@@ -14,6 +15,7 @@ export interface NetworkGraphState {
   filteredNodes: GraphNode[];
   filteredEdges: GraphEdge[];
   activeFilterLabels: string[];
+  nodeLimitNote: string | null;
 }
 
 export interface NetworkDiagramFilterState {
@@ -60,7 +62,6 @@ export const AnalysisPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { data, loading, error, refetch } = useAnalysisData(fileId!);
-  const { filters } = useConversationFilters();
   const [activeTab, setActiveTab] = useState('overview');
   const [reportLoading, setReportLoading] = useState(false);
   const [reportError, setReportError] = useState<string | null>(null);
@@ -103,6 +104,7 @@ export const AnalysisPage = () => {
     filteredNodes: [],
     filteredEdges: [],
     activeFilterLabels: [],
+    nodeLimitNote: null,
   });
 
   useEffect(() => {
@@ -126,12 +128,40 @@ export const AnalysisPage = () => {
     setReportError(null);
     setReportStep('Rendering network diagrams…');
     try {
-      const { filteredNodes, filteredEdges, activeFilterLabels } = networkGraphStateRef.current;
+      const { filteredNodes, filteredEdges, nodeLimitNote: refNodeLimitNote } = networkGraphStateRef.current;
 
-      // If the user never visited the Network Diagram tab the ref will be empty.
-      // Fall back to a fresh unfiltered fetch so the PDF always contains diagrams.
+      // Build filter labels from the lifted state — always accurate regardless
+      // of whether the Network Diagram tab has been visited.
+      const activeFilterLabels: string[] = [];
+      if (ipFilter) activeFilterLabels.push(`IP: ${ipFilter}`);
+      if (portFilter) activeFilterLabels.push(`Port: ${portFilter}`);
+      if (hasRisksOnly) activeFilterLabels.push('Has Risks: Yes');
+      if (activeLegendProtocols.length > 0)
+        activeFilterLabels.push(`Protocol: ${activeLegendProtocols.join(', ')}`);
+      if (activeNodeFilters.length > 0)
+        activeFilterLabels.push(`Node type: ${activeNodeFilters.map(nodeFilterLabel).join(', ')}`);
+      if (activeAppFilters.length > 0)
+        activeFilterLabels.push(`App: ${activeAppFilters.join(', ')}`);
+      if (activeL7Protocols.length > 0)
+        activeFilterLabels.push(`L7: ${activeL7Protocols.join(', ')}`);
+      if (activeCategories.length > 0)
+        activeFilterLabels.push(`Category: ${activeCategories.join(', ')}`);
+      if (activeRiskTypes.length > 0)
+        activeFilterLabels.push(`Risk type: ${activeRiskTypes.join(', ')}`);
+      if (activeCustomSigs.length > 0)
+        activeFilterLabels.push(`Custom signature: ${activeCustomSigs.join(', ')}`);
+      if (activeFileTypes.length > 0)
+        activeFilterLabels.push(`File type: ${activeFileTypes.join(', ')}`);
+      if (activeCountries.length > 0)
+        activeFilterLabels.push(`Country: ${activeCountries.join(', ')}`);
+
       let diagramNodes = filteredNodes;
       let diagramEdges = filteredEdges;
+      let nodeLimitNote: string | null = refNodeLimitNote ?? null;
+
+      // If the user never visited the Network Diagram tab the ref will be empty.
+      // Fetch the raw graph then apply the same client-side filters so the PDF
+      // matches what the user would see on the diagram tab.
       if (diagramNodes.length === 0) {
         setReportStep('Fetching network data…');
         const { conversationService } = await import(
@@ -147,10 +177,78 @@ export const AnalysisPage = () => {
           conversationService.getHostClassifications(fileId).catch(() => undefined),
         ]);
         const graph = networkService.buildNetworkGraph(
-          convResponse.data, data ?? undefined, 500, hostClassifications
+          convResponse.data, data ?? undefined, nodeLimit, hostClassifications
         );
-        diagramNodes = graph.nodes;
-        diagramEdges = graph.edges;
+
+        // Apply the same client-side filters the diagram tab would use.
+        let fe = graph.edges;
+        if (hasRisksOnly) fe = fe.filter(e => e.data.hasRisks);
+        if (activeLegendProtocols.length > 0)
+          fe = fe.filter(e => activeLegendProtocols.some(k => {
+            const p = e.data.protocol.toUpperCase();
+            const a = (e.data.appName ?? '').toUpperCase();
+            if (k === 'HTTPS') return p === 'HTTPS' || a.includes('TLS') || a.includes('SSL') || a.includes('HTTPS');
+            if (k === 'ICMP') return p === 'ICMP' || p === 'ICMPV6';
+            if (k === 'STP') return p === 'STP' || p === 'RSTP';
+            return p === k || a.includes(k);
+          }));
+        if (activeAppFilters.length > 0)
+          fe = fe.filter(e => activeAppFilters.includes(e.data.appName ?? ''));
+        if (activeL7Protocols.length > 0)
+          fe = fe.filter(e => activeL7Protocols.includes(e.data.l7Protocol ?? ''));
+        if (activeCategories.length > 0)
+          fe = fe.filter(e => activeCategories.includes(e.data.category ?? ''));
+        if (activeRiskTypes.length > 0)
+          fe = fe.filter(e => activeRiskTypes.some(r => e.data.flowRisks?.includes(r)));
+        if (activeCustomSigs.length > 0)
+          fe = fe.filter(e => activeCustomSigs.some(s => e.data.customSignatures?.includes(s)));
+        if (activeFileTypes.length > 0)
+          fe = fe.filter(e => activeFileTypes.some(f => e.data.detectedFileTypes?.includes(f)));
+        if (activeCountries.length > 0)
+          fe = fe.filter(e =>
+            activeCountries.includes(e.data.srcCountry ?? '') ||
+            activeCountries.includes(e.data.dstCountry ?? '')
+          );
+        if (activeNodeFilters.length > 0) {
+          const matchIds = new Set(
+            graph.nodes.filter(n => activeNodeFilters.some(k => {
+              if (k.startsWith('nt:')) return n.data.nodeType === k.slice(3);
+              if (k.startsWith('dt:')) return n.data.deviceType === k.slice(3);
+              return false;
+            })).map(n => n.id)
+          );
+          fe = fe.filter(e => matchIds.has(e.source) || matchIds.has(e.target));
+        }
+        if (portFilter) {
+          const portNum = parseInt(portFilter, 10);
+          if (!isNaN(portNum))
+            fe = fe.filter(e => e.data.srcPort === portNum || e.data.dstPort === portNum);
+        }
+
+        const visibleIds = new Set<string>();
+        fe.forEach(e => { visibleIds.add(e.source); visibleIds.add(e.target); });
+        let fn = graph.nodes.filter(n => visibleIds.has(n.id));
+        if (ipFilter) {
+          const ipLower = ipFilter.toLowerCase();
+          const ipMatchIds = new Set(
+            graph.nodes
+              .filter(n => n.data.ip.toLowerCase().includes(ipLower) ||
+                (n.data.hostname ?? '').toLowerCase().includes(ipLower))
+              .map(n => n.id)
+          );
+          fe = fe.filter(e => ipMatchIds.has(e.source) || ipMatchIds.has(e.target));
+          fn = graph.nodes.filter(n => {
+            const inEdge = fe.some(e => e.source === n.id || e.target === n.id);
+            return inEdge || ipMatchIds.has(n.id);
+          });
+        }
+
+        // If all filters are default (no active filters), use the full graph.
+        diagramNodes = fn.length > 0 || activeFilterLabels.length > 0 ? fn : graph.nodes;
+        diagramEdges = fn.length > 0 || activeFilterLabels.length > 0 ? fe : graph.edges;
+        if (graph.hiddenNodes && graph.hiddenNodes > 0) {
+          nodeLimitNote = `Showing the ${nodeLimit} most significant nodes (${graph.hiddenNodes} hidden). Ranked by traffic volume, risk signals, and connectivity.`;
+        }
         setReportStep('Rendering network diagrams…');
       }
 
@@ -163,6 +261,7 @@ export const AnalysisPage = () => {
           forceDirectedImage: diagrams.forceDirected,
           hierarchicalImage: diagrams.hierarchical,
           activeFilters: activeFilterLabels,
+          nodeLimitNote,
         },
         { responseType: 'blob' }
       );

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -177,7 +177,7 @@ export const AnalysisPage = () => {
           conversationService.getHostClassifications(fileId).catch(() => undefined),
         ]);
         const graph = networkService.buildNetworkGraph(
-          convResponse.data, data ?? undefined, nodeLimit, hostClassifications
+          convResponse.data, data ?? undefined, 500, hostClassifications, nodeLimit
         );
 
         // Apply the same client-side filters the diagram tab would use.

--- a/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
+++ b/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
@@ -7,6 +7,7 @@ import {
   CONVERSATION_LIMIT_ENABLED,
   MAX_DIAGRAM_NODES,
 } from '@/features/network/hooks/useNetworkData';
+import { nodeFilterLabel } from '@/features/network/constants';
 import { NetworkGraph } from '@components/network/NetworkGraph';
 import { NetworkControls } from '@components/network/NetworkControls';
 import { NodeDetails } from '@components/network/NodeDetails';
@@ -355,7 +356,8 @@ export const NetworkDiagramPage = () => {
     if (hasRisksOnly) labels.push('Has Risks: Yes');
     if (activeLegendProtocols.length > 0)
       labels.push(`Protocol: ${activeLegendProtocols.join(', ')}`);
-    if (activeNodeFilters.length > 0) labels.push(`Node type: ${activeNodeFilters.join(', ')}`);
+    if (activeNodeFilters.length > 0)
+      labels.push(`Node type: ${activeNodeFilters.map(nodeFilterLabel).join(', ')}`);
     if (activeAppFilters.length > 0) labels.push(`App: ${activeAppFilters.join(', ')}`);
     if (activeL7Protocols.length > 0) labels.push(`L7: ${activeL7Protocols.join(', ')}`);
     if (activeCategories.length > 0) labels.push(`Category: ${activeCategories.join(', ')}`);
@@ -364,7 +366,11 @@ export const NetworkDiagramPage = () => {
       labels.push(`Custom signature: ${activeCustomSigs.join(', ')}`);
     if (activeFileTypes.length > 0) labels.push(`File type: ${activeFileTypes.join(', ')}`);
     if (activeCountries.length > 0) labels.push(`Country: ${activeCountries.join(', ')}`);
-    networkGraphStateRef.current = { filteredNodes, filteredEdges, activeFilterLabels: labels };
+    const nodeLimitNote =
+      hiddenNodes > 0
+        ? `Showing the ${nodeLimit} most significant nodes (${hiddenNodes} hidden). Ranked by traffic volume, risk signals, and connectivity.`
+        : null;
+    networkGraphStateRef.current = { filteredNodes, filteredEdges, activeFilterLabels: labels, nodeLimitNote };
   });
 
   if (loading) {


### PR DESCRIPTION
## Summary

- Active network diagram filters are now reflected in the PDF report — filter chips appear at the bottom of each topology diagram page, and the node-limit banner ("Showing the N most significant nodes (X hidden)…") is included when applicable
- Filters are applied even when the Network Diagram tab was never visited (fallback path fetches the graph and runs the same client-side filter logic)
- Internal `nt:`/`dt:` key prefixes are stripped and mapped to human-readable labels (e.g. `nt:router` → `Router / Gateway`, `dt:IOT` → `IoT Device`)
- Diagram page layout is fully absolute-positioned via `PdfContentByte` so the title, image, and footer never overlap — image height is fluid and derived from the exact measured heights of all footer elements via `PdfPTable.getTotalHeight()`

## Test plan

- [ ] Generate a report with no filters — diagram pages show only the disclaimer, no filter chips
- [ ] Generate a report with filters active — chips appear at the bottom of both diagram pages with correct human-readable labels
- [ ] Apply node limit (large PCAP) — "Showing the N most significant nodes" line appears above the disclaimer
- [ ] Apply many filters (4+ rows of chips) — image shrinks to fit, nothing overlaps
- [ ] Generate a report without visiting the Network Diagram tab — diagram still reflects active filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)