### PR TITLE
fix: LLM pre-flight health check and consistent error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE / Editor settings
+.vscode/settings.json
+
 # Environment files with secrets
 .env
 .env.local

--- a/backend/src/main/java/com/tracepcap/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tracepcap/common/exception/GlobalExceptionHandler.java
@@ -117,6 +117,7 @@ public class GlobalExceptionHandler {
             .error("Bad Gateway")
             .message(ex.getMessage())
             .path(request.getRequestURI())
+            .errorCode(ex.getErrorCode().name())
             .build();
 
     return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(error);

--- a/backend/src/main/java/com/tracepcap/common/exception/LlmException.java
+++ b/backend/src/main/java/com/tracepcap/common/exception/LlmException.java
@@ -3,11 +3,26 @@ package com.tracepcap.common.exception;
 /** Exception thrown when the LLM service is unreachable or returns an error */
 public class LlmException extends RuntimeException {
 
+  public enum ErrorCode { LLM_UNREACHABLE, LLM_TIMEOUT }
+
+  private final ErrorCode errorCode;
+
   public LlmException(String message) {
     super(message);
+    this.errorCode = ErrorCode.LLM_UNREACHABLE;
   }
 
   public LlmException(String message, Throwable cause) {
     super(message, cause);
+    this.errorCode = ErrorCode.LLM_UNREACHABLE;
+  }
+
+  public LlmException(String message, Throwable cause, ErrorCode errorCode) {
+    super(message, cause);
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
   }
 }

--- a/backend/src/main/java/com/tracepcap/config/LlmConfig.java
+++ b/backend/src/main/java/com/tracepcap/config/LlmConfig.java
@@ -42,4 +42,13 @@ public class LlmConfig {
     factory.setReadTimeout(timeoutMs);
     return new RestTemplate(factory);
   }
+
+  /** Short-timeout RestTemplate used only for the pre-flight reachability check. */
+  @Bean
+  public RestTemplate llmHealthCheckRestTemplate() {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(2_000);
+    factory.setReadTimeout(2_000);
+    return new RestTemplate(factory);
+  }
 }

--- a/backend/src/main/java/com/tracepcap/filter/service/FilterService.java
+++ b/backend/src/main/java/com/tracepcap/filter/service/FilterService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tracepcap.common.TsharkHexUtil;
+import com.tracepcap.common.exception.LlmException;
 import com.tracepcap.file.entity.FileEntity;
 import com.tracepcap.file.service.FileService;
 import com.tracepcap.file.service.StorageService;
@@ -186,6 +187,8 @@ public class FilterService {
                         + "Please respond with ONLY valid JSON in the exact format specified.",
                     naturalLanguageQuery);
           }
+        } catch (LlmException e) {
+          throw e;
         } catch (Exception e) {
           log.error("Error processing LLM response on attempt {}", attempt, e);
           lastValidationError = "Error processing LLM response: " + e.getMessage();
@@ -206,6 +209,8 @@ public class FilterService {
                 MAX_GENERATION_RETRIES, lastValidationError));
       }
 
