### PR TITLE
fix: UI polish — nav wrapping, filter collapse, scrollbar, dark mode popovers, node colour tooltip

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
@@ -302,13 +302,17 @@ public class DeviceClassifierService {
     }
 
     // --- Signal 3: nDPI app profile ---
+    Set<String> mobileApps = classificationProps.getMobileApps();
+    Set<String> desktopApps = classificationProps.getDesktopApps();
+    Set<String> serverApps = classificationProps.getServerApps();
+    Set<String> iotCategories = classificationProps.getIotCategories();
     for (String app : p.apps) {
-      if (classificationProps.getMobileApps().contains(app)) scores.merge(MOBILE, 20, Integer::sum);
-      if (classificationProps.getDesktopApps().contains(app)) scores.merge(LAPTOP_DESKTOP, 20, Integer::sum);
-      if (classificationProps.getServerApps().contains(app)) scores.merge(SERVER, 20, Integer::sum);
+      if (mobileApps.contains(app)) scores.merge(MOBILE, 20, Integer::sum);
+      if (desktopApps.contains(app)) scores.merge(LAPTOP_DESKTOP, 20, Integer::sum);
+      if (serverApps.contains(app)) scores.merge(SERVER, 20, Integer::sum);
     }
     for (String cat : p.categories) {
-      if (classificationProps.getIotCategories().contains(cat)) scores.merge(IOT, 15, Integer::sum);
+      if (iotCategories.contains(cat)) scores.merge(IOT, 15, Integer::sum);
       if ("Web".equals(cat) || "Media".equals(cat)) scores.merge(LAPTOP_DESKTOP, 5, Integer::sum);
     }
 

--- a/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
@@ -1,12 +1,14 @@
 package com.tracepcap.analysis.service;
 
 import com.tracepcap.analysis.entity.HostClassificationEntity;
