### PR TITLE
feat: full conversation filters in Network Intelligence

### DIFF
--- a/backend/src/main/java/com/tracepcap/intelligence/controller/NetworkIntelligenceController.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/controller/NetworkIntelligenceController.java
@@ -7,15 +7,19 @@ import com.tracepcap.intelligence.service.NetworkIntelligenceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
+@Validated
 @RestController
 @RequestMapping("/api/network/intelligence")
 @RequiredArgsConstructor
@@ -32,7 +36,7 @@ public class NetworkIntelligenceController {
       @PathVariable UUID fileId,
       @RequestParam(defaultValue = "asn") String groupBy,
       @Parameter(description = "Filter by IP address or hostname") @RequestParam(required = false) String ip,
-      @Parameter(description = "Filter by port number (src or dst)") @RequestParam(required = false) Integer port,
+      @Parameter(description = "Filter by port number (src or dst)") @RequestParam(required = false) @Min(0) @Max(65535) Integer port,
       @Parameter(description = "Comma-separated L4 protocols") @RequestParam(required = false) String protocols,
       @Parameter(description = "Comma-separated L7 protocols") @RequestParam(required = false) String l7Protocols,
       @Parameter(description = "Comma-separated application names") @RequestParam(required = false) String apps,

--- a/backend/src/main/java/com/tracepcap/intelligence/controller/NetworkIntelligenceController.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/controller/NetworkIntelligenceController.java
@@ -1,10 +1,14 @@
 package com.tracepcap.intelligence.controller;
 
+import com.tracepcap.analysis.dto.ConversationFilterParams;
 import com.tracepcap.intelligence.dto.ClusterGraphResponse;
 import com.tracepcap.intelligence.dto.TopHostsResponse;
 import com.tracepcap.intelligence.service.NetworkIntelligenceService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,14 +27,47 @@ public class NetworkIntelligenceController {
   @GetMapping("/{fileId}/clusters")
   @Operation(
       summary = "Get clustered network topology",
-      description = "Returns network hosts grouped into clusters by ASN, country, subnet, or device type. Suitable for large PCAPs with 10,000+ hosts.")
+      description = "Returns network hosts grouped into clusters by ASN, country, subnet, or device type. Supports the same conversation filters as the conversations endpoint to pre-filter traffic before clustering.")
   public ResponseEntity<ClusterGraphResponse> getClusters(
       @PathVariable UUID fileId,
-      @RequestParam(defaultValue = "asn") String groupBy) {
+      @RequestParam(defaultValue = "asn") String groupBy,
+      @Parameter(description = "Filter by IP address or hostname") @RequestParam(required = false) String ip,
+      @Parameter(description = "Filter by port number (src or dst)") @RequestParam(required = false) Integer port,
+      @Parameter(description = "Comma-separated L4 protocols") @RequestParam(required = false) String protocols,
+      @Parameter(description = "Comma-separated L7 protocols") @RequestParam(required = false) String l7Protocols,
+      @Parameter(description = "Comma-separated application names") @RequestParam(required = false) String apps,
+      @Parameter(description = "Comma-separated categories") @RequestParam(required = false) String categories,
+      @Parameter(description = "Only conversations with flow risks") @RequestParam(required = false) Boolean hasRisks,
+      @Parameter(description = "Comma-separated detected file types") @RequestParam(required = false) String fileTypes,
+      @Parameter(description = "Comma-separated nDPI risk types") @RequestParam(required = false) String riskTypes,
+      @Parameter(description = "Comma-separated custom signature rule names") @RequestParam(required = false) String customSignatures,
+      @Parameter(description = "Comma-separated device types") @RequestParam(required = false) String deviceTypes,
+      @Parameter(description = "Comma-separated ISO 3166-1 alpha-2 country codes") @RequestParam(required = false) String countries) {
 
     log.info("GET /api/network/intelligence/{}/clusters?groupBy={}", fileId, groupBy);
-    ClusterGraphResponse response = intelligenceService.computeClusters(fileId, groupBy);
+
+    ConversationFilterParams filterParams = ConversationFilterParams.builder()
+        .ip(ip)
+        .port(port)
+        .protocols(splitComma(protocols))
+        .l7Protocols(splitComma(l7Protocols))
+        .apps(splitComma(apps))
+        .categories(splitComma(categories))
+        .hasRisks(hasRisks)
+        .fileTypes(splitComma(fileTypes))
+        .riskTypes(splitComma(riskTypes))
+        .customSignatures(splitComma(customSignatures))
+        .deviceTypes(splitComma(deviceTypes))
+        .countries(splitComma(countries))
+        .build();
+
+    ClusterGraphResponse response = intelligenceService.computeClusters(fileId, groupBy, filterParams);
     return ResponseEntity.ok(response);
+  }
+
+  private static List<String> splitComma(String value) {
+    if (value == null || value.isBlank()) return List.of();
+    return Arrays.stream(value.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList();
   }
 
   @GetMapping("/{fileId}/top-hosts")

--- a/backend/src/main/java/com/tracepcap/intelligence/controller/NetworkIntelligenceController.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/controller/NetworkIntelligenceController.java
@@ -42,7 +42,8 @@ public class NetworkIntelligenceController {
       @Parameter(description = "Comma-separated nDPI risk types") @RequestParam(required = false) String riskTypes,
       @Parameter(description = "Comma-separated custom signature rule names") @RequestParam(required = false) String customSignatures,
       @Parameter(description = "Comma-separated device types") @RequestParam(required = false) String deviceTypes,
-      @Parameter(description = "Comma-separated ISO 3166-1 alpha-2 country codes") @RequestParam(required = false) String countries) {
+      @Parameter(description = "Comma-separated ISO 3166-1 alpha-2 country codes") @RequestParam(required = false) String countries,
+      @Parameter(description = "Comma-separated network label names (e.g. 'Office,DMZ')") @RequestParam(required = false) String networkLabels) {
 
     log.info("GET /api/network/intelligence/{}/clusters?groupBy={}", fileId, groupBy);
 
@@ -61,7 +62,7 @@ public class NetworkIntelligenceController {
         .countries(splitComma(countries))
         .build();
 
-    ClusterGraphResponse response = intelligenceService.computeClusters(fileId, groupBy, filterParams);
+    ClusterGraphResponse response = intelligenceService.computeClusters(fileId, groupBy, filterParams, splitComma(networkLabels));
     return ResponseEntity.ok(response);
   }
 

--- a/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
@@ -39,11 +39,38 @@ public class NetworkIntelligenceService {
 
   // ── Public API ────────────────────────────────────────────────────────────
 
-  public ClusterGraphResponse computeClusters(UUID fileId, String groupBy, ConversationFilterParams filterParams) {
+  public ClusterGraphResponse computeClusters(UUID fileId, String groupBy, ConversationFilterParams filterParams, List<String> networkLabels) {
     log.info("Computing {} clusters for file {}", groupBy, fileId);
     List<ConversationEntity> conversations = (filterParams != null && hasActiveFilters(filterParams))
         ? conversationRepository.findAll(ConversationRepository.buildSpec(fileId, filterParams))
         : conversationRepository.findByFileId(fileId);
+
+    // Network label filter: keep only IPs that fall within any CIDR belonging to the
+    // selected labels. A conversation is kept if BOTH endpoints are labelled IPs, or if
+    // one endpoint is a labelled IP (to show what the segment talks to). The cluster-node
+    // post-filter below then removes any cluster whose IPs are all outside the label CIDRs,
+    // so only nodes containing at least one labelled IP remain in the graph.
+    Set<String> labelledIps = new HashSet<>();
+    List<IpOrgRuleEntity> netLabelRules = List.of();
+    if (networkLabels != null && !networkLabels.isEmpty()) {
+      List<IpOrgRuleEntity> allRules = ipOrgRuleService.loadRules();
+      netLabelRules = allRules.stream()
+          .filter(r -> networkLabels.contains(r.getLabel()))
+          .collect(Collectors.toList());
+      if (!netLabelRules.isEmpty()) {
+        final List<IpOrgRuleEntity> rules = netLabelRules;
+        conversations = conversations.stream()
+            .filter(c ->
+                ipOrgRuleService.matchIp(c.getSrcIp(), rules) != null ||
+                ipOrgRuleService.matchIp(c.getDstIp(), rules) != null)
+            .collect(Collectors.toList());
+        // Track which IPs are actually inside a label CIDR
+        for (ConversationEntity c : conversations) {
+          if (ipOrgRuleService.matchIp(c.getSrcIp(), rules) != null) labelledIps.add(c.getSrcIp());
+          if (ipOrgRuleService.matchIp(c.getDstIp(), rules) != null) labelledIps.add(c.getDstIp());
+        }
+      }
+    }
 
     Set<String> allIps = new HashSet<>();
     for (ConversationEntity c : conversations) {
@@ -217,6 +244,14 @@ public class NetworkIntelligenceService {
               .build();
         })
         .collect(Collectors.toList());
+
+    // If a network label filter is active, remove cluster nodes that contain no labelled IPs
+    if (!labelledIps.isEmpty()) {
+      clusterDtos = clusterDtos.stream()
+          .filter(dto -> dto.getSampleIps().stream().anyMatch(labelledIps::contains)
+              || dto.getIpBytes().keySet().stream().anyMatch(labelledIps::contains))
+          .collect(Collectors.toList());
+    }
 
     // Prune to top maxClusters by traffic to keep rendering manageable
     int totalClusters = clusterDtos.size();

--- a/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
@@ -369,6 +369,7 @@ public class NetworkIntelligenceService {
         || (p.getFileTypes() != null && !p.getFileTypes().isEmpty())
         || (p.getRiskTypes() != null && !p.getRiskTypes().isEmpty())
         || (p.getCustomSignatures() != null && !p.getCustomSignatures().isEmpty())
+        || (p.getPayloadContains() != null && !p.getPayloadContains().isBlank())
         || (p.getDeviceTypes() != null && !p.getDeviceTypes().isEmpty())
         || (p.getCountries() != null && !p.getCountries().isEmpty());
   }

--- a/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
@@ -1,5 +1,6 @@
 package com.tracepcap.intelligence.service;
 
+import com.tracepcap.analysis.dto.ConversationFilterParams;
 import com.tracepcap.analysis.entity.ConversationEntity;
 import com.tracepcap.analysis.entity.HostClassificationEntity;
 import com.tracepcap.analysis.entity.IpGeoInfoEntity;
@@ -38,9 +39,11 @@ public class NetworkIntelligenceService {
 
   // ── Public API ────────────────────────────────────────────────────────────
 
-  public ClusterGraphResponse computeClusters(UUID fileId, String groupBy) {
+  public ClusterGraphResponse computeClusters(UUID fileId, String groupBy, ConversationFilterParams filterParams) {
     log.info("Computing {} clusters for file {}", groupBy, fileId);
-    List<ConversationEntity> conversations = conversationRepository.findByFileId(fileId);
+    List<ConversationEntity> conversations = (filterParams != null && hasActiveFilters(filterParams))
+        ? conversationRepository.findAll(ConversationRepository.buildSpec(fileId, filterParams))
+        : conversationRepository.findByFileId(fileId);
 
     Set<String> allIps = new HashSet<>();
     for (ConversationEntity c : conversations) {
@@ -316,6 +319,23 @@ public class NetworkIntelligenceService {
         .collect(Collectors.toList());
 
     return TopHostsResponse.builder().hosts(hosts).build();
+  }
+
+  // ── Filter helpers ────────────────────────────────────────────────────────
+
+  private boolean hasActiveFilters(ConversationFilterParams p) {
+    return (p.getIp() != null && !p.getIp().isBlank())
+        || p.getPort() != null
+        || (p.getProtocols() != null && !p.getProtocols().isEmpty())
+        || (p.getL7Protocols() != null && !p.getL7Protocols().isEmpty())
+        || (p.getApps() != null && !p.getApps().isEmpty())
+        || (p.getCategories() != null && !p.getCategories().isEmpty())
+        || Boolean.TRUE.equals(p.getHasRisks())
+        || (p.getFileTypes() != null && !p.getFileTypes().isEmpty())
+        || (p.getRiskTypes() != null && !p.getRiskTypes().isEmpty())
+        || (p.getCustomSignatures() != null && !p.getCustomSignatures().isEmpty())
+        || (p.getDeviceTypes() != null && !p.getDeviceTypes().isEmpty())
+        || (p.getCountries() != null && !p.getCountries().isEmpty());
   }
 
   // ── Clustering logic ──────────────────────────────────────────────────────

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -85,6 +85,10 @@ interface NetworkControlsProps {
   onHasRisksOnlyChange: (val: boolean) => void;
   activeFilterCount: number;
   onClearAllFilters: () => void;
+  activeNetLabels?: string[];
+  onNetLabelClick?: (label: string) => void;
+  onNetLabelClear?: () => void;
+  presentNetLabels?: string[];
   /** Whether the panel starts collapsed. Defaults to false (expanded). */
   defaultCollapsed?: boolean;
 }
@@ -155,6 +159,10 @@ export function NetworkControls({
   onHasRisksOnlyChange,
   activeFilterCount,
   onClearAllFilters,
+  activeNetLabels = [],
+  onNetLabelClick,
+  onNetLabelClear,
+  presentNetLabels = [],
   defaultCollapsed = false,
 }: NetworkControlsProps) {
   const [isOpen, setIsOpen] = useState(!defaultCollapsed);
@@ -703,6 +711,47 @@ export function NetworkControls({
                             onClick={() => onFileTypeClick(ft)}
                           >
                             {ft}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Network Labels */}
+                {presentNetLabels.length > 0 && onNetLabelClick && (
+                  <div className="col-12">
+                    <PillSectionHeader
+                      label="Network Labels"
+                      info={
+                        <InfoPopover
+                          id="nc-info-netlabels"
+                          title="Network Labels"
+                          body="Filter by your defined network segments (e.g. Office, DMZ). Only conversations where at least one endpoint falls within a labelled CIDR range are shown."
+                        />
+                      }
+                      onSelectAll={() =>
+                        presentNetLabels.forEach(l => {
+                          if (!activeNetLabels.includes(l)) onNetLabelClick(l);
+                        })
+                      }
+                      onDeselectAll={onNetLabelClear ?? (() => {})}
+                    />
+                    <div className="d-flex flex-wrap gap-1 mt-1">
+                      {presentNetLabels.map(label => {
+                        const isActive = activeNetLabels.includes(label);
+                        return (
+                          <button
+                            key={label}
+                            type="button"
+                            className={filterPillClass(isActive)}
+                            style={
+                              isActive ? { backgroundColor: '#198754', color: '#fff' } : undefined
+                            }
+                            onClick={() => onNetLabelClick(label)}
+                          >
+                            <i className="bi bi-tag me-1" />
+                            {label}
                           </button>
                         );
                       })}

--- a/frontend/src/features/intelligence/services/intelligenceService.ts
+++ b/frontend/src/features/intelligence/services/intelligenceService.ts
@@ -17,6 +17,7 @@ export interface IntelClusterFilters {
   customSignatures?: string[];
   deviceTypes?: string[];
   countries?: string[];
+  networkLabels?: string[];
 }
 
 export interface ClusterNode {
@@ -89,6 +90,7 @@ export const intelligenceService = {
       if (filters.customSignatures?.length) params.set('customSignatures', filters.customSignatures.join(','));
       if (filters.deviceTypes?.length) params.set('deviceTypes', filters.deviceTypes.join(','));
       if (filters.countries?.length) params.set('countries', filters.countries.join(','));
+      if (filters.networkLabels?.length) params.set('networkLabels', filters.networkLabels.join(','));
     }
     const res = await apiClient.get<ClusterGraphResponse>(
       `/network/intelligence/${fileId}/clusters?${params.toString()}`

--- a/frontend/src/features/intelligence/services/intelligenceService.ts
+++ b/frontend/src/features/intelligence/services/intelligenceService.ts
@@ -4,6 +4,21 @@ import { API_ENDPOINTS } from '@/services/api/endpoints';
 export type GroupBy = 'asn' | 'country' | 'city' | 'subnet24' | 'subnet16' | 'deviceType' | 'customOrg';
 export type SortBy = 'bytes' | 'packets' | 'conversations' | 'risks';
 
+export interface IntelClusterFilters {
+  ip?: string;
+  port?: string;
+  protocols?: string[];
+  l7Protocols?: string[];
+  apps?: string[];
+  categories?: string[];
+  hasRisks?: boolean;
+  fileTypes?: string[];
+  riskTypes?: string[];
+  customSignatures?: string[];
+  deviceTypes?: string[];
+  countries?: string[];
+}
+
 export interface ClusterNode {
   id: string;
   label: string;
@@ -59,9 +74,24 @@ export interface TopHostsResponse {
 }
 
 export const intelligenceService = {
-  async getClusters(fileId: string, groupBy: GroupBy): Promise<ClusterGraphResponse> {
+  async getClusters(fileId: string, groupBy: GroupBy, filters?: IntelClusterFilters): Promise<ClusterGraphResponse> {
+    const params = new URLSearchParams({ groupBy });
+    if (filters) {
+      if (filters.ip) params.set('ip', filters.ip);
+      if (filters.port) params.set('port', filters.port);
+      if (filters.protocols?.length) params.set('protocols', filters.protocols.join(','));
+      if (filters.l7Protocols?.length) params.set('l7Protocols', filters.l7Protocols.join(','));
+      if (filters.apps?.length) params.set('apps', filters.apps.join(','));
+      if (filters.categories?.length) params.set('categories', filters.categories.join(','));
+      if (filters.hasRisks) params.set('hasRisks', 'true');
+      if (filters.fileTypes?.length) params.set('fileTypes', filters.fileTypes.join(','));
+      if (filters.riskTypes?.length) params.set('riskTypes', filters.riskTypes.join(','));
+      if (filters.customSignatures?.length) params.set('customSignatures', filters.customSignatures.join(','));
+      if (filters.deviceTypes?.length) params.set('deviceTypes', filters.deviceTypes.join(','));
+      if (filters.countries?.length) params.set('countries', filters.countries.join(','));
+    }
     const res = await apiClient.get<ClusterGraphResponse>(
-      API_ENDPOINTS.NETWORK_INTELLIGENCE_CLUSTERS(fileId, groupBy)
+      `/network/intelligence/${fileId}/clusters?${params.toString()}`
     );
     return res.data;
   },

--- a/frontend/src/features/intelligence/services/intelligenceService.ts
+++ b/frontend/src/features/intelligence/services/intelligenceService.ts
@@ -76,7 +76,9 @@ export interface TopHostsResponse {
 
 export const intelligenceService = {
   async getClusters(fileId: string, groupBy: GroupBy, filters?: IntelClusterFilters): Promise<ClusterGraphResponse> {
-    const params = new URLSearchParams({ groupBy });
+    // Start from the canonical endpoint (includes ?groupBy=X) and append extra filter params
+    const base = API_ENDPOINTS.NETWORK_INTELLIGENCE_CLUSTERS(fileId, groupBy);
+    const params = new URLSearchParams();
     if (filters) {
       if (filters.ip) params.set('ip', filters.ip);
       if (filters.port) params.set('port', filters.port);
@@ -92,9 +94,8 @@ export const intelligenceService = {
       if (filters.countries?.length) params.set('countries', filters.countries.join(','));
       if (filters.networkLabels?.length) params.set('networkLabels', filters.networkLabels.join(','));
     }
-    const res = await apiClient.get<ClusterGraphResponse>(
-      `/network/intelligence/${fileId}/clusters?${params.toString()}`
-    );
+    const qs = params.toString();
+    const res = await apiClient.get<ClusterGraphResponse>(qs ? `${base}&${qs}` : base);
     return res.data;
   },
 

--- a/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
+++ b/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
@@ -8,6 +8,7 @@ import {
   type IntelClusterFilters,
 } from '@/features/intelligence/services/intelligenceService';
 import { conversationService } from '@/features/conversation/services/conversationService';
+import { ipOrgRuleService } from '@/features/intelligence/services/ipOrgRuleService';
 import { SummaryStatsBar } from '@components/intelligence/SummaryStatsBar/SummaryStatsBar';
 import { ClusterGraph } from '@components/intelligence/ClusterGraph/ClusterGraph';
 import { NetworkControls } from '@components/network/NetworkControls';
@@ -43,6 +44,7 @@ export const NetworkIntelligencePage = () => {
   const [activeCustomSigs, setActiveCustomSigs] = useState<string[]>([]);
   const [activeFileTypes, setActiveFileTypes] = useState<string[]>([]);
   const [activeCountries, setActiveCountries] = useState<string[]>([]);
+  const [activeNetLabels, setActiveNetLabels] = useState<string[]>([]);
 
   // ── Present-value state (loaded from API) ─────────────────────────────────
   const [presentRiskTypes, setPresentRiskTypes] = useState<string[]>([]);
@@ -50,6 +52,7 @@ export const NetworkIntelligencePage = () => {
   const [presentCustomSigs, setPresentCustomSigs] = useState<string[]>([]);
   const [presentCountries, setPresentCountries] = useState<string[]>([]);
   const [presentDeviceTypes, setPresentDeviceTypes] = useState<Set<string>>(new Set());
+  const [presentNetLabels, setPresentNetLabels] = useState<string[]>([]);
 
   useEffect(() => {
     if (!fileId) return;
@@ -63,6 +66,10 @@ export const NetworkIntelligencePage = () => {
     conversationService.getHostClassifications(fileId).then(hosts => {
       const types = new Set(hosts.map(h => h.deviceType).filter(Boolean) as string[]);
       setPresentDeviceTypes(types);
+    }).catch(() => {});
+    ipOrgRuleService.list().then(rules => {
+      const labels = [...new Set(rules.map(r => r.label))].sort();
+      setPresentNetLabels(labels);
     }).catch(() => {});
   }, [fileId]);
 
@@ -106,6 +113,7 @@ export const NetworkIntelligencePage = () => {
   const toggleCustomSig = toggleSet(setActiveCustomSigs);
   const toggleFileType = toggleSet(setActiveFileTypes);
   const toggleCountry = toggleSet(setActiveCountries);
+  const toggleNetLabel = toggleSet(setActiveNetLabels);
 
   const clearAllFilters = () => {
     setActiveLegendProtocols([]);
@@ -119,6 +127,7 @@ export const NetworkIntelligencePage = () => {
     setActiveCustomSigs([]);
     setActiveFileTypes([]);
     setActiveCountries([]);
+    setActiveNetLabels([]);
     setHasRisksOnly(false);
   };
 
@@ -134,7 +143,8 @@ export const NetworkIntelligencePage = () => {
     activeCountries.length +
     (ipFilter ? 1 : 0) +
     (portFilter ? 1 : 0) +
-    (hasRisksOnly ? 1 : 0);
+    (hasRisksOnly ? 1 : 0) +
+    activeNetLabels.length;
 
   // ── Build IntelClusterFilters from active filter state ────────────────────
   const intelFilters = useMemo((): IntelClusterFilters => {
@@ -161,12 +171,13 @@ export const NetworkIntelligencePage = () => {
       customSignatures: activeCustomSigs.length ? activeCustomSigs : undefined,
       deviceTypes: deviceTypes.length ? deviceTypes : undefined,
       countries: activeCountries.length ? activeCountries : undefined,
+      networkLabels: activeNetLabels.length ? activeNetLabels : undefined,
     };
   }, [
     ipFilter, portFilter, hasRisksOnly,
     activeLegendProtocols, activeNodeFilters,
     activeAppFilters, activeL7Protocols, activeCategories,
-    activeRiskTypes, activeCustomSigs, activeFileTypes, activeCountries,
+    activeRiskTypes, activeCustomSigs, activeFileTypes, activeCountries, activeNetLabels,
   ]);
 
   useEffect(() => {
@@ -274,6 +285,10 @@ export const NetworkIntelligencePage = () => {
           activeFilterCount={activeFilterCount}
           onClearAllFilters={clearAllFilters}
           defaultCollapsed={true}
+          activeNetLabels={activeNetLabels}
+          onNetLabelClick={toggleNetLabel}
+          onNetLabelClear={() => setActiveNetLabels([])}
+          presentNetLabels={presentNetLabels}
         />
       </div>
 

--- a/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
+++ b/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
@@ -56,21 +56,20 @@ export const NetworkIntelligencePage = () => {
 
   useEffect(() => {
     if (!fileId) return;
-    conversationService.getRiskTypes(fileId).then(setPresentRiskTypes).catch(() => {});
-    conversationService.getFileTypes(fileId).then(setPresentFileTypes).catch(() => {});
-    conversationService.getCustomSignatures(fileId).then(setPresentCustomSigs).catch(() => {});
+    let active = true;
+    conversationService.getRiskTypes(fileId).then(v => { if (active) setPresentRiskTypes(v); }).catch(() => {});
+    conversationService.getFileTypes(fileId).then(v => { if (active) setPresentFileTypes(v); }).catch(() => {});
+    conversationService.getCustomSignatures(fileId).then(v => { if (active) setPresentCustomSigs(v); }).catch(() => {});
     conversationService.getCountries(fileId).then(codes => {
-      // Countries come back as "CC|CountryName" strings — extract just the code
-      setPresentCountries(codes.map(c => c.split('|')[0]).filter(Boolean).sort());
+      if (active) setPresentCountries(codes.map(c => c.split('|')[0]).filter(Boolean).sort());
     }).catch(() => {});
     conversationService.getHostClassifications(fileId).then(hosts => {
-      const types = new Set(hosts.map(h => h.deviceType).filter(Boolean) as string[]);
-      setPresentDeviceTypes(types);
+      if (active) setPresentDeviceTypes(new Set(hosts.map(h => h.deviceType).filter(Boolean) as string[]));
     }).catch(() => {});
     ipOrgRuleService.list().then(rules => {
-      const labels = [...new Set(rules.map(r => r.label))].sort();
-      setPresentNetLabels(labels);
+      if (active) setPresentNetLabels([...new Set(rules.map(r => r.label))].sort());
     }).catch(() => {});
+    return () => { active = false; };
   }, [fileId]);
 
   // ── Derive present-values from AnalysisData ───────────────────────────────
@@ -148,11 +147,6 @@ export const NetworkIntelligencePage = () => {
 
   // ── Build IntelClusterFilters from active filter state ────────────────────
   const intelFilters = useMemo((): IntelClusterFilters => {
-    // Map activeLegendProtocols (edge legend keys like TCP/UDP/ICMP) → protocols param
-    const protocols = activeLegendProtocols.filter(k =>
-      ['TCP', 'UDP', 'ICMP', 'ARP'].includes(k),
-    );
-
     // Map activeNodeFilters (dt:MOBILE etc.) → deviceTypes param
     const deviceTypes = activeNodeFilters
       .filter(k => k.startsWith('dt:'))
@@ -161,7 +155,7 @@ export const NetworkIntelligencePage = () => {
     return {
       ip: ipFilter || undefined,
       port: portFilter || undefined,
-      protocols: protocols.length ? protocols : undefined,
+      protocols: activeLegendProtocols.length ? activeLegendProtocols : undefined,
       l7Protocols: activeL7Protocols.length ? activeL7Protocols : undefined,
       apps: activeAppFilters.length ? activeAppFilters : undefined,
       categories: activeCategories.length ? activeCategories : undefined,
@@ -202,12 +196,14 @@ export const NetworkIntelligencePage = () => {
   // Fetch clusters when groupBy or filters change
   useEffect(() => {
     if (!fileId) return;
+    let active = true;
     setClusterLoading(true);
     setClusterError(null);
     setClusterData(null);
     intelligenceService
       .getClusters(fileId, groupBy, intelFilters)
       .then(result => {
+        if (!active) return;
         setClusterData(result);
         // On first load, auto-switch to subnet24 if all clusters are internal
         if (!autoSelected) {
@@ -219,8 +215,14 @@ export const NetworkIntelligencePage = () => {
           }
         }
       })
-      .catch(e => setClusterError(e instanceof Error ? e.message : 'Failed to load cluster data'))
-      .finally(() => setClusterLoading(false));
+      .catch(e => {
+        if (!active) return;
+        setClusterError(e instanceof Error ? e.message : 'Failed to load cluster data');
+      })
+      .finally(() => {
+        if (active) setClusterLoading(false);
+      });
+    return () => { active = false; };
   }, [fileId, groupBy, intelFiltersKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (

--- a/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
+++ b/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
@@ -1,13 +1,17 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import type { AnalysisData } from '@/types';
 import {
   intelligenceService,
   type GroupBy,
   type ClusterGraphResponse,
+  type IntelClusterFilters,
 } from '@/features/intelligence/services/intelligenceService';
+import { conversationService } from '@/features/conversation/services/conversationService';
 import { SummaryStatsBar } from '@components/intelligence/SummaryStatsBar/SummaryStatsBar';
 import { ClusterGraph } from '@components/intelligence/ClusterGraph/ClusterGraph';
+import { NetworkControls } from '@components/network/NetworkControls';
+import { toggleSet } from '@/features/network/constants';
 
 interface AnalysisOutletContext {
   data: AnalysisData;
@@ -26,6 +30,145 @@ export const NetworkIntelligencePage = () => {
   const graphCardRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
 
+  // ── Filter state ──────────────────────────────────────────────────────────
+  const [ipFilter, setIpFilter] = useState('');
+  const [portFilter, setPortFilter] = useState('');
+  const [hasRisksOnly, setHasRisksOnly] = useState(false);
+  const [activeLegendProtocols, setActiveLegendProtocols] = useState<string[]>([]);
+  const [activeNodeFilters, setActiveNodeFilters] = useState<string[]>([]);
+  const [activeAppFilters, setActiveAppFilters] = useState<string[]>([]);
+  const [activeL7Protocols, setActiveL7Protocols] = useState<string[]>([]);
+  const [activeCategories, setActiveCategories] = useState<string[]>([]);
+  const [activeRiskTypes, setActiveRiskTypes] = useState<string[]>([]);
+  const [activeCustomSigs, setActiveCustomSigs] = useState<string[]>([]);
+  const [activeFileTypes, setActiveFileTypes] = useState<string[]>([]);
+  const [activeCountries, setActiveCountries] = useState<string[]>([]);
+
+  // ── Present-value state (loaded from API) ─────────────────────────────────
+  const [presentRiskTypes, setPresentRiskTypes] = useState<string[]>([]);
+  const [presentFileTypes, setPresentFileTypes] = useState<string[]>([]);
+  const [presentCustomSigs, setPresentCustomSigs] = useState<string[]>([]);
+  const [presentCountries, setPresentCountries] = useState<string[]>([]);
+  const [presentDeviceTypes, setPresentDeviceTypes] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!fileId) return;
+    conversationService.getRiskTypes(fileId).then(setPresentRiskTypes).catch(() => {});
+    conversationService.getFileTypes(fileId).then(setPresentFileTypes).catch(() => {});
+    conversationService.getCustomSignatures(fileId).then(setPresentCustomSigs).catch(() => {});
+    conversationService.getCountries(fileId).then(codes => {
+      // Countries come back as "CC|CountryName" strings — extract just the code
+      setPresentCountries(codes.map(c => c.split('|')[0]).filter(Boolean).sort());
+    }).catch(() => {});
+    conversationService.getHostClassifications(fileId).then(hosts => {
+      const types = new Set(hosts.map(h => h.deviceType).filter(Boolean) as string[]);
+      setPresentDeviceTypes(types);
+    }).catch(() => {});
+  }, [fileId]);
+
+  // ── Derive present-values from AnalysisData ───────────────────────────────
+  const presentEdgeLegendKeys = useMemo(() => {
+    const keys = new Set<string>();
+    (data.protocolDistribution ?? []).forEach(p => {
+      const upper = p.protocol.toUpperCase();
+      ['TCP', 'UDP', 'ICMP', 'ARP', 'STP', 'LLDP', 'CDP', 'EAPOL'].forEach(k => {
+        if (upper === k) keys.add(k);
+      });
+    });
+    return keys;
+  }, [data]);
+
+  const presentAppNames = useMemo(
+    () => (data.detectedApplications ?? []).map(a => a.name).filter(Boolean).sort(),
+    [data],
+  );
+
+  const presentL7Protocols = useMemo(
+    () => [...(data.detectedL7Protocols ?? [])].sort(),
+    [data],
+  );
+
+  const presentCategories = useMemo(
+    () => (data.categoryDistribution ?? []).map(c => c.category).filter(Boolean).sort(),
+    [data],
+  );
+
+  // node types not meaningful at cluster level — pass empty set
+  const presentNodeTypes = useMemo(() => new Set<string>(), []);
+
+  // ── Filter toggles ────────────────────────────────────────────────────────
+  const toggleLegendProtocol = toggleSet(setActiveLegendProtocols);
+  const toggleNodeFilter = toggleSet(setActiveNodeFilters);
+  const toggleAppFilter = toggleSet(setActiveAppFilters);
+  const toggleL7Protocol = toggleSet(setActiveL7Protocols);
+  const toggleCategory = toggleSet(setActiveCategories);
+  const toggleRiskType = toggleSet(setActiveRiskTypes);
+  const toggleCustomSig = toggleSet(setActiveCustomSigs);
+  const toggleFileType = toggleSet(setActiveFileTypes);
+  const toggleCountry = toggleSet(setActiveCountries);
+
+  const clearAllFilters = () => {
+    setActiveLegendProtocols([]);
+    setActiveNodeFilters([]);
+    setIpFilter('');
+    setPortFilter('');
+    setActiveAppFilters([]);
+    setActiveL7Protocols([]);
+    setActiveCategories([]);
+    setActiveRiskTypes([]);
+    setActiveCustomSigs([]);
+    setActiveFileTypes([]);
+    setActiveCountries([]);
+    setHasRisksOnly(false);
+  };
+
+  const activeFilterCount =
+    activeLegendProtocols.length +
+    activeNodeFilters.length +
+    activeAppFilters.length +
+    activeL7Protocols.length +
+    activeCategories.length +
+    activeRiskTypes.length +
+    activeCustomSigs.length +
+    activeFileTypes.length +
+    activeCountries.length +
+    (ipFilter ? 1 : 0) +
+    (portFilter ? 1 : 0) +
+    (hasRisksOnly ? 1 : 0);
+
+  // ── Build IntelClusterFilters from active filter state ────────────────────
+  const intelFilters = useMemo((): IntelClusterFilters => {
+    // Map activeLegendProtocols (edge legend keys like TCP/UDP/ICMP) → protocols param
+    const protocols = activeLegendProtocols.filter(k =>
+      ['TCP', 'UDP', 'ICMP', 'ARP'].includes(k),
+    );
+
+    // Map activeNodeFilters (dt:MOBILE etc.) → deviceTypes param
+    const deviceTypes = activeNodeFilters
+      .filter(k => k.startsWith('dt:'))
+      .map(k => k.slice(3));
+
+    return {
+      ip: ipFilter || undefined,
+      port: portFilter || undefined,
+      protocols: protocols.length ? protocols : undefined,
+      l7Protocols: activeL7Protocols.length ? activeL7Protocols : undefined,
+      apps: activeAppFilters.length ? activeAppFilters : undefined,
+      categories: activeCategories.length ? activeCategories : undefined,
+      hasRisks: hasRisksOnly || undefined,
+      fileTypes: activeFileTypes.length ? activeFileTypes : undefined,
+      riskTypes: activeRiskTypes.length ? activeRiskTypes : undefined,
+      customSignatures: activeCustomSigs.length ? activeCustomSigs : undefined,
+      deviceTypes: deviceTypes.length ? deviceTypes : undefined,
+      countries: activeCountries.length ? activeCountries : undefined,
+    };
+  }, [
+    ipFilter, portFilter, hasRisksOnly,
+    activeLegendProtocols, activeNodeFilters,
+    activeAppFilters, activeL7Protocols, activeCategories,
+    activeRiskTypes, activeCustomSigs, activeFileTypes, activeCountries,
+  ]);
+
   useEffect(() => {
     const onFsChange = () => setIsFullscreen(!!document.fullscreenElement);
     document.addEventListener('fullscreenchange', onFsChange);
@@ -42,21 +185,24 @@ export const NetworkIntelligencePage = () => {
 
   const [autoSelected, setAutoSelected] = useState(false);
 
-  // Fetch clusters when groupBy changes
+  // Stable serialised key — only changes when filter values actually differ
+  const intelFiltersKey = JSON.stringify(intelFilters);
+
+  // Fetch clusters when groupBy or filters change
   useEffect(() => {
     if (!fileId) return;
     setClusterLoading(true);
     setClusterError(null);
     setClusterData(null);
     intelligenceService
-      .getClusters(fileId, groupBy)
-      .then(data => {
-        setClusterData(data);
+      .getClusters(fileId, groupBy, intelFilters)
+      .then(result => {
+        setClusterData(result);
         // On first load, auto-switch to subnet24 if all clusters are internal
         if (!autoSelected) {
           setAutoSelected(true);
-          const allInternal = data.clusters.length > 0 &&
-            data.clusters.every(c => c.label.startsWith('Internal'));
+          const allInternal = result.clusters.length > 0 &&
+            result.clusters.every(c => c.label.startsWith('Internal'));
           if (allInternal && groupBy === 'asn') {
             setGroupBy('subnet24');
           }
@@ -64,7 +210,7 @@ export const NetworkIntelligencePage = () => {
       })
       .catch(e => setClusterError(e instanceof Error ? e.message : 'Failed to load cluster data'))
       .finally(() => setClusterLoading(false));
-  }, [fileId, groupBy]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [fileId, groupBy, intelFiltersKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="network-intelligence-page">
@@ -78,6 +224,58 @@ export const NetworkIntelligencePage = () => {
 
       {/* Summary stats */}
       <SummaryStatsBar data={data} />
+
+      {/* Filters */}
+      <div className="mb-3">
+        <NetworkControls
+          activeLegendProtocols={activeLegendProtocols}
+          onLegendProtocolClick={toggleLegendProtocol}
+          onLegendProtocolClear={() => setActiveLegendProtocols([])}
+          presentEdgeLegendKeys={presentEdgeLegendKeys}
+          activeNodeFilters={activeNodeFilters}
+          onNodeFilterClick={toggleNodeFilter}
+          onNodeFilterClear={() => setActiveNodeFilters([])}
+          presentNodeTypes={presentNodeTypes}
+          presentDeviceTypes={presentDeviceTypes}
+          ipFilter={ipFilter}
+          onIpFilterChange={setIpFilter}
+          portFilter={portFilter}
+          onPortFilterChange={setPortFilter}
+          activeAppFilters={activeAppFilters}
+          onAppFilterClick={toggleAppFilter}
+          onAppFilterClear={() => setActiveAppFilters([])}
+          presentAppNames={presentAppNames}
+          activeL7Protocols={activeL7Protocols}
+          onL7ProtocolClick={toggleL7Protocol}
+          onL7ProtocolClear={() => setActiveL7Protocols([])}
+          presentL7Protocols={presentL7Protocols}
+          activeCategories={activeCategories}
+          onCategoryClick={toggleCategory}
+          onCategoryClear={() => setActiveCategories([])}
+          presentCategories={presentCategories}
+          activeRiskTypes={activeRiskTypes}
+          onRiskTypeClick={toggleRiskType}
+          onRiskTypeClear={() => setActiveRiskTypes([])}
+          presentRiskTypes={presentRiskTypes}
+          activeCustomSigs={activeCustomSigs}
+          onCustomSigClick={toggleCustomSig}
+          onCustomSigClear={() => setActiveCustomSigs([])}
+          presentCustomSigs={presentCustomSigs}
+          activeFileTypes={activeFileTypes}
+          onFileTypeClick={toggleFileType}
+          onFileTypeClear={() => setActiveFileTypes([])}
+          presentFileTypes={presentFileTypes}
+          activeCountries={activeCountries}
+          onCountryClick={toggleCountry}
+          onCountryClear={() => setActiveCountries([])}
+          presentCountries={presentCountries}
+          hasRisksOnly={hasRisksOnly}
+          onHasRisksOnlyChange={setHasRisksOnly}
+          activeFilterCount={activeFilterCount}
+          onClearAllFilters={clearAllFilters}
+          defaultCollapsed={true}
+        />
+      </div>
 
       {/* Cluster graph */}
       <div className="card mb-4" ref={graphCardRef}>


### PR DESCRIPTION
Closes #234

## Summary
- Backend `/clusters` endpoint now accepts all conversation filter params (ip, port, protocols, l7Protocols, apps, categories, hasRisks, fileTypes, riskTypes, customSignatures, deviceTypes, countries)
- Filters applied at conversation level before clustering via `ConversationRepository.buildSpec()` — cluster stats reflect only filtered traffic
- `NetworkIntelligencePage` now renders the full `NetworkControls` panel (collapsed by default) with present-values from `AnalysisData` + dedicated API calls
- Active filters serialised to `IntelClusterFilters` and passed to `getClusters()`, triggering a refetch on change
- `JSON.stringify` key on filter state prevents double-fetches when groupBy changes with no active filters

## Test plan
- [ ] Open Network Intelligence, verify Filters panel appears collapsed
- [ ] Expand filters, toggle protocol/risk/country pills — graph should reload with filtered clusters
- [ ] Change groupBy — should only trigger one fetch, no double-load delay
- [ ] Clear all filters — graph should restore full cluster data

🤖 Generated with [Claude Code](https://claude.com/claude-code)