### PR TITLE
feat: replace hardcoded IP_PROTO map with IANA CSV and fix protocol label terminology

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/TsharkEnrichmentService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/TsharkEnrichmentService.java
@@ -51,19 +51,24 @@ public class TsharkEnrichmentService {
   private static Map<String, String> loadIanaProtocolNumbers() {
     Map<String, String> map = new HashMap<>();
     try (InputStream is =
-            TsharkEnrichmentService.class.getResourceAsStream("/iana/protocol-numbers.csv");
-        BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
-      br.readLine(); // skip header
-      String line;
-      while ((line = br.readLine()) != null) {
-        String[] cols = line.split(",", 3);
-        if (cols.length < 2 || cols[1].isBlank()) continue;
-        String keyword = cols[1].trim();
-        keyword = KEYWORD_OVERRIDES.getOrDefault(keyword, keyword.toUpperCase());
-        map.put(cols[0].trim(), keyword);
+        TsharkEnrichmentService.class.getResourceAsStream("/iana/protocol-numbers.csv")) {
+      if (is == null) {
+        log.warn("IANA protocol numbers CSV not found on classpath");
+        return Collections.emptyMap();
+      }
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+        br.readLine(); // skip header
+        String line;
+        while ((line = br.readLine()) != null) {
+          String[] cols = line.split(",", 3);
+          if (cols.length < 2 || cols[1].isBlank()) continue;
+          String keyword = cols[1].trim();
+          keyword = KEYWORD_OVERRIDES.getOrDefault(keyword, keyword.toUpperCase());
+          map.put(cols[0].trim(), keyword);
+        }
       }
     } catch (Exception e) {
-      log.warn("Could not load IANA protocol numbers: {}", e.getMessage());
+      log.warn("Could not load IANA protocol numbers", e);
     }
     return Collections.unmodifiableMap(map);
   }

--- a/backend/src/main/java/com/tracepcap/analysis/service/TsharkEnrichmentService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/TsharkEnrichmentService.java
@@ -2,8 +2,10 @@ package com.tracepcap.analysis.service;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -39,21 +41,32 @@ public class TsharkEnrichmentService {
 
   private static final String TSHARK_BINARY = "tshark";
 
-  /** ip.proto number → transport protocol name. */
-  private static final Map<String, String> IP_PROTO =
-      Map.ofEntries(
-          Map.entry("1", "ICMP"),
-          Map.entry("2", "IGMP"),
-          Map.entry("6", "TCP"),
-          Map.entry("17", "UDP"),
-          Map.entry("47", "GRE"),
-          Map.entry("50", "ESP"),
-          Map.entry("51", "AH"),
-          Map.entry("58", "ICMPv6"),
-          Map.entry("89", "OSPF"),
-          Map.entry("103", "PIM"),
-          Map.entry("112", "VRRP"),
-          Map.entry("132", "SCTP"));
+  /** Normalise IANA keyword names to match what tshark/nDPI emit. */
+  private static final Map<String, String> KEYWORD_OVERRIDES =
+      Map.of("IPv6-ICMP", "ICMPv6", "OSPFIGP", "OSPF");
+
+  /** ip.proto number → transport protocol name, loaded from IANA registry CSV. */
+  private static final Map<String, String> IP_PROTO = loadIanaProtocolNumbers();
+
+  private static Map<String, String> loadIanaProtocolNumbers() {
+    Map<String, String> map = new HashMap<>();
+    try (InputStream is =
+            TsharkEnrichmentService.class.getResourceAsStream("/iana/protocol-numbers.csv");
+        BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+      br.readLine(); // skip header
+      String line;
+      while ((line = br.readLine()) != null) {
+        String[] cols = line.split(",", 3);
+        if (cols.length < 2 || cols[1].isBlank()) continue;
+        String keyword = cols[1].trim();
+        keyword = KEYWORD_OVERRIDES.getOrDefault(keyword, keyword.toUpperCase());
+        map.put(cols[0].trim(), keyword);
+      }
+    } catch (Exception e) {
+      log.warn("Could not load IANA protocol numbers: {}", e.getMessage());
+    }
+    return Collections.unmodifiableMap(map);
+  }
 
   // ---------------------------------------------------------------------------
   // Public API
@@ -221,8 +234,7 @@ public class TsharkEnrichmentService {
 
     // Transport protocol from ip.proto / ipv6.nxt number
     String protoNum = !f[8].isEmpty() ? f[8] : f[9];
-    String proto =
-        IP_PROTO.getOrDefault(protoNum, protoNum.isEmpty() ? "UNKNOWN" : protoNum.toUpperCase());
+    String proto = resolveProtoNumber(protoNum);
 
     String frameProtocols = f[10].trim();
     if (!frameProtocols.isEmpty()) {
@@ -292,6 +304,11 @@ public class TsharkEnrichmentService {
    */
   private static final Set<String> NON_APP_PROTOCOLS =
       Set.of("DATA", "FRAME", "ETH", "ETHERNET", "SLL", "RAW");
+
+  /** Maps an ip.proto number string to a protocol name, or falls back to the raw number. */
+  static String resolveProtoNumber(String protoNum) {
+    return IP_PROTO.getOrDefault(protoNum, protoNum.isEmpty() ? "UNKNOWN" : protoNum.toUpperCase());
+  }
 
   /**
    * Returns the upperscased deepest protocol from a {@code frame.protocols} stack (e.g. {@code

--- a/backend/src/main/resources/iana/protocol-numbers.csv
+++ b/backend/src/main/resources/iana/protocol-numbers.csv
@@ -1,0 +1,150 @@
+Decimal,Keyword,Protocol,IPv6 Extension Header,Reference
+0,HOPOPT,IPv6 Hop-by-Hop Option,Y,[RFC8200]
+1,ICMP,Internet Control Message,,[RFC792]
+2,IGMP,Internet Group Management,,[RFC1112]
+3,GGP,Gateway-to-Gateway,,[RFC823]
+4,IPv4,IPv4 encapsulation,,[RFC2003]
+5,ST,Stream,,[RFC1190][RFC1819]
+6,TCP,Transmission Control,,[RFC9293]
+7,CBT,CBT,,
+8,EGP,Exterior Gateway Protocol,,[RFC888]
+9,IGP,any private interior gateway,,[IANA]
+10,BBN-RCC-MON,BBN RCC Monitoring,,
+11,NVP-II,Network Voice Protocol,,[RFC741]
+12,PUP,PUP,,
+13,ARGUS,ARGUS (deprecated),,
+14,EMCON,EMCON,,
+15,XNET,Cross Net Debugger,,
+16,CHAOS,Chaos,,
+17,UDP,User Datagram,,[RFC768]
+18,MUX,Multiplexing,,
+19,DCN-MEAS,DCN Measurement Subsystems,,
+20,HMP,Host Monitoring,,[RFC869]
+21,PRM,Packet Radio Measurement,,
+22,XNS-IDP,XEROX NS IDP,,
+23,TRUNK-1,Trunk-1,,
+24,TRUNK-2,Trunk-2,,
+25,LEAF-1,Leaf-1,,
+26,LEAF-2,Leaf-2,,
+27,RDP,Reliable Datagram Protocol,,[RFC908]
+28,IRTP,Internet Reliable Transaction,,[RFC938]
+29,ISO-TP4,ISO Transport Protocol Class 4,,[RFC905]
+30,NETBLT,Bulk Data Transfer Protocol,,[RFC998]
+31,MFE-NSP,MFE Network Services Protocol,,
+32,MERIT-INP,MERIT Internodal Protocol,,
+33,DCCP,Datagram Congestion Control Protocol,,[RFC4340]
+34,3PC,Third Party Connect Protocol,,
+35,IDPR,Inter-Domain Policy Routing Protocol,,
+36,XTP,XTP,,
+37,DDP,Datagram Delivery Protocol,,
+38,IDPR-CMTP,IDPR Control Message Transport Proto,,
+39,TP++,TP++ Transport Protocol,,
+40,IL,IL Transport Protocol,,
+41,IPv6,IPv6 encapsulation,,[RFC2473]
+42,SDRP,Source Demand Routing Protocol,,
+43,IPv6-Route,Routing Header for IPv6,Y,[RFC8200]
+44,IPv6-Frag,Fragment Header for IPv6,Y,[RFC8200]
+45,IDRP,Inter-Domain Routing Protocol,,
+46,RSVP,Reservation Protocol,,[RFC2205][RFC3209]
+47,GRE,Generic Routing Encapsulation,,[RFC2784]
+48,DSR,Dynamic Source Routing Protocol,,[RFC4728]
+49,BNA,BNA,,
+50,ESP,Encap Security Payload,Y,[RFC4303]
+51,AH,Authentication Header,Y,[RFC4302]
+52,I-NLSP,Integrated Net Layer Security TUBA,,
+53,SWIPE,IP with Encryption (deprecated),,
+54,NARP,NBMA Address Resolution Protocol,,[RFC1735]
+55,Min-IPv4,Minimal IPv4 Encapsulation,,[RFC2004]
+56,TLSP,Transport Layer Security Protocol,,
+57,SKIP,SKIP,,
+58,IPv6-ICMP,ICMP for IPv6,,[RFC8200]
+59,IPv6-NoNxt,No Next Header for IPv6,,[RFC8200]
+60,IPv6-Opts,Destination Options for IPv6,Y,[RFC8200]
+61,,any host internal protocol,,
+62,CFTP,CFTP,,
+63,,any local network,,
+64,SAT-EXPAK,SATNET and Backroom EXPAK,,
+65,KRYPTOLAN,Kryptolan,,
+66,RVD,MIT Remote Virtual Disk Protocol,,
+67,IPPC,Internet Pluribus Packet Core,,
+68,,any distributed file system,,
+69,SAT-MON,SATNET Monitoring,,
+70,VISA,VISA Protocol,,
+71,IPCV,Internet Packet Core Utility,,
+72,CPNX,Computer Protocol Network Executive,,
+73,CPHB,Computer Protocol Heart Beat,,
+74,WSN,Wang Span Network,,
+75,PVP,Packet Video Protocol,,
+76,BR-SAT-MON,Backroom SATNET Monitoring,,
+77,SUN-ND,SUN ND PROTOCOL-Temporary,,
+78,WB-MON,WIDEBAND Monitoring,,
+79,WB-EXPAK,WIDEBAND EXPAK,,
+80,ISO-IP,ISO Internet Protocol,,
+81,VMTP,VMTP,,
+82,SECURE-VMTP,SECURE-VMTP,,
+83,VINES,VINES,,
+84,IPTM,Internet Protocol Traffic Manager,,
+85,NSFNET-IGP,NSFNET-IGP,,
+86,DGP,Dissimilar Gateway Protocol,,
+87,TCF,TCF,,
+88,EIGRP,EIGRP,,[RFC7868]
+89,OSPFIGP,OSPF,,[RFC1583][RFC2328][RFC5340]
+90,Sprite-RPC,Sprite RPC Protocol,,
+91,LARP,Locus Address Resolution Protocol,,
+92,MTP,Multicast Transport Protocol,,
+93,AX.25,AX.25 Frames,,
+94,IPIP,IP-within-IP Encapsulation Protocol,,[RFC2003]
+95,MICP,Mobile Internetworking Control Protocol (deprecated),,
+96,SCC-SP,Semaphore Communications Sec. Pro.,,
+97,ETHERIP,Ethernet-within-IP Encapsulation,,[RFC3378]
+98,ENCAP,Encapsulation Header,,[RFC1241]
+99,,any private encryption scheme,,
+100,GMTP,GMTP,,
+101,IFMP,Ipsilon Flow Management Protocol,,
+102,PNNI,PNNI over IP,,
+103,PIM,Protocol Independent Multicast,,[RFC7761]
+104,ARIS,ARIS,,
+105,SCPS,SCPS,,
+106,QNX,QNX,,
+107,A/N,Active Networks,,
+108,IPComp,IP Payload Compression Protocol,,[RFC2393]
+109,SNP,Sitara Networks Protocol,,
+110,Compaq-Peer,Compaq Peer Protocol,,
+111,IPX-in-IP,IPX in IP,,
+112,VRRP,Virtual Router Redundancy Protocol,,[RFC5798]
+113,PGM,PGM Reliable Transport Protocol,,[RFC3208]
+114,,any 0-hop protocol,,
+115,L2TP,Layer Two Tunneling Protocol,,[RFC3931]
+116,DDX,D-II Data Exchange (DDX),,
+117,IATP,Interactive Agent Transfer Protocol,,
+118,STP,Schedule Transfer Protocol,,
+119,SRP,SpectraLink Radio Protocol,,
+120,UTI,Universal Transport Interface Protocol,,
+121,SMP,Simple Message Protocol,,
+122,SM,Simple Multicast Protocol (deprecated),,
+123,PTP,Performance Transparency Protocol,,
+124,ISIS over IPv4,,,
+125,FIRE,Flexible Intra-AS Routing Environment,,
+126,CRTP,Combat Radio Transport Protocol,,
+127,CRUDP,Combat Radio User Datagram,,
+128,SSCOPMCE,Service-Specific Connection-Oriented Protocol in a Multilink and Connectionless Environment,,
+129,IPLT,,,
+130,SPS,Secure Packet Shield,,
+131,PIPE,Private IP Encapsulation within IP,,
+132,SCTP,Stream Control Transmission Protocol,,[RFC9260]
+133,FC,Fibre Channel,,
+134,RSVP-E2E-IGNORE,Reservation Protocol (RSVP) End-to-End Ignore,,[RFC3175]
+135,Mobility Header,,Y,[RFC6275]
+136,UDPLite,,,[RFC3828]
+137,MPLS-in-IP,,,[RFC4023]
+138,manet,MANET Protocols,,[RFC5498]
+139,HIP,Host Identity Protocol,Y,[RFC7401]
+140,Shim6,Shim6 Protocol,Y,[RFC5533]
+141,WESP,Wrapped Encapsulating Security Payload,,[RFC5840]
+142,ROHC,Robust Header Compression,,[RFC5858]
+143,Ethernet,Ethernet,,[RFC8986]
+144,AGGFRAG,AGGFRAG Encapsulation Payload for ESP,,[RFC9347]
+145,NSH,Network Service Header,,[RFC9491]
+253,,Use for experimentation and testing,,[RFC3692]
+254,,Use for experimentation and testing,,[RFC3692]
+255,Reserved,,,

--- a/backend/src/test/java/com/tracepcap/analysis/service/TsharkEnrichmentServiceTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/service/TsharkEnrichmentServiceTest.java
@@ -92,6 +92,44 @@ class TsharkEnrichmentServiceTest {
         .isNull();
   }
 
+  // --- resolveProtoNumber ---
+
+  @Test
+  void resolveProtoNumber_commonProtocols_returnExpectedNames() {
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("1")).isEqualTo("ICMP");
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("2")).isEqualTo("IGMP");
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("6")).isEqualTo("TCP");
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("17")).isEqualTo("UDP");
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("47")).isEqualTo("GRE");
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("50")).isEqualTo("ESP");
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("51")).isEqualTo("AH");
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("103")).isEqualTo("PIM");
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("112")).isEqualTo("VRRP");
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("132")).isEqualTo("SCTP");
+  }
+
+  @Test
+  void resolveProtoNumber_icmpv6Override_appliesNormalization() {
+    // IANA keyword is "IPv6-ICMP"; override maps it to "ICMPv6"
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("58")).isEqualTo("ICMPv6");
+  }
+
+  @Test
+  void resolveProtoNumber_ospfOverride_appliesNormalization() {
+    // IANA keyword is "OSPFIGP"; override maps it to "OSPF"
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("89")).isEqualTo("OSPF");
+  }
+
+  @Test
+  void resolveProtoNumber_unknownNumber_returnsUpperCasedNumber() {
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("200")).isEqualTo("200");
+  }
+
+  @Test
+  void resolveProtoNumber_emptyString_returnsUnknown() {
+    assertThat(TsharkEnrichmentService.resolveProtoNumber("")).isEqualTo("UNKNOWN");
+  }
+
   // --- normalizeL7Protocol ---
 
   @Test

--- a/frontend/src/components/analysis/ProtocolBreakdown/ProtocolBreakdownChart.tsx
+++ b/frontend/src/components/analysis/ProtocolBreakdown/ProtocolBreakdownChart.tsx
@@ -12,11 +12,10 @@ const protocolInfoPopover = (
     <Popover.Header>Protocol distribution</Popover.Header>
     <Popover.Body>
       <p className="mb-0">
-        Shows the breakdown of <strong>transport-layer protocols</strong> (TCP, UDP, ICMP, ARP,
-        etc.) read directly from IP packet headers — no heuristics involved. The counts accurately
-        reflect what is declared in each packet's header. Note that tunnelled traffic (e.g. GRE,
-        VXLAN, IP-in-IP) will appear as its outer transport protocol, not the encapsulated inner
-        protocol.
+        Shows the breakdown of protocols read directly from the IP header's Protocol field — no
+        heuristics involved. The counts accurately reflect what is declared in each packet's header.
+        Note that tunnelled traffic (e.g. GRE, VXLAN, IP-in-IP) will appear as its outer protocol,
+        not the encapsulated inner protocol.
       </p>
     </Popover.Body>
   </Popover>
@@ -57,7 +56,7 @@ export const ProtocolBreakdownChart = ({ protocolStats }: ProtocolBreakdownChart
   return (
     <div className="protocol-breakdown">
       <h3 className="breakdown-title d-flex align-items-center gap-2">
-        L4 Protocol Distribution
+        Protocol Distribution
         <OverlayTrigger trigger="click" placement="right" overlay={protocolInfoPopover} rootClose>
           <button
             type="button"

--- a/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
+++ b/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
@@ -286,7 +286,7 @@ export const ConversationDetail = ({
                 </dd>
                 <GeoInfoRows geo={conversation.srcGeo} label="Src" ip={source.ip} />
                 <GeoInfoRows geo={conversation.dstGeo} label="Dst" ip={destination.ip} />
-                <dt className="col-sm-4">L4 Protocol:</dt>
+                <dt className="col-sm-4">Protocol:</dt>
                 <dd className="col-sm-8">
                   {(() => {
                     const bg = getProtocolColor(conversation.protocol.name);
@@ -302,7 +302,7 @@ export const ConversationDetail = ({
                 </dd>
                 {conversation.tsharkProtocol && (
                   <>
-                    <dt className="col-sm-4">L7 Protocol:</dt>
+                    <dt className="col-sm-4">Dissected Protocol:</dt>
                     <dd className="col-sm-8">
                       {(() => {
                         const bg = getL7ProtocolColor(conversation.tsharkProtocol!);

--- a/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
+++ b/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
@@ -298,12 +298,12 @@ export function ConversationFilterPanel({
               {protocols.length > 0 && (
                 <div className="col-12">
                   <PillSectionHeader
-                    label="L4 Protocol"
+                    label="Protocol"
                     info={
                       <InfoPopover
                         id="info-protocol"
-                        title="L4 Protocol"
-                        body="Filter by Layer 4 transport protocol (e.g. TCP, UDP, ICMP). Select multiple to show any of them."
+                        title="Protocol"
+                        body="The protocol carried by each IP packet, determined by the Protocol field in the IP header — no heuristics involved (e.g. TCP, UDP, ICMP, OSPF, GRE). Select multiple to show any of them."
                       />
                     }
                     onSelectAll={() =>
@@ -333,16 +333,16 @@ export function ConversationFilterPanel({
                 </div>
               )}
 
-              {/* L7 Protocol pills */}
+              {/* Dissected Protocol pills */}
               {l7Protocols.length > 0 && (
                 <div className="col-12">
                   <PillSectionHeader
-                    label="L7 Protocol"
+                    label="Dissected Protocol"
                     info={
                       <InfoPopover
                         id="info-l7protocol"
-                        title="L7 Protocol"
-                        body="Layer 7 application-layer protocol identified by Wireshark's deterministic dissectors (e.g. TLS, HTTP, DNS, QUIC). Select multiple to show any of them."
+                        title="Dissected Protocol"
+                        body="The deepest protocol Wireshark's tshark could decode in each flow, determined by its built-in deterministic dissectors (e.g. TLS, HTTP, DNS, QUIC). Select multiple to show any of them."
                       />
                     }
                     onSelectAll={() => onFiltersChange({ l7Protocols })}
@@ -676,7 +676,7 @@ export function ConversationFilterPanel({
                     <InfoPopover
                       id="info-devicetype"
                       title="Device Type"
-                      body="Filter by the classified device type of hosts in each conversation. Device types are inferred from traffic patterns and port usage. Click on a device type badge in the conversation details to see the confidence score and evidence."
+                      body="Device types are inferred using a multi-signal heuristic: MAC OUI vendor lookup, TTL fingerprinting, observed application profiles from nDPI, and traffic patterns (e.g. port usage, peer count). Custom signatures can override the classification with 100% confidence. Click a device type badge in conversation details to see the confidence score and evidence."
                     />
                   }
                   onSelectAll={() => onFiltersChange({ deviceTypes: presentDeviceTypes })}

--- a/frontend/src/components/conversation/ConversationList/ConversationList.tsx
+++ b/frontend/src/components/conversation/ConversationList/ConversationList.tsx
@@ -106,9 +106,9 @@ export const ConversationList = ({
             <tr>
               {col('source') && <SortableHeader field="srcIp" label="Source" />}
               {col('destination') && <SortableHeader field="dstIp" label="Destination" />}
-              {col('protocol') && <th style={{ whiteSpace: 'nowrap' }}>L4 Protocol</th>}
+              {col('protocol') && <th style={{ whiteSpace: 'nowrap' }}>Protocol</th>}
               {col('tsharkProtocol') && hasL7Protocols && (
-                <th style={{ whiteSpace: 'nowrap' }}>L7 Protocol</th>
+                <th style={{ whiteSpace: 'nowrap' }}>Dissected Protocol</th>
               )}
               {col('appName') && hasAppNames && <th>Application</th>}
               {col('category') && hasCategories && <th>Category</th>}

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -319,7 +319,7 @@ export function NetworkControls({
                       <InfoPopover
                         id="nc-info-nodetypes"
                         title="Node Types"
-                        body="Filter by the role of each node in the network graph — e.g. Client, Server, Gateway. Roles are inferred from port usage and traffic direction."
+                        body="Filter by the inferred role of each node. Determined from graph data: a node's dominant inbound port identifies it as a specific server type (e.g. DNS, HTTP), a high distinct peer count marks it as a router, and nodes that only initiate connections are classified as clients."
                       />
                     }
                     onSelectAll={() =>
@@ -419,16 +419,16 @@ export function NetworkControls({
                   </div>
                 )}
 
-                {/* L7 Protocols */}
+                {/* Dissected Protocols */}
                 {presentL7Protocols.length > 0 && (
                   <div className="col-12">
                     <PillSectionHeader
-                      label="L7 Protocol"
+                      label="Dissected Protocol"
                       info={
                         <InfoPopover
                           id="nc-info-l7protocol"
-                          title="L7 Protocol"
-                          body="Layer 7 application-layer protocol identified by Wireshark's deterministic dissectors (e.g. TLS, HTTP, DNS, QUIC). Select multiple to show any of them."
+                          title="Dissected Protocol"
+                          body="The deepest protocol Wireshark's tshark could decode in each flow, determined by its built-in deterministic dissectors (e.g. TLS, HTTP, DNS, QUIC). Select multiple to show any of them."
                         />
                       }
                       onSelectAll={() =>

--- a/frontend/src/features/conversation/constants.ts
+++ b/frontend/src/features/conversation/constants.ts
@@ -18,8 +18,8 @@ export type ColumnKey =
 export const COLUMN_DEFS: { key: ColumnKey; label: string; defaultVisible: boolean }[] = [
   { key: 'source', label: 'Source', defaultVisible: true },
   { key: 'destination', label: 'Destination', defaultVisible: true },
-  { key: 'protocol', label: 'L4 Protocol', defaultVisible: false },
-  { key: 'tsharkProtocol', label: 'L7 Protocol', defaultVisible: true },
+  { key: 'protocol', label: 'Protocol', defaultVisible: false },
+  { key: 'tsharkProtocol', label: 'Dissected Protocol', defaultVisible: true },
   { key: 'appName', label: 'Application', defaultVisible: true },
   { key: 'category', label: 'Category', defaultVisible: true },
   { key: 'risks', label: 'Risks', defaultVisible: true },

--- a/frontend/src/pages/Analysis/AnalysisOverview.tsx
+++ b/frontend/src/pages/Analysis/AnalysisOverview.tsx
@@ -49,15 +49,15 @@ const ndpiPopover = (
 
 const l7Popover = (
   <Popover id="l7-info" style={{ maxWidth: '320px' }}>
-    <Popover.Header>About L7 protocols</Popover.Header>
+    <Popover.Header>About dissected protocols</Popover.Header>
     <Popover.Body>
       <p className="mb-2">
-        Layer 7 protocols are identified by{' '}
+        Determined by{' '}
         <a href="https://www.wireshark.org/" target="_blank" rel="noopener noreferrer">
           Wireshark
-        </a>{' '}
-        (tshark) deterministic dissectors — e.g. TLS, HTTP, DNS, QUIC. These reflect the
-        application-layer protocol in use, independent of the service generating the traffic.
+        </a>
+        's tshark, which inspects each flow's payload using built-in deterministic dissectors and
+        reports the deepest protocol it can decode — e.g. TLS, HTTP, DNS, QUIC.
       </p>
       <p className="mb-0">
         Click any badge to filter the Conversations tab to flows using that protocol.
@@ -192,7 +192,7 @@ export const AnalysisOverview = () => {
         <div className="mt-4">
           <h5 className="mb-3 d-flex align-items-center gap-2">
             <i className="bi bi-layers me-2"></i>
-            L7 Protocols Detected
+            Dissected Protocols
             <OverlayTrigger trigger="click" placement="right" overlay={l7Popover} rootClose>
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- Replaces the 12-entry hardcoded `IP_PROTO` map in `TsharkEnrichmentService` with the full IANA protocol numbers registry (~146 entries) bundled as a classpath CSV, with overrides to normalise `IPv6-ICMP`→`ICMPv6` and `OSPFIGP`→`OSPF`
- Extracts `resolveProtoNumber()` as a testable static method and adds 5 unit tests
- Renames "L4 Protocol" → "Protocol" and "L7 Protocol" → "Dissected Protocol" across the UI, with accurate tooltips describing how each value is determined

## Test plan
- [ ] Run `mvn test -Dtest=TsharkEnrichmentServiceTest` in `backend/` — 21 tests should pass
- [ ] Upload `sample-files/new_protocols_demo.pcap` and verify conversations show protocol names (EIGRP, DCCP, L2TP, ETHERIP) instead of raw numbers
- [ ] Verify column headers, filter panel labels, and tooltips reflect the new naming

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)