### PR TITLE
feat: move device classification app lists to YAML configuration

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
@@ -302,13 +302,17 @@ public class DeviceClassifierService {
     }
 
     // --- Signal 3: nDPI app profile ---
+    Set<String> mobileApps = classificationProps.getMobileApps();
+    Set<String> desktopApps = classificationProps.getDesktopApps();
+    Set<String> serverApps = classificationProps.getServerApps();
+    Set<String> iotCategories = classificationProps.getIotCategories();
     for (String app : p.apps) {
-      if (classificationProps.getMobileApps().contains(app)) scores.merge(MOBILE, 20, Integer::sum);
-      if (classificationProps.getDesktopApps().contains(app)) scores.merge(LAPTOP_DESKTOP, 20, Integer::sum);
-      if (classificationProps.getServerApps().contains(app)) scores.merge(SERVER, 20, Integer::sum);
+      if (mobileApps.contains(app)) scores.merge(MOBILE, 20, Integer::sum);
+      if (desktopApps.contains(app)) scores.merge(LAPTOP_DESKTOP, 20, Integer::sum);
+      if (serverApps.contains(app)) scores.merge(SERVER, 20, Integer::sum);
     }
     for (String cat : p.categories) {
-      if (classificationProps.getIotCategories().contains(cat)) scores.merge(IOT, 15, Integer::sum);
+      if (iotCategories.contains(cat)) scores.merge(IOT, 15, Integer::sum);
       if ("Web".equals(cat) || "Media".equals(cat)) scores.merge(LAPTOP_DESKTOP, 5, Integer::sum);
     }
 

--- a/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
@@ -1,12 +1,14 @@
 package com.tracepcap.analysis.service;
 
 import com.tracepcap.analysis.entity.HostClassificationEntity;