+    } catch (LlmException e) {
+      throw e;
     } catch (Exception e) {
       log.error("Error generating filter", e);
       throw new RuntimeException("Failed to generate filter: " + e.getMessage(), e);

--- a/backend/src/main/java/com/tracepcap/story/service/LlmClient.java
+++ b/backend/src/main/java/com/tracepcap/story/service/LlmClient.java
@@ -9,7 +9,6 @@ import com.tracepcap.config.LlmConfig;
 import jakarta.annotation.PostConstruct;
 import java.util.List;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -18,11 +17,21 @@ import org.springframework.web.client.RestTemplate;
 /** Client for communicating with OpenAI-compatible LLM APIs */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class LlmClient {
 
   private final LlmConfig llmConfig;
   private final RestTemplate llmRestTemplate;
+  private final RestTemplate llmHealthCheckRestTemplate;
+
+  public LlmClient(
+      LlmConfig llmConfig,
+      RestTemplate llmRestTemplate,
+      RestTemplate llmHealthCheckRestTemplate) {
+    this.llmConfig = llmConfig;
+    this.llmRestTemplate = llmRestTemplate;
+    this.llmHealthCheckRestTemplate = llmHealthCheckRestTemplate;
+  }
+
   private static final Pattern PATTERN_PROMPT_TOKENS = Pattern.compile("\\((\\d+) in the messages");
   private static final Pattern PATTERN_CONTEXT_LENGTH = Pattern.compile("maximum context length is (\\d+)");
   private static final Pattern PATTERN_CONTEXT_LENGTH_ALT = Pattern.compile("context length is (\\d+)");
@@ -138,6 +147,26 @@ public class LlmClient {
     return null;
   }
 
+  /**
+   * Pre-flight reachability check using a short 2s timeout. Throws LLM_UNREACHABLE immediately
+   * if the LLM server cannot be reached, so the user gets a fast failure rather than waiting for
+   * the full generation timeout.
+   */
+  private void checkReachable() {
+    try {
+      String url = llmConfig.getApi().getBaseUrl() + "/models";
+      HttpHeaders headers = new HttpHeaders();
+      headers.setBearerAuth(llmConfig.getApi().getApiKey());
+      HttpEntity<Void> entity = new HttpEntity<>(headers);
+      llmHealthCheckRestTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+      log.debug("LLM health check passed");
+    } catch (Exception e) {
+      log.warn("LLM pre-flight health check failed: {}", e.getMessage());
+      throw new LlmException(
+          "LLM server is not reachable: " + e.getMessage(), e, LlmException.ErrorCode.LLM_UNREACHABLE);
+    }
+  }
+
   /** Get the effective max tokens (adjusted based on model capabilities) */
   public Integer getEffectiveMaxTokens() {
     return effectiveMaxTokens != null ? effectiveMaxTokens : llmConfig.getApi().getMaxTokens();
@@ -171,6 +200,11 @@ public class LlmClient {
         throw new ContextLengthExceededException(estimatedPromptTokens, modelContextLength, userPrompt);
       }
     }
+
+    // Pre-flight: fail fast with LLM_UNREACHABLE if the server isn't responding (2s timeout).
+    // This runs before the main generation call so users get an instant error instead of waiting
+    // for the full generation timeout.
+    checkReachable();
 
     try {
       log.info("Sending request to LLM API: {}", llmConfig.getApi().getBaseUrl());
@@ -246,10 +280,11 @@ public class LlmClient {
       } else {
         log.error("Error calling LLM API", e);
       }
-      // Distinguish connection failures from read/generation timeouts
+      // Distinguish read/generation timeouts from connection failures
       Throwable cause = e.getCause() != null ? e.getCause() : e;
+      String causeMsg = cause.getMessage() != null ? cause.getMessage() : "";
       boolean isReadTimeout = cause instanceof java.net.SocketTimeoutException
-          && cause.getMessage() != null && cause.getMessage().contains("Read timed out");
+          && causeMsg.contains("Read timed out");
       LlmException.ErrorCode code = isReadTimeout
           ? LlmException.ErrorCode.LLM_TIMEOUT
           : LlmException.ErrorCode.LLM_UNREACHABLE;

--- a/backend/src/main/java/com/tracepcap/story/service/LlmClient.java
+++ b/backend/src/main/java/com/tracepcap/story/service/LlmClient.java
@@ -246,7 +246,14 @@ public class LlmClient {
       } else {
         log.error("Error calling LLM API", e);
       }
-      throw new LlmException("Failed to reach the LLM service: " + e.getMessage(), e);
+      // Distinguish connection failures from read/generation timeouts
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      boolean isReadTimeout = cause instanceof java.net.SocketTimeoutException
+          && cause.getMessage() != null && cause.getMessage().contains("Read timed out");
+      LlmException.ErrorCode code = isReadTimeout
+          ? LlmException.ErrorCode.LLM_TIMEOUT
+          : LlmException.ErrorCode.LLM_UNREACHABLE;
+      throw new LlmException("Failed to reach the LLM service: " + e.getMessage(), e, code);
     }
   }
 

--- a/backend/src/main/java/com/tracepcap/tracer/controller/ConversationTracerController.java
+++ b/backend/src/main/java/com/tracepcap/tracer/controller/ConversationTracerController.java
@@ -35,6 +35,10 @@ public class ConversationTracerController {
       description = "Generates a plain-English explanation for each packet in the conversation using the configured LLM. Results are cached per conversation.")
   public ResponseEntity<TracerExplainResponse> explainSteps(@PathVariable UUID conversationId) {
     log.info("POST /api/tracer/{}/explain", conversationId);
-    return ResponseEntity.ok(tracerService.explainSteps(conversationId));
+    TracerExplainResponse response = tracerService.explainSteps(conversationId);
+    if (response.getError() != null) {
+      return ResponseEntity.status(503).body(response);
+    }
+    return ResponseEntity.ok(response);
   }
 }

--- a/backend/src/main/java/com/tracepcap/tracer/dto/TracerExplainResponse.java
+++ b/backend/src/main/java/com/tracepcap/tracer/dto/TracerExplainResponse.java
@@ -9,4 +9,6 @@ import lombok.Data;
 public class TracerExplainResponse {
   private String conversationId;
   private List<StepExplanation> explanations;
+  /** Non-null when the LLM was unreachable or returned an error. */
+  private String error;
 }