+import com.tracepcap.config.DeviceClassificationProperties;
 import com.tracepcap.file.entity.FileEntity;
 import jakarta.annotation.PostConstruct;
 import java.io.BufferedReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,7 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class DeviceClassifierService {
 
   // -------------------------------------------------------------------------
@@ -47,6 +50,8 @@ public class DeviceClassifierService {
   // -------------------------------------------------------------------------
   // OUI vendor lookup — loaded at startup from /usr/share/wireshark/manuf
   // -------------------------------------------------------------------------
+
+  private final DeviceClassificationProperties classificationProps;
 
   @Value("${app.wireshark.manuf-path:/usr/share/wireshark/manuf}")
   private String manufFile;
@@ -122,68 +127,6 @@ public class DeviceClassifierService {
     ouiVendor = Collections.unmodifiableMap(mutable);
     log.info("Loaded {} OUI entries from {}", loaded, manufFile);
   }
-
-  // -------------------------------------------------------------------------
-  // App profile signals
-  // -------------------------------------------------------------------------
-
-  /** nDPI apps strongly associated with mobile devices */
-  private static final Set<String> MOBILE_APPS =
-      Set.of(
-          "Instagram",
-          "TikTok",
-          "Snapchat",
-          "WhatsApp",
-          "WeChat",
-          "Line",
-          "Viber",
-          "Telegram",
-          "Signal",
-          "iMessage",
-          "FaceTime",
-          "AirDrop",
-          "Siri");
-
-  /** nDPI apps/categories suggesting a laptop/desktop */
-  private static final Set<String> DESKTOP_APPS =
-      Set.of(
-          "Zoom",
-          "Teams",
-          "Slack",
-          "Discord",
-          "Skype",
-          "WebEx",
-          "GoToMeeting",
-          "BitTorrent",
-          "Steam",
-          "Battle.net",
-          "League of Legends",
-          "Valorant",
-          "Remote Desktop",
-          "SSH",
-          "SMB",
-          "NFS",
-          "VNC",
-          "TeamViewer");
-
-  /** nDPI apps associated with server or infrastructure roles */
-  private static final Set<String> SERVER_APPS =
-      Set.of(
-          "PostgreSQL",
-          "MySQL",
-          "MongoDB",
-          "Redis",
-          "Elasticsearch",
-          "Kafka",
-          "RabbitMQ",
-          "Memcached",
-          "LDAP",
-          "Kerberos",
-          "SNMP",
-          "Syslog");
-
-  /** nDPI categories strongly associated with IoT / embedded devices */
-  private static final Set<String> IOT_CATEGORIES = Set.of("IoT-Scada", "Cloud");
 
   // -------------------------------------------------------------------------
   // Classification
@@ -360,12 +303,12 @@ public class DeviceClassifierService {
 
     // --- Signal 3: nDPI app profile ---
     for (String app : p.apps) {
-      if (MOBILE_APPS.contains(app)) scores.merge(MOBILE, 20, Integer::sum);
-      if (DESKTOP_APPS.contains(app)) scores.merge(LAPTOP_DESKTOP, 20, Integer::sum);
-      if (SERVER_APPS.contains(app)) scores.merge(SERVER, 20, Integer::sum);
+      if (classificationProps.getMobileApps().contains(app)) scores.merge(MOBILE, 20, Integer::sum);
+      if (classificationProps.getDesktopApps().contains(app)) scores.merge(LAPTOP_DESKTOP, 20, Integer::sum);
+      if (classificationProps.getServerApps().contains(app)) scores.merge(SERVER, 20, Integer::sum);
     }
     for (String cat : p.categories) {
-      if (IOT_CATEGORIES.contains(cat)) scores.merge(IOT, 15, Integer::sum);
+      if (classificationProps.getIotCategories().contains(cat)) scores.merge(IOT, 15, Integer::sum);
       if ("Web".equals(cat) || "Media".equals(cat)) scores.merge(LAPTOP_DESKTOP, 5, Integer::sum);
     }
 

--- a/backend/src/main/java/com/tracepcap/config/DeviceClassificationProperties.java
+++ b/backend/src/main/java/com/tracepcap/config/DeviceClassificationProperties.java
@@ -1,0 +1,26 @@
+package com.tracepcap.config;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** Configuration properties for device classification app/category signal lists. */
+@Configuration
+@ConfigurationProperties(prefix = "tracepcap.device-classification")
+@Data
+public class DeviceClassificationProperties {
+
+  /** nDPI app names strongly associated with mobile devices. */
+  private Set<String> mobileApps = new LinkedHashSet<>();
+
+  /** nDPI app names suggesting a laptop or desktop. */
+  private Set<String> desktopApps = new LinkedHashSet<>();
+
+  /** nDPI app names associated with server or infrastructure roles. */
+  private Set<String> serverApps = new LinkedHashSet<>();
+
+  /** nDPI category names strongly associated with IoT / embedded devices. */
+  private Set<String> iotCategories = new LinkedHashSet<>();
+}

--- a/backend/src/main/java/com/tracepcap/config/DeviceClassificationProperties.java
+++ b/backend/src/main/java/com/tracepcap/config/DeviceClassificationProperties.java
@@ -1,26 +1,33 @@
 package com.tracepcap.config;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
 
 /** Configuration properties for device classification app/category signal lists. */
 @Configuration
 @ConfigurationProperties(prefix = "tracepcap.device-classification")
+@Validated
 @Data
 public class DeviceClassificationProperties {
 
   /** nDPI app names strongly associated with mobile devices. */
+  @NotNull
   private Set<String> mobileApps = new LinkedHashSet<>();
 
   /** nDPI app names suggesting a laptop or desktop. */
+  @NotNull
   private Set<String> desktopApps = new LinkedHashSet<>();
 
   /** nDPI app names associated with server or infrastructure roles. */
+  @NotNull
   private Set<String> serverApps = new LinkedHashSet<>();
 
   /** nDPI category names strongly associated with IoT / embedded devices. */
+  @NotNull
   private Set<String> iotCategories = new LinkedHashSet<>();
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -170,3 +170,53 @@ tracepcap:
   intelligence:
     max-clusters: ${INTELLIGENCE_MAX_CLUSTERS:60}   # Max cluster nodes returned per groupBy request
     max-edges: ${INTELLIGENCE_MAX_EDGES:200}         # Max edges returned per groupBy request
+  device-classification:
+    mobile-apps:
+      - Instagram
+      - TikTok
+      - Snapchat
+      - WhatsApp
+      - WeChat
+      - Line
+      - Viber
+      - Telegram
+      - Signal
+      - iMessage
+      - FaceTime
+      - AirDrop
+      - Siri
+    desktop-apps:
+      - Zoom
+      - Teams
+      - Slack
+      - Discord
+      - Skype
+      - WebEx
+      - GoToMeeting
+      - BitTorrent
+      - Steam
+      - Battle.net
+      - League of Legends
+      - Valorant
+      - Remote Desktop
+      - SSH
+      - SMB
+      - NFS
+      - VNC
+      - TeamViewer
+    server-apps:
+      - PostgreSQL
+      - MySQL
+      - MongoDB
+      - Redis
+      - Elasticsearch
+      - Kafka
+      - RabbitMQ
+      - Memcached
+      - LDAP
+      - Kerberos
+      - SNMP
+      - Syslog
+    iot-categories:
+      - IoT-Scada
+      - Cloud

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -171,6 +171,10 @@ tracepcap:
     max-clusters: ${INTELLIGENCE_MAX_CLUSTERS:60}   # Max cluster nodes returned per groupBy request
     max-edges: ${INTELLIGENCE_MAX_EDGES:200}         # Max edges returned per groupBy request
   device-classification:
+    # nDPI application/category names used to infer host device types.
+    # When a conversation's detected app matches an entry here, it adds weight
+    # to that device type during classification. Edit these lists to tune
+    # classification without recompiling.
     mobile-apps:
       - Instagram
       - TikTok

--- a/frontend/src/components/common/DeviceClassificationPopup/DeviceClassificationPopup.tsx
+++ b/frontend/src/components/common/DeviceClassificationPopup/DeviceClassificationPopup.tsx
@@ -39,8 +39,9 @@ export function DeviceClassificationPopup({ info, onClose }: DeviceClassificatio
         maxWidth: '380px',
         boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
         borderRadius: '8px',
-        backgroundColor: '#fff',
-        border: '1px solid #dee2e6',
+        backgroundColor: 'var(--tp-surface)',
+        border: '1px solid var(--tp-border)',
+        color: 'var(--tp-text)',
       }}
     >
       {/* Header */}
@@ -89,7 +90,7 @@ export function DeviceClassificationPopup({ info, onClose }: DeviceClassificatio
               <div>
                 <span className="badge bg-secondary">{typeLabel}</span>
                 {typeNote && (
-                  <div className="mt-1" style={{ fontSize: '0.75rem', color: '#6c757d' }}>
+                  <div className="mt-1 text-muted" style={{ fontSize: '0.75rem' }}>
                     {typeNote}
                   </div>
                 )}
@@ -108,7 +109,7 @@ export function DeviceClassificationPopup({ info, onClose }: DeviceClassificatio
               {deviceTypeLabel(info.deviceType)}
             </span>
             {signals.length > 0 && (
-              <ul className="mb-1 ps-3 mt-1" style={{ fontSize: '0.75rem', color: '#6c757d' }}>
+              <ul className="mb-1 ps-3 mt-1 text-muted" style={{ fontSize: '0.75rem' }}>
                 {signals.map((s, i) => (
                   <li key={i}>{s}</li>
                 ))}
@@ -118,7 +119,7 @@ export function DeviceClassificationPopup({ info, onClose }: DeviceClassificatio
               <div
                 style={{
                   flex: 1,
-                  background: '#e9ecef',
+                  background: 'var(--tp-bg-subtle)',
                   borderRadius: '4px',
                   height: '4px',
                   overflow: 'hidden',
@@ -133,7 +134,7 @@ export function DeviceClassificationPopup({ info, onClose }: DeviceClassificatio
                   }}
                 />
               </div>
-              <span style={{ fontSize: '0.72rem', color: '#6c757d', whiteSpace: 'nowrap' }}>
+              <span className="text-muted" style={{ fontSize: '0.72rem', whiteSpace: 'nowrap' }}>
                 {info.confidence}% — {level}
               </span>
             </div>
@@ -150,7 +151,7 @@ export function DeviceClassificationPopup({ info, onClose }: DeviceClassificatio
               <span className={`badge ${info.role === 'client' ? 'bg-primary' : 'bg-success'}`}>
                 {info.role.charAt(0).toUpperCase() + info.role.slice(1)}
               </span>
-              <div className="mt-1" style={{ fontSize: '0.75rem', color: '#6c757d' }}>
+              <div className="mt-1 text-muted" style={{ fontSize: '0.75rem' }}>
                 {info.role === 'client'
                   ? 'Initiated this conversation'
                   : 'Received this conversation'}

--- a/frontend/src/components/common/ScrollableTable/ScrollableTable.css
+++ b/frontend/src/components/common/ScrollableTable/ScrollableTable.css
@@ -1,9 +1,9 @@
 /* Top phantom scrollbar — sits above the table, synced via JS */
 .sct-top-scrollbar {
   overflow: scroll hidden;
-  height: 12px;
+  height: 6px;
   scrollbar-width: thin;
-  scrollbar-color: var(--tp-scrollbar, #adb5bd) transparent;
+  scrollbar-color: var(--tp-scrollbar, #adb5bd) var(--tp-border, #dee2e6);
 }
 
 .sct-top-scrollbar::-webkit-scrollbar {
@@ -11,7 +11,7 @@
 }
 
 .sct-top-scrollbar::-webkit-scrollbar-track {
-  background: var(--tp-bg-subtle, #f1f3f5);
+  background: var(--tp-border, #dee2e6);
   border-radius: 3px;
 }
 

--- a/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
+++ b/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
@@ -89,14 +89,14 @@ function GeoSourceBadge({ source }: { source?: string }) {
             top: popoverPos.top,
             left: popoverPos.left,
             zIndex: 9999,
-            background: '#fff',
-            border: '1px solid #dee2e6',
+            background: 'var(--tp-surface)',
+            border: '1px solid var(--tp-border)',
             borderRadius: 6,
             boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
             padding: '10px 12px',
             width: 260,
             fontSize: 11,
-            color: '#212529',
+            color: 'var(--tp-text)',
           }}
           onClick={e => e.stopPropagation()}
         >

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -213,36 +213,32 @@ export function NetworkControls({
   return (
     <>
       <div className="nc-filter-panel">
-        <div className="card">
-          {/* Card header — click anywhere to toggle */}
-          <div
-            className="card-header d-flex justify-content-between align-items-center"
-            style={{ cursor: 'pointer' }}
+        {/* Toggle button */}
+        <div className="d-flex align-items-center gap-2">
+          <button
+            type="button"
+            className="btn btn-outline-secondary btn-sm"
             onClick={() => setIsOpen(o => !o)}
           >
-            <div className="d-flex align-items-center gap-2">
-              <strong>Filters</strong>
-              {activeFilterCount > 0 && (
-                <span className="badge bg-primary">{activeFilterCount}</span>
-              )}
-            </div>
-            <div className="d-flex align-items-center gap-2">
-              <button
-                className="btn btn-link btn-sm p-0 text-muted"
-                onClick={e => {
-                  e.stopPropagation();
-                  setShowColorInfo(true);
-                }}
-                title="How are node colours determined?"
-              >
-                <i className="bi bi-info-circle me-1"></i>Node colours
-              </button>
-              <i className={`bi ${isOpen ? 'bi-chevron-up' : 'bi-chevron-down'} text-muted`} />
-            </div>
-          </div>
+            <i className="bi bi-funnel me-1"></i>
+            Filters
+            {activeFilterCount > 0 && (
+              <span className="badge bg-primary ms-2">{activeFilterCount}</span>
+            )}
+            <i className={`bi ms-2 ${isOpen ? 'bi-chevron-up' : 'bi-chevron-down'}`}></i>
+          </button>
+          <button
+            className="btn btn-link btn-sm p-0 text-muted"
+            onClick={() => setShowColorInfo(true)}
+            title="How are node colours determined?"
+          >
+            <i className="bi bi-info-circle me-1"></i>Node colours
+          </button>
+        </div>
 
-          {/* Collapsible body */}
-          {isOpen && (
+        {/* Collapsible panel */}
+        {isOpen && (
+          <div className="card mt-2">
             <div className="card-body p-3">
               <div className="row g-3">
                 {/* IP / Hostname */}
@@ -813,8 +809,8 @@ export function NetworkControls({
                 </div>
               )}
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
 
       {/* Node colour priority modal */}
@@ -846,41 +842,25 @@ export function NetworkControls({
                 </p>
                 <ol className="ps-3" style={{ lineHeight: '2' }}>
                   <li>
-                    <span
-                      className="badge me-2"
-                      style={{ backgroundColor: NODE_TYPE_COLORS['anomaly'], color: '#fff' }}
-                    >
-                      Anomaly
-                    </span>
-                    <strong>Anomaly detected</strong> — always shown in red regardless of type.
+                    <span className="badge me-2" style={{ backgroundColor: NODE_TYPE_COLORS['dns-server'], color: '#fff' }}>DNS</span>
+                    <span className="badge me-2" style={{ backgroundColor: NODE_TYPE_COLORS['web-server'], color: '#fff' }}>Web</span>
+                    <span className="badge me-2" style={{ backgroundColor: NODE_TYPE_COLORS['router'], color: '#fff' }}>Router</span>
+                    <strong>Specific server role</strong> — the node's dominant inbound port identifies it as a known server type (DNS, web, SSH, FTP, mail, DHCP, NTP, database, router). Each type has a fixed colour.
                   </li>
                   <li>
-                    <span className="badge bg-warning text-dark me-2">Specific server role</span>
-                    <strong>Port-based server classification</strong> — DNS, web, SSH, FTP, mail,
-                    DHCP, NTP, database, and router nodes keep their dedicated colours.
+                    <span className="badge me-2" style={{ backgroundColor: '#8b5cf6', color: '#fff' }}>Mobile</span>
+                    <span className="badge me-2" style={{ backgroundColor: '#0ea5e9', color: '#fff' }}>IoT</span>
+                    <strong>Device classification</strong> — inferred from MAC OUI vendor lookup, TTL fingerprinting, and observed nDPI application profiles. Overrides generic node type when a non-unknown device type is detected.
                   </li>
                   <li>
-                    <span
-                      className="badge me-2"
-                      style={{ backgroundColor: '#8b5cf6', color: '#fff' }}
-                    >
-                      Device type
-                    </span>
-                    <strong>Device classification</strong> — Mobile, Laptop/Desktop, IoT, etc.
+                    <span className="badge me-2" style={{ backgroundColor: NODE_TYPE_COLORS['client'], color: '#fff' }}>Client</span>
+                    <strong>Generic node type</strong> — nodes that only initiate outbound connections with no dominant inbound port are classified as clients and shown in blue.
                   </li>
                   <li>
-                    <span
-                      className="badge me-2"
-                      style={{ backgroundColor: NODE_TYPE_COLORS['client'], color: '#fff' }}
-                    >
-                      Client
-                    </span>
-                    <strong>Generic node type</strong> — port-based classification colour.
-                  </li>
-                  <li>
-                    <span className="badge bg-secondary me-2">Role fallback</span>
-                    <strong>Traffic role</strong> — green for server, purple for both, grey
-                    otherwise.
+                    <span className="badge me-2" style={{ backgroundColor: '#2ecc71', color: '#fff' }}>Server</span>
+                    <span className="badge me-2" style={{ backgroundColor: '#9b59b6', color: '#fff' }}>Both</span>
+                    <span className="badge bg-secondary me-2">Other</span>
+                    <strong>Traffic role fallback</strong> — if no type can be determined, nodes are coloured by their observed role: green if they only receive connections (server), purple if they both send and receive (both), grey otherwise.
                   </li>
                 </ol>
               </div>

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -848,8 +848,8 @@ export function NetworkControls({
                     <strong>Specific server role</strong> — the node's dominant inbound port identifies it as a known server type (DNS, web, SSH, FTP, mail, DHCP, NTP, database, router). Each type has a fixed colour.
                   </li>
                   <li>
-                    <span className="badge me-2" style={{ backgroundColor: '#8b5cf6', color: '#fff' }}>Mobile</span>
-                    <span className="badge me-2" style={{ backgroundColor: '#0ea5e9', color: '#fff' }}>IoT</span>
+                    <span className="badge me-2" style={{ backgroundColor: deviceTypeColor('MOBILE'), color: '#fff' }}>Mobile</span>
+                    <span className="badge me-2" style={{ backgroundColor: deviceTypeColor('IOT'), color: '#fff' }}>IoT</span>
                     <strong>Device classification</strong> — inferred from MAC OUI vendor lookup, TTL fingerprinting, and observed nDPI application profiles. Overrides generic node type when a non-unknown device type is detected.
                   </li>
                   <li>

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -274,7 +274,7 @@ export const AnalysisPage = () => {
       {/* Navigation Tabs */}
       <ul
         className="nav nav-tabs"
-        style={{ flexWrap: 'nowrap', overflowX: 'auto', display: 'flex', borderBottom: 'none', paddingTop: '1px' }}
+        style={{ display: 'flex', flexWrap: 'wrap', borderBottom: 'none', paddingTop: '1px' }}
       >
         <li className="nav-item">
           <button


### PR DESCRIPTION
Closes #241

## Summary
- **Nav tabs**: fixed horizontal scroll — tabs now wrap to next row
- **Network Intelligence filter**: collapse button now matches Conversations tab design (`btn-outline-secondary` with funnel icon + chevron)
- **Top scrollbar**: height reduced to 6px; track uses `--tp-border` so it's visually distinct from the page background
- **Dark mode popovers**: `DeviceClassificationPopup` and geo-source popover replaced hardcoded `#fff`/`#212529` with `var(--tp-surface)`, `var(--tp-border)`, `var(--tp-text)`
- **Node colour tooltip**: removed stale Anomaly entry (never implemented in `getNodeColor`); rewrote four entries with accurate how-it-works descriptions

## Test plan
- [ ] Nav tabs wrap on narrow screen, no horizontal scroll
- [ ] Network Intelligence filter button matches Conversations filter button style
- [ ] Top scrollbar track is visible and distinct from background
- [ ] Device classification popup renders correctly in dark mode
- [ ] Node colour info modal shows 4 entries (no Anomaly), descriptions accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)