+import com.tracepcap.config.DeviceClassificationProperties;
 import com.tracepcap.file.entity.FileEntity;
 import jakarta.annotation.PostConstruct;
 import java.io.BufferedReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,7 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class DeviceClassifierService {
 
   // -------------------------------------------------------------------------
@@ -47,6 +50,8 @@ public class DeviceClassifierService {
   // -------------------------------------------------------------------------
   // OUI vendor lookup — loaded at startup from /usr/share/wireshark/manuf
   // -------------------------------------------------------------------------
+
+  private final DeviceClassificationProperties classificationProps;
 
   @Value("${app.wireshark.manuf-path:/usr/share/wireshark/manuf}")
   private String manufFile;
@@ -122,68 +127,6 @@ public class DeviceClassifierService {
     ouiVendor = Collections.unmodifiableMap(mutable);
     log.info("Loaded {} OUI entries from {}", loaded, manufFile);
   }
-
-  // -------------------------------------------------------------------------
-  // App profile signals
-  // -------------------------------------------------------------------------
-
-  /** nDPI apps strongly associated with mobile devices */
-  private static final Set<String> MOBILE_APPS =
-      Set.of(
-          "Instagram",
-          "TikTok",
-          "Snapchat",
-          "WhatsApp",
-          "WeChat",
-          "Line",
-          "Viber",
-          "Telegram",
-          "Signal",
-          "iMessage",
-          "FaceTime",
-          "AirDrop",
-          "Siri");
-
-  /** nDPI apps/categories suggesting a laptop/desktop */
-  private static final Set<String> DESKTOP_APPS =
-      Set.of(
-          "Zoom",
-          "Teams",
-          "Slack",
-          "Discord",
-          "Skype",
-          "WebEx",
-          "GoToMeeting",
-          "BitTorrent",
-          "Steam",
-          "Battle.net",
-          "League of Legends",
-          "Valorant",
-          "Remote Desktop",
-          "SSH",
-          "SMB",
-          "NFS",
-          "VNC",
-          "TeamViewer");
-
-  /** nDPI apps associated with server or infrastructure roles */
-  private static final Set<String> SERVER_APPS =
-      Set.of(
-          "PostgreSQL",
-          "MySQL",
-          "MongoDB",
-          "Redis",
-          "Elasticsearch",
-          "Kafka",
-          "RabbitMQ",
-          "Memcached",
-          "LDAP",
-          "Kerberos",
-          "SNMP",
-          "Syslog");
-
-  /** nDPI categories strongly associated with IoT / embedded devices */
-  private static final Set<String> IOT_CATEGORIES = Set.of("IoT-Scada", "Cloud");
 
   // -------------------------------------------------------------------------
   // Classification
@@ -360,12 +303,12 @@ public class DeviceClassifierService {
 
     // --- Signal 3: nDPI app profile ---
     for (String app : p.apps) {
-      if (MOBILE_APPS.contains(app)) scores.merge(MOBILE, 20, Integer::sum);
-      if (DESKTOP_APPS.contains(app)) scores.merge(LAPTOP_DESKTOP, 20, Integer::sum);
-      if (SERVER_APPS.contains(app)) scores.merge(SERVER, 20, Integer::sum);
+      if (classificationProps.getMobileApps().contains(app)) scores.merge(MOBILE, 20, Integer::sum);
+      if (classificationProps.getDesktopApps().contains(app)) scores.merge(LAPTOP_DESKTOP, 20, Integer::sum);
+      if (classificationProps.getServerApps().contains(app)) scores.merge(SERVER, 20, Integer::sum);
     }
     for (String cat : p.categories) {
-      if (IOT_CATEGORIES.contains(cat)) scores.merge(IOT, 15, Integer::sum);
+      if (classificationProps.getIotCategories().contains(cat)) scores.merge(IOT, 15, Integer::sum);
       if ("Web".equals(cat) || "Media".equals(cat)) scores.merge(LAPTOP_DESKTOP, 5, Integer::sum);
     }
 

--- a/backend/src/main/java/com/tracepcap/config/DeviceClassificationProperties.java
+++ b/backend/src/main/java/com/tracepcap/config/DeviceClassificationProperties.java
@@ -1,0 +1,26 @@
+package com.tracepcap.config;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** Configuration properties for device classification app/category signal lists. */
+@Configuration
+@ConfigurationProperties(prefix = "tracepcap.device-classification")
+@Data
+public class DeviceClassificationProperties {
+
+  /** nDPI app names strongly associated with mobile devices. */
+  private Set<String> mobileApps = new LinkedHashSet<>();
+
+  /** nDPI app names suggesting a laptop or desktop. */
+  private Set<String> desktopApps = new LinkedHashSet<>();
+
+  /** nDPI app names associated with server or infrastructure roles. */
+  private Set<String> serverApps = new LinkedHashSet<>();
+
+  /** nDPI category names strongly associated with IoT / embedded devices. */
+  private Set<String> iotCategories = new LinkedHashSet<>();
+}

--- a/backend/src/main/java/com/tracepcap/config/DeviceClassificationProperties.java
+++ b/backend/src/main/java/com/tracepcap/config/DeviceClassificationProperties.java
@@ -1,26 +1,33 @@
 package com.tracepcap.config;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
 
 /** Configuration properties for device classification app/category signal lists. */
 @Configuration
 @ConfigurationProperties(prefix = "tracepcap.device-classification")
+@Validated
 @Data
 public class DeviceClassificationProperties {
 
   /** nDPI app names strongly associated with mobile devices. */
+  @NotNull
   private Set<String> mobileApps = new LinkedHashSet<>();
 
   /** nDPI app names suggesting a laptop or desktop. */
+  @NotNull
   private Set<String> desktopApps = new LinkedHashSet<>();
 
   /** nDPI app names associated with server or infrastructure roles. */
+  @NotNull
   private Set<String> serverApps = new LinkedHashSet<>();
 
   /** nDPI category names strongly associated with IoT / embedded devices. */
+  @NotNull
   private Set<String> iotCategories = new LinkedHashSet<>();
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -170,3 +170,53 @@ tracepcap:
   intelligence:
     max-clusters: ${INTELLIGENCE_MAX_CLUSTERS:60}   # Max cluster nodes returned per groupBy request
     max-edges: ${INTELLIGENCE_MAX_EDGES:200}         # Max edges returned per groupBy request
+  device-classification:
+    mobile-apps:
+      - Instagram
+      - TikTok
+      - Snapchat
+      - WhatsApp
+      - WeChat
+      - Line
+      - Viber
+      - Telegram
+      - Signal
+      - iMessage
+      - FaceTime
+      - AirDrop
+      - Siri
+    desktop-apps:
+      - Zoom
+      - Teams
+      - Slack
+      - Discord
+      - Skype
+      - WebEx
+      - GoToMeeting
+      - BitTorrent
+      - Steam
+      - Battle.net
+      - League of Legends
+      - Valorant
+      - Remote Desktop
+      - SSH
+      - SMB
+      - NFS
+      - VNC
+      - TeamViewer
+    server-apps:
+      - PostgreSQL
+      - MySQL
+      - MongoDB
+      - Redis
+      - Elasticsearch
+      - Kafka
+      - RabbitMQ
+      - Memcached
+      - LDAP
+      - Kerberos
+      - SNMP
+      - Syslog
+    iot-categories:
+      - IoT-Scada
+      - Cloud

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -171,6 +171,10 @@ tracepcap:
     max-clusters: ${INTELLIGENCE_MAX_CLUSTERS:60}   # Max cluster nodes returned per groupBy request
     max-edges: ${INTELLIGENCE_MAX_EDGES:200}         # Max edges returned per groupBy request
   device-classification:
+    # nDPI application/category names used to infer host device types.
+    # When a conversation's detected app matches an entry here, it adds weight
+    # to that device type during classification. Edit these lists to tune
+    # classification without recompiling.
     mobile-apps:
       - Instagram
       - TikTok


### PR DESCRIPTION
## Summary
- Removes four hardcoded static `Set<String>` collections (`MOBILE_APPS`, `DESKTOP_APPS`, `SERVER_APPS`, `IOT_CATEGORIES`) from `DeviceClassifierService`
- Introduces `DeviceClassificationProperties` — a `@ConfigurationProperties` bean bound to `tracepcap.device-classification.*` — following the same pattern as `AnalysisProperties` and `CleanupProperties`
- Moves all lists to `application.yml` under `tracepcap.device-classification`; classification behaviour is identical to before
- Adding or changing app/category signals now requires only a YAML edit — no recompile or redeployment

## Test plan
- [ ] `mvn compile` passes with no errors
- [ ] Upload any sample pcap and verify device types are still classified correctly (MOBILE, SERVER, ROUTER, etc.)
- [ ] Add a new entry to `mobile-apps` in `application.yml`, rebuild, and confirm the new app influences classification

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)