### PR TITLE
refactor: consolidate deviceType.ts switch statements into DEVICE_TYPE_CONFIG (#155)

### DIFF
--- a/frontend/src/utils/deviceType.ts
+++ b/frontend/src/utils/deviceType.ts
@@ -1,46 +1,33 @@
 import type { DeviceType } from '@/types';
 
+interface DeviceTypeConfig {
+  label: string;
+  color: string;
+}
+
+const DEVICE_TYPE_CONFIG: Record<string, DeviceTypeConfig> = {
+  ROUTER:         { label: 'Router',           color: '#f97316' }, // orange
+  MOBILE:         { label: 'Mobile',           color: '#8b5cf6' }, // violet
+  LAPTOP_DESKTOP: { label: 'Laptop / Desktop', color: '#3b82f6' }, // blue
+  SERVER:         { label: 'Server',           color: '#10b981' }, // emerald
+  IOT:            { label: 'IoT Device',       color: '#ec4899' }, // pink
+  UNKNOWN:        { label: 'Unknown',          color: '#6b7280' }, // gray
+};
+
+const DEFAULT_CONFIG: DeviceTypeConfig = { label: '', color: '#6b7280' };
+
 /**
  * Returns a human-readable label for the device type.
  */
 export function deviceTypeLabel(deviceType: DeviceType): string {
-  switch (deviceType) {
-    case 'ROUTER':
-      return 'Router';
-    case 'MOBILE':
-      return 'Mobile';
-    case 'LAPTOP_DESKTOP':
-      return 'Laptop / Desktop';
-    case 'SERVER':
-      return 'Server';
-    case 'IOT':
-      return 'IoT Device';
-    case 'UNKNOWN':
-      return 'Unknown';
-    default:
-      return deviceType; // custom YAML override values pass through as-is
-  }
+  return DEVICE_TYPE_CONFIG[deviceType]?.label ?? deviceType; // custom YAML override values pass through as-is
 }
 
 /**
  * Returns a hex colour for the device type (used in NetworkDiagram nodes).
  */
 export function deviceTypeColor(deviceType: DeviceType): string {
-  switch (deviceType) {
-    case 'ROUTER':
-      return '#f97316'; // orange
-    case 'MOBILE':
-      return '#8b5cf6'; // violet
-    case 'LAPTOP_DESKTOP':
-      return '#3b82f6'; // blue
-    case 'SERVER':
-      return '#10b981'; // emerald
-    case 'IOT':
-      return '#ec4899'; // pink
-    case 'UNKNOWN':
-    default:
-      return '#6b7280'; // gray
-  }
+  return (DEVICE_TYPE_CONFIG[deviceType] ?? DEFAULT_CONFIG).color;
 }
 
 /**

--- a/frontend/src/utils/deviceType.ts
+++ b/frontend/src/utils/deviceType.ts
@@ -5,7 +5,7 @@ interface DeviceTypeConfig {
   color: string;
 }
 
-const DEVICE_TYPE_CONFIG: Record<string, DeviceTypeConfig> = {
+const DEVICE_TYPE_CONFIG: Partial<Record<DeviceType, DeviceTypeConfig>> = {
   ROUTER:         { label: 'Router',           color: '#f97316' }, // orange
   MOBILE:         { label: 'Mobile',           color: '#8b5cf6' }, // violet
   LAPTOP_DESKTOP: { label: 'Laptop / Desktop', color: '#3b82f6' }, // blue
@@ -14,7 +14,7 @@ const DEVICE_TYPE_CONFIG: Record<string, DeviceTypeConfig> = {
   UNKNOWN:        { label: 'Unknown',          color: '#6b7280' }, // gray
 };
 
-const DEFAULT_CONFIG: DeviceTypeConfig = { label: '', color: '#6b7280' };
+const DEFAULT_COLOR = '#6b7280';
 
 /**
  * Returns a human-readable label for the device type.
@@ -27,7 +27,7 @@ export function deviceTypeLabel(deviceType: DeviceType): string {
  * Returns a hex colour for the device type (used in NetworkDiagram nodes).
  */
 export function deviceTypeColor(deviceType: DeviceType): string {
-  return (DEVICE_TYPE_CONFIG[deviceType] ?? DEFAULT_CONFIG).color;
+  return DEVICE_TYPE_CONFIG[deviceType]?.color ?? DEFAULT_COLOR;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replaces two `switch` statements (`deviceTypeLabel`, `deviceTypeColor`) with a single `DEVICE_TYPE_CONFIG` record
- Public API (`deviceTypeLabel`, `deviceTypeColor`, `DEVICE_TYPES`) is unchanged — all call sites continue to work without modification
- Adding a new device type now requires updating exactly one place instead of two

Closes #155

## Test plan

- [ ] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] All 6 device types render correct label / colour in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)