--- a/backend/src/main/java/com/tracepcap/tracer/service/ConversationTracerService.java
+++ b/backend/src/main/java/com/tracepcap/tracer/service/ConversationTracerService.java
@@ -104,10 +104,13 @@ public class ConversationTracerService {
       llmResponse = llmClient.generateCompletion(systemPrompt, userPrompt);
     } catch (LlmException e) {
       log.warn("LLM call failed for tracer {}: {}", conversationId, e.getMessage());
-      // Return empty explanations rather than failing the whole request
+      String errorMsg = e.getErrorCode() == com.tracepcap.common.exception.LlmException.ErrorCode.LLM_TIMEOUT
+          ? "AI explanation unavailable — the language model took too long to respond."
+          : "AI explanation unavailable — could not reach the language model. Check your LLM configuration.";
       return TracerExplainResponse.builder()
           .conversationId(conversationId.toString())
           .explanations(Collections.emptyList())
+          .error(errorMsg)
           .build();
     }
 
@@ -154,9 +157,34 @@ public class ConversationTracerService {
       if (p.getInfo() != null && !p.getInfo().isBlank()) {
         sb.append("  Info: ").append(p.getInfo()).append("\n");
       }
+      String ascii = extractAsciiPayload(p.getPayload());
+      if (!ascii.isEmpty()) {
+        sb.append("  Payload (ASCII): ").append(ascii).append("\n");
+      }
       sb.append("\n");
     }
     return sb.toString();
+  }
+
+  /**
+   * Converts up to the first 64 bytes of a hex payload string to a printable ASCII excerpt.
+   * Non-printable bytes are replaced with '.'. Returns empty string if payload is null/blank.
+   */
+  private String extractAsciiPayload(String hexPayload) {
+    if (hexPayload == null || hexPayload.isBlank()) return "";
+    // Strip any whitespace
+    String hex = hexPayload.replaceAll("\\s", "");
+    int byteLen = Math.min(hex.length() / 2, 64);
+    if (byteLen == 0) return "";
+    StringBuilder ascii = new StringBuilder(byteLen);
+    for (int i = 0; i < byteLen; i++) {
+      int b = Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+      ascii.append((b >= 0x20 && b < 0x7f) ? (char) b : '.');
+    }
+    // Only return if there's meaningful printable content (at least 4 consecutive printable chars)
+    String result = ascii.toString();
+    if (!result.matches(".*[\\x20-\\x7e]{4,}.*")) return "";
+    return result;
   }
 
   private List<StepExplanation> parseExplanations(String llmResponse, int packetCount) {

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,159 @@
+# Backend REST API Reference
+
+> **Status**: Initial inventory — audit and full request/response schemas to be added.
+> Tracked in [#226](https://github.com/NotYuSheng/TracePcap/issues/226).
+
+## Base URL
+
+All endpoints are prefixed with `/api`.
+
+---
+
+## Files — `/api/files`
+
+Controllers: `FileController`, `ReportController`, `SecurityAlertsController`, `HostClassificationsController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/files` | Upload a PCAP file (multipart/form-data) |
+| `GET` | `/api/files` | List all uploaded files |
+| `GET` | `/api/files/{fileId}` | Get metadata for a single file |
+| `GET` | `/api/files/{fileId}/download` | Download the raw PCAP file |
+| `DELETE` | `/api/files/{fileId}` | Delete a file |
+| `POST` | `/api/files/merge` | Merge multiple PCAP files |
+| `POST` | `/api/files/{fileId}/report` | Generate a report for a file |
+| `POST` | `/api/files/compare/report` | Generate a comparison report |
+| `GET` | `/api/files/{fileId}/security-alerts` | Get security alerts for a file |
+| `GET` | `/api/files/{fileId}/host-classifications` | Get host classifications for a file |
+
+---
+
+## Conversations — `/api/conversations`
+
+Controller: `ConversationsController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/conversations/{fileId}` | List conversations for a file (supports filters) |
+| `GET` | `/api/conversations/{fileId}/file-types` | Get distinct file types in conversations |
+| `GET` | `/api/conversations/{fileId}/risk-types` | Get distinct risk types |
+| `GET` | `/api/conversations/{fileId}/custom-signatures` | Get custom signature hits |
+| `GET` | `/api/conversations/{fileId}/countries` | Get countries involved in conversations |
+| `GET` | `/api/conversations/{fileId}/export` | Export conversations as CSV/JSON |
+| `GET` | `/api/conversations/{fileId}/export-pcap` | Export filtered conversations as PCAP |
+| `GET` | `/api/conversations/{conversationId}/session` | Get session data for a conversation |
+| `GET` | `/api/conversations/detail/{conversationId}` | Get full detail for a single conversation |
+| `GET` | `/api/conversations/detail/{conversationId}/export-pcap` | Export a single conversation as PCAP |
+
+---
+
+## Analysis — `/api/analysis`
+
+Controller: `AnalysisController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/analysis/{fileId}/summary` | Get analysis summary for a file |
+| `GET` | `/api/analysis/{fileId}/protocols` | Get protocol breakdown for a file |
+
+---
+
+## Timeline — `/api/timeline`
+
+Controller: `TimelineController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/timeline/{fileId}` | Get timeline events for a file |
+| `GET` | `/api/timeline/{fileId}/range` | Get timeline events within a time range |
+
+---
+
+## Extracted Files — `/api/files/{fileId}/extractions`
+
+Controller: `ExtractedFilesController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/files/{fileId}/extractions` | List extracted files from a PCAP |
+| `GET` | `/api/files/{fileId}/extractions/{extractionId}/download` | Download an extracted file |
+
+---
+
+## Signatures — `/api/signatures`
+
+Controller: `SignaturesController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/signatures` | List all signatures |
+| `GET` | `/api/signatures/rules` | Get signature rules |
+| `PUT` | `/api/signatures` | Update signatures |
+
+---
+
+## Story — `/api/story`
+
+Controller: `StoryController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/story/generate/{fileId}` | Generate an AI story for a file |
+| `GET` | `/api/story/{storyId}` | Get a story by ID |
+| `POST` | `/api/story/{storyId}/ask` | Ask a follow-up question on a story |
+| `GET` | `/api/story/file/{fileId}` | Get story for a file |
+
+---
+
+## Conversation Tracer — `/api/tracer`
+
+Controller: `ConversationTracerController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/tracer/{conversationId}/steps` | Get trace steps for a conversation |
+| `POST` | `/api/tracer/{conversationId}/explain` | Generate LLM explanation for a conversation |
+
+---
+
+## Network Intelligence — `/api/network/intelligence`
+
+Controller: `NetworkIntelligenceController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/network/intelligence/{fileId}/clusters` | Get network clusters for a file |
+| `GET` | `/api/network/intelligence/{fileId}/top-hosts` | Get top hosts by traffic volume |
+
+---
+
+## IP Org Rules — `/api/ip-org-rules`
+
+Controller: `IpOrgRuleController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/ip-org-rules` | List all IP-to-org mapping rules |
+| `POST` | `/api/ip-org-rules` | Create a new rule |
+| `DELETE` | `/api/ip-org-rules/{id}` | Delete a rule |
+
+---
+
+## Filter — `/api/filter`
+
+Controller: `FilterController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/filter/generate/{fileId}` | Generate a display filter for a file |
+| `POST` | `/api/filter/execute/{fileId}` | Execute a filter on a file |
+
+---
+
+## System — `/api/system`
+
+Controller: `SystemController`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/system/limits` | Get system resource limits |

--- a/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
+++ b/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
@@ -143,8 +143,9 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
         data.explanations.forEach(e => map.set(e.stepIndex, e.explanation));
         setExplanations(map);
       })
-      .catch(() => {
-        setExplainError('AI explanation unavailable — could not reach the language model. Check your LLM configuration.');
+      .catch((err) => {
+        const backendError = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+        setExplainError(backendError || 'AI explanation unavailable — could not reach the language model. Check your LLM configuration.');
       })
       .finally(() => setExplainLoading(false));
   }, [tracer, conversationId]);

--- a/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
+++ b/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
@@ -1,6 +1,41 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import { tracerService, type TracerStep, type TracerStepsResponse } from '@/features/tracer/tracerService';
 import { conversationService } from '@/features/conversation/services/conversationService';
+
+function AiExplanationInfoPopover() {
+  const popover = (
+    <Popover id="info-ai-explanation" style={{ maxWidth: '320px' }}>
+      <Popover.Header>AI Explanation — How it works</Popover.Header>
+      <Popover.Body className="small">
+        <p className="mb-2">
+          For each packet the LLM receives: direction, protocol, size, tshark's dissector info
+          string, and up to 64 bytes of payload decoded as ASCII (where readable).
+        </p>
+        <p className="mb-2">
+          <strong>Works well for:</strong> TCP handshakes, HTTP requests, DNS queries, TLS
+          handshake phases — where the info field or payload is descriptive.
+        </p>
+        <p className="mb-0">
+          <strong>Limited for:</strong> encrypted traffic (TLS data, RDP) where only size and
+          direction are available — explanations will be generic.
+        </p>
+      </Popover.Body>
+    </Popover>
+  );
+  return (
+    <OverlayTrigger trigger="click" placement="right" overlay={popover} rootClose>
+      <button
+        type="button"
+        className="btn btn-link p-0 text-muted"
+        style={{ lineHeight: 1, flexShrink: 0 }}
+        aria-label="About AI Explanation"
+      >
+        <i className="bi bi-info-circle" style={{ fontSize: '0.85rem' }}></i>
+      </button>
+    </OverlayTrigger>
+  );
+}
 
 interface ConversationTracerModalProps {
   conversationId: string;
@@ -46,6 +81,7 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
   const [isPlaying, setIsPlaying] = useState(false);
   const [explanations, setExplanations] = useState<Map<number, string>>(new Map());
   const [explainLoading, setExplainLoading] = useState(false);
+  const [explainError, setExplainError] = useState<string | null>(null);
 
   const [dotT, setDotT] = useState(0);
 
@@ -96,13 +132,20 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
   useEffect(() => {
     if (!tracer || tracer.steps.length === 0) return;
     setExplainLoading(true);
+    setExplainError(null);
     tracerService.explain(conversationId)
       .then(data => {
+        if (data.error) {
+          setExplainError(data.error);
+          return;
+        }
         const map = new Map<number, string>();
         data.explanations.forEach(e => map.set(e.stepIndex, e.explanation));
         setExplanations(map);
       })
-      .catch(console.error)
+      .catch(() => {
+        setExplainError('AI explanation unavailable — could not reach the language model. Check your LLM configuration.');
+      })
       .finally(() => setExplainLoading(false));
   }, [tracer, conversationId]);
 
@@ -324,27 +367,33 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
                 )}
 
                 {/* LLM explanation */}
-                <div
-                  style={{
-                    minHeight: 44,
-                    background: 'var(--tp-bg-subtle)',
-                    borderRadius: 6,
-                    padding: '6px 12px',
-                    fontSize: 12,
-                    color: 'var(--tp-text)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                  }}
-                >
-                  <i className="bi bi-stars" style={{ color: '#6c757d', flexShrink: 0 }} />
-                  {explainLoading && !explanations.has(currentStep) ? (
-                    <span className="text-muted">Generating AI explanation…</span>
-                  ) : explanations.has(currentStep) ? (
-                    <span>{explanations.get(currentStep)}</span>
-                  ) : (
-                    <span className="text-muted">No explanation available for this packet.</span>
-                  )}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <AiExplanationInfoPopover />
+                  <div
+                    style={{
+                      flex: 1,
+                      minHeight: 44,
+                      background: 'var(--tp-bg-subtle)',
+                      borderRadius: 6,
+                      padding: '6px 12px',
+                      fontSize: 12,
+                      color: 'var(--tp-text)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                    }}
+                  >
+                    <i className="bi bi-stars" style={{ color: '#6c757d', flexShrink: 0 }} />
+                    {explainLoading ? (
+                      <span className="text-muted">Generating AI explanation…</span>
+                    ) : explainError ? (
+                      <span style={{ color: 'var(--bs-danger)' }}>{explainError}</span>
+                    ) : explanations.has(currentStep) ? (
+                      <span>{explanations.get(currentStep)}</span>
+                    ) : (
+                      <span className="text-muted">No explanation available for this packet.</span>
+                    )}
+                  </div>
                 </div>
               </div>
 

--- a/frontend/src/features/filter/services/filterService.ts
+++ b/frontend/src/features/filter/services/filterService.ts
@@ -11,14 +11,15 @@ export const filterService = {
   /**
    * Generate a pcap filter from natural language query
    */
-  generateFilter: async (fileId: string, query: string): Promise<FilterGenerationResponse> => {
+  generateFilter: async (fileId: string, query: string, timeoutMs?: number): Promise<FilterGenerationResponse> => {
     const request: FilterGenerationRequest = {
       fileId,
       naturalLanguageQuery: query,
     };
     const response = await apiClient.post<FilterGenerationResponse>(
       API_ENDPOINTS.GENERATE_FILTER(fileId),
-      request
+      request,
+      { ...(timeoutMs !== undefined && { timeout: timeoutMs }) }
     );
     return response.data;
   },

--- a/frontend/src/features/filter/services/filterService.ts
+++ b/frontend/src/features/filter/services/filterService.ts
@@ -19,7 +19,7 @@ export const filterService = {
     const response = await apiClient.post<FilterGenerationResponse>(
       API_ENDPOINTS.GENERATE_FILTER(fileId),
       request,
-      { ...(timeoutMs !== undefined && { timeout: timeoutMs }) }
+      { ...(timeoutMs !== undefined && { timeout: timeoutMs + 10000 }) }
     );
     return response.data;
   },

--- a/frontend/src/features/story/services/storyService.ts
+++ b/frontend/src/features/story/services/storyService.ts
@@ -22,7 +22,7 @@ export const storyService = {
     const response = await apiClient.post<Story>(
       API_ENDPOINTS.GENERATE_STORY(fileId),
       Object.keys(body).length > 0 ? body : undefined,
-      { ...(timeoutMs !== undefined && { timeout: timeoutMs }) }
+      { ...(timeoutMs !== undefined && { timeout: timeoutMs + 10000 }) }
     );
     return response.data;
   },

--- a/frontend/src/features/tracer/tracerService.ts
+++ b/frontend/src/features/tracer/tracerService.ts
@@ -31,6 +31,7 @@ export interface StepExplanation {
 export interface TracerExplainResponse {
   conversationId: string;
   explanations: StepExplanation[];
+  error?: string;
 }
 
 export const tracerService = {

--- a/frontend/src/pages/FilterGenerator/FilterGeneratorPage.tsx
+++ b/frontend/src/pages/FilterGenerator/FilterGeneratorPage.tsx
@@ -104,15 +104,15 @@ export const FilterGeneratorPage = () => {
       const status = (err as { response?: { status?: number } })?.response?.status;
       const data = (err as { response?: { data?: Record<string, unknown> } })?.response?.data ?? {};
       const errorMsg = err instanceof Error ? err.message : String(err);
-      const isTimeout = (err as { code?: string })?.code === 'ECONNABORTED' || errorMsg.toLowerCase().includes('timeout');
-      if (isTimeout || data.errorCode === 'LLM_TIMEOUT') {
+      const isClientTimeout = (err as { code?: string })?.code === 'ECONNABORTED';
+      if (data.errorCode === 'LLM_UNREACHABLE' || status === 502 || status === 503) {
+        setError('The LLM server is not responding. Make sure the LLM service is running and reachable, then try again.');
+      } else if (data.errorCode === 'LLM_TIMEOUT' || isClientTimeout) {
         const totalSeconds = Math.round(llmTimeoutMs / 1000);
         const timeoutLabel = totalSeconds < 60
           ? `${totalSeconds} second${totalSeconds !== 1 ? 's' : ''}`
           : `${Math.round(totalSeconds / 60)} minute${Math.round(totalSeconds / 60) !== 1 ? 's' : ''}`;
         setError(`Filter generation timed out after ${timeoutLabel}. The LLM is responding but took too long — try again or simplify your query.`);
-      } else if (status === 502 || status === 503 || data.errorCode === 'LLM_UNREACHABLE') {
-        setError('The LLM server is not responding. Make sure the LLM service is running and reachable, then try again.');
       } else {
         setError(`Error: ${errorMsg || 'Failed to generate filter'}`);
       }

--- a/frontend/src/pages/FilterGenerator/FilterGeneratorPage.tsx
+++ b/frontend/src/pages/FilterGenerator/FilterGeneratorPage.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import type { AnalysisData, Packet } from '@/types';
+import { apiClient } from '@/services/api/client';
 import { filterService } from '@/features/filter/services/filterService';
 import { Pagination } from '@components/common/Pagination';
 
@@ -25,6 +26,13 @@ export const FilterGeneratorPage = () => {
   const [error, setError] = useState<string | null>(null);
   const [selectedPacket, setSelectedPacket] = useState<Packet | null>(null);
   const [showCheatSheet, setShowCheatSheet] = useState(false);
+  const [llmTimeoutMs, setLlmTimeoutMs] = useState<number>(300000);
+
+  useEffect(() => {
+    apiClient.get<{ llmTimeoutMs?: number }>('/system/limits')
+      .then(res => { if (res.data.llmTimeoutMs) setLlmTimeoutMs(res.data.llmTimeoutMs); })
+      .catch(() => { /* keep default */ });
+  }, []);
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -72,12 +80,12 @@ export const FilterGeneratorPage = () => {
     try {
       setGenerating(true);
       setError(null);
-      const result = await filterService.generateFilter(fileId, query);
+      const result = await filterService.generateFilter(fileId, query, llmTimeoutMs);
 
       // Validate the generated filter
       const validation = validateFilter(result.filter);
       if (!validation.valid) {
-        setError(`❌ Invalid Filter Generated: ${validation.message}`);
+        setError(`Invalid Filter Generated: ${validation.message}`);
         setGeneratedFilter('');
         setEditableFilter('');
         return;
@@ -93,22 +101,20 @@ export const FilterGeneratorPage = () => {
       setTotalMatches(0);
       setExecutionTime(null);
     } catch (err) {
-      // Provide helpful error message for common issues
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      const data = (err as { response?: { data?: Record<string, unknown> } })?.response?.data ?? {};
       const errorMsg = err instanceof Error ? err.message : String(err);
-      if (
-        errorMsg.includes('500') ||
-        errorMsg.includes('LLM') ||
-        errorMsg.includes('Failed to generate')
-      ) {
-        setError(
-          'The LLM server is not responding. Make sure the LLM service is running and reachable, then try again.'
-        );
-      } else if (errorMsg.includes('timeout') || errorMsg.includes('ECONNREFUSED')) {
-        setError(
-          'The LLM server is not responding. Make sure the LLM service is running and reachable, then try again.'
-        );
+      const isTimeout = (err as { code?: string })?.code === 'ECONNABORTED' || errorMsg.toLowerCase().includes('timeout');
+      if (isTimeout || data.errorCode === 'LLM_TIMEOUT') {
+        const totalSeconds = Math.round(llmTimeoutMs / 1000);
+        const timeoutLabel = totalSeconds < 60
+          ? `${totalSeconds} second${totalSeconds !== 1 ? 's' : ''}`
+          : `${Math.round(totalSeconds / 60)} minute${Math.round(totalSeconds / 60) !== 1 ? 's' : ''}`;
+        setError(`Filter generation timed out after ${timeoutLabel}. The LLM is responding but took too long — try again or simplify your query.`);
+      } else if (status === 502 || status === 503 || data.errorCode === 'LLM_UNREACHABLE') {
+        setError('The LLM server is not responding. Make sure the LLM service is running and reachable, then try again.');
       } else {
-        setError(`❌ Error: ${errorMsg || 'Failed to generate filter'}`);
+        setError(`Error: ${errorMsg || 'Failed to generate filter'}`);
       }
     } finally {
       setGenerating(false);
@@ -140,16 +146,16 @@ export const FilterGeneratorPage = () => {
         errorMsg.includes('parse filter')
       ) {
         setError(
-          `❌ Invalid BPF Syntax: The filter "${editableFilter}" is not valid BPF syntax. Common valid filters: "tcp port 80", "udp port 53", "host 192.168.1.1", "icmp". Check the BPF Cheat Sheet for help.`
+          `Invalid BPF Syntax: The filter "${editableFilter}" is not valid BPF syntax. Common valid filters: "tcp port 80", "udp port 53", "host 192.168.1.1", "icmp". Check the BPF Cheat Sheet for help.`
         );
       } else if (errorMsg.includes('500')) {
         setError(
-          '🔴 Server Error: The backend encountered an error while executing the filter. This might be due to invalid syntax or a server issue.'
+          'Server Error: The backend encountered an error while executing the filter. This might be due to invalid syntax or a server issue.'
         );
       } else if (errorMsg.includes('404')) {
-        setError('❌ File Not Found: The PCAP file could not be found. It may have been deleted.');
+        setError('File Not Found: The PCAP file could not be found. It may have been deleted.');
       } else {
-        setError(`❌ Execution Failed: ${errorMsg || 'Unknown error occurred'}`);
+        setError(`Execution Failed: ${errorMsg || 'Unknown error occurred'}`);
       }
     } finally {
       setExecuting(false);

--- a/frontend/src/pages/Story/StoryPage.tsx
+++ b/frontend/src/pages/Story/StoryPage.tsx
@@ -131,7 +131,7 @@ export const StoryPage = () => {
       const status = (err as { response?: { status?: number } })?.response?.status;
       const data = (err as { response?: { data?: Record<string, unknown> } })?.response?.data ?? {};
       const serverMsg: string = (data.message as string) ?? '';
-      const isTimeout = (err as { code?: string })?.code === 'ECONNABORTED' || msg.toLowerCase().includes('timeout');
+      const isClientTimeout = (err as { code?: string })?.code === 'ECONNABORTED';
       if (data.errorCode === 'CONTEXT_LENGTH_EXCEEDED') {
         setContextError({
           promptText: (data.promptText as string) ?? '',
@@ -139,17 +139,17 @@ export const StoryPage = () => {
           contextLength: (data.contextLength as number) ?? 0,
         });
         setEditablePrompt((data.promptText as string) ?? '');
-      } else if (isTimeout || data.errorCode === 'LLM_TIMEOUT') {
+      } else if (data.errorCode === 'LLM_UNREACHABLE' || status === 502) {
+        setError(
+          'The LLM server is not responding. Make sure the LLM service is running and reachable, then try again.'
+        );
+      } else if (data.errorCode === 'LLM_TIMEOUT' || isClientTimeout) {
         const totalSeconds = Math.round(llmTimeoutMs / 1000);
         const timeoutLabel = totalSeconds < 60
           ? `${totalSeconds} second${totalSeconds !== 1 ? 's' : ''}`
           : `${Math.round(totalSeconds / 60)} minute${Math.round(totalSeconds / 60) !== 1 ? 's' : ''}`;
         setError(
           `Story generation timed out after ${timeoutLabel}. The LLM is responding but took too long — try again or reduce the capture size.`
-        );
-      } else if (status === 502 || data.errorCode === 'LLM_UNREACHABLE') {
-        setError(
-          'The LLM server is not responding. Make sure the LLM service is running and reachable, then try again.'
         );
       } else {
         setError(serverMsg || msg || 'Failed to generate story');

--- a/frontend/src/pages/Story/StoryPage.tsx
+++ b/frontend/src/pages/Story/StoryPage.tsx
@@ -139,12 +139,15 @@ export const StoryPage = () => {
           contextLength: (data.contextLength as number) ?? 0,
         });
         setEditablePrompt((data.promptText as string) ?? '');
-      } else if (isTimeout) {
-        const minutes = Math.round(llmTimeoutMs / 60000);
+      } else if (isTimeout || data.errorCode === 'LLM_TIMEOUT') {
+        const totalSeconds = Math.round(llmTimeoutMs / 1000);
+        const timeoutLabel = totalSeconds < 60
+          ? `${totalSeconds} second${totalSeconds !== 1 ? 's' : ''}`
+          : `${Math.round(totalSeconds / 60)} minute${Math.round(totalSeconds / 60) !== 1 ? 's' : ''}`;
         setError(
-          `Story generation timed out after ${minutes} minute${minutes !== 1 ? 's' : ''}. The LLM is taking too long to respond. Try again or reduce the capture size.`
+          `Story generation timed out after ${timeoutLabel}. The LLM is responding but took too long — try again or reduce the capture size.`
         );
-      } else if (status === 502) {
+      } else if (status === 502 || data.errorCode === 'LLM_UNREACHABLE') {
         setError(
           'The LLM server is not responding. Make sure the LLM service is running and reachable, then try again.'
         );
@@ -219,7 +222,8 @@ export const StoryPage = () => {
     const seconds = elapsedSeconds % 60;
     const elapsed =
       minutes > 0 ? `${minutes}m ${seconds.toString().padStart(2, '0')}s` : `${seconds}s`;
-    const timeoutMinutes = Math.round(llmTimeoutMs / 60000);
+    const timeoutSec = Math.round(llmTimeoutMs / 1000);
+    const timeoutLabel = timeoutSec < 60 ? `${timeoutSec}s` : `${Math.round(timeoutSec / 60)} min`;
     return (
       <div className="text-center py-5">
         <LoadingSpinner
@@ -230,7 +234,7 @@ export const StoryPage = () => {
           AI is analyzing the network traffic and creating a comprehensive narrative...
         </p>
         <p className="text-muted small mt-1">
-          Elapsed: <strong>{elapsed}</strong> &nbsp;|&nbsp; Timeout: {timeoutMinutes} min
+          Elapsed: <strong>{elapsed}</strong> &nbsp;|&nbsp; Timeout: {timeoutLabel}
         </p>
       </div>
     );
@@ -342,6 +346,18 @@ export const StoryPage = () => {
           </div>
         </div>
       </div>
+
+      {/* Regeneration error banner */}
+      {error && (
+        <div className="row mb-3">
+          <div className="col-12">
+            <div className="alert alert-danger py-2 mb-0" role="alert">
+              <i className="bi bi-exclamation-triangle-fill me-2"></i>
+              {error}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* How stories are generated */}
       <div className="row mb-4">


### PR DESCRIPTION
Closes #220

## Summary

- **Pre-flight health check**: Before every LLM generation call, a 2-second `GET /v1/models` request is made using a dedicated short-timeout `RestTemplate`. If the server is unreachable, users get an immediate `LLM_UNREACHABLE` error (~2s) instead of waiting for the full generation timeout.
- **Distinct error states**: `LLM_UNREACHABLE` (server down/not responding) vs `LLM_TIMEOUT` (server responded but generation was too slow) are now surfaced as distinct, user-friendly messages across all three LLM-powered features: Story, Filter Generator, and Tracer AI explanation.
- **Consistent timeout config**: Filter Generator now fetches `llmTimeoutMs` from `/system/limits` (same as Story page), and passes it to the service. Axios gets a +10s buffer over the backend timeout so the backend always responds first.
- **Display fix**: Timeout labels use seconds when < 60s to avoid showing "0 minutes".

## Changes

- \`LlmConfig.java\` — new \`llmHealthCheckRestTemplate\` bean (2s connect/read timeout)
- \`LlmClient.java\` — inject health check template; add \`checkReachable()\` called at start of \`generateCompletion()\`
- \`FilterGeneratorPage.tsx\` — fetch \`llmTimeoutMs\` from \`/system/limits\`; prioritise \`data.errorCode\` over axios \`ECONNABORTED\`; remove emoji prefixes from error messages
- \`StoryPage.tsx\` — reorder error checks (\`LLM_UNREACHABLE\` before \`LLM_TIMEOUT\`); show regeneration error banner when story already exists; seconds label for short timeouts
- \`filterService.ts\` / \`storyService.ts\` — axios timeout buffer (+10s)

## Test plan

- [ ] LLM server stopped → all three features show "server not responding" message within ~2 seconds
- [ ] LLM server running but slow → generation timeout shows "took too long" message
- [ ] Normal generation succeeds for Story, Filter Generator, and Tracer AI explanation
- [ ] Regenerating a story when one already exists and LLM fails shows error banner (not silent failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)