### PR TITLE
feat: gzip/deflate payload decompression in session reconstruction (#209)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/dto/SessionResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/SessionResponse.java
@@ -107,8 +107,17 @@ public class SessionResponse {
     /** True when the body contained non-printable bytes (body field will be null). */
     private boolean bodyBinary;
 
-    /** True when the body was gzip-encoded and successfully decompressed. */
+    /** True when the body was content-encoded and successfully decompressed. */
     private boolean bodyDecompressed;
+
+    /**
+     * The original Content-Encoding value (e.g. "gzip", "deflate", "br") when decompression was
+     * applied, otherwise null.
+     */
+    private String bodyEncoding;
+
+    /** Compressed byte length before decompression; 0 when not decompressed. */
+    private long bodyCompressedLength;
 
     /** True when the body was trimmed to the display limit. */
     private boolean bodyTruncated;

--- a/backend/src/main/java/com/tracepcap/analysis/service/SessionReconstructionService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SessionReconstructionService.java
@@ -986,8 +986,9 @@ public class SessionReconstructionService {
       return iis.readAllBytes();
     } catch (Exception e) {
       // Fall back to raw deflate (no zlib wrapper).
-      try (InflaterInputStream iis =
-          new InflaterInputStream(new ByteArrayInputStream(data), new Inflater(true))) {
+      try (Inflater inflater = new Inflater(true);
+          InflaterInputStream iis =
+              new InflaterInputStream(new ByteArrayInputStream(data), inflater)) {
         return iis.readAllBytes();
       } catch (Exception e2) {
         return null;

--- a/backend/src/main/java/com/tracepcap/analysis/service/SessionReconstructionService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SessionReconstructionService.java
@@ -9,6 +9,8 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -895,13 +897,23 @@ public class SessionReconstructionService {
 
     long actualBodyLength = bodyBytes.length;
 
-    // Handle gzip/deflate
+    // Handle content-encoding (gzip / deflate)
     boolean decompressed = false;
-    String contentEncoding = headers.getOrDefault("content-encoding", "");
-    if (contentEncoding.toLowerCase().contains("gzip") && bodyBytes.length > 0) {
-      byte[] decompressed_ = tryDecompress(bodyBytes);
-      if (decompressed_ != null) {
-        bodyBytes = decompressed_;
+    String bodyEncoding = null;
+    long bodyCompressedLength = 0;
+    String contentEncoding = headers.getOrDefault("content-encoding", "").toLowerCase();
+    if (bodyBytes.length > 0 && !contentEncoding.isEmpty()) {
+      byte[] result = null;
+      if (contentEncoding.contains("gzip")) {
+        result = tryDecompressGzip(bodyBytes);
+        if (result != null) bodyEncoding = "gzip";
+      } else if (contentEncoding.contains("deflate")) {
+        result = tryDecompressDeflate(bodyBytes);
+        if (result != null) bodyEncoding = "deflate";
+      }
+      if (result != null) {
+        bodyCompressedLength = bodyBytes.length;
+        bodyBytes = result;
         actualBodyLength = bodyBytes.length;
         decompressed = true;
       }
@@ -922,6 +934,8 @@ public class SessionReconstructionService {
         .body(bodyText)
         .bodyBinary(binary)
         .bodyDecompressed(decompressed)
+        .bodyEncoding(bodyEncoding)
+        .bodyCompressedLength(bodyCompressedLength)
         .bodyTruncated(bodyTruncated)
         .bodyLength(actualBodyLength)
         .build();
@@ -958,11 +972,26 @@ public class SessionReconstructionService {
     }
   }
 
-  private byte[] tryDecompress(byte[] data) {
+  private byte[] tryDecompressGzip(byte[] data) {
     try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(data))) {
       return gzip.readAllBytes();
     } catch (Exception e) {
       return null;
+    }
+  }
+
+  private byte[] tryDecompressDeflate(byte[] data) {
+    // Try zlib-wrapped deflate first (RFC 7230 recommends this format).
+    try (InflaterInputStream iis = new InflaterInputStream(new ByteArrayInputStream(data))) {
+      return iis.readAllBytes();
+    } catch (Exception e) {
+      // Fall back to raw deflate (no zlib wrapper).
+      try (InflaterInputStream iis =
+          new InflaterInputStream(new ByteArrayInputStream(data), new Inflater(true))) {
+        return iis.readAllBytes();
+      } catch (Exception e2) {
+        return null;
+      }
     }
   }
 

--- a/frontend/src/components/conversation/SessionTab/SessionTab.tsx
+++ b/frontend/src/components/conversation/SessionTab/SessionTab.tsx
@@ -135,7 +135,9 @@ function HttpMessageBlock({
         <code style={{ fontSize: '0.8rem', color: '#fff', flex: 1 }}>{message.firstLine}</code>
         {message.bodyDecompressed && (
           <span className="badge bg-light text-dark" style={{ fontSize: '0.65rem' }}>
-            gzip decoded
+            {message.bodyEncoding ?? 'compressed'} decoded
+            {message.bodyCompressedLength > 0 &&
+              ` (${formatBytes(message.bodyCompressedLength)} → ${formatBytes(message.bodyLength)})`}
           </span>
         )}
       </div>

--- a/frontend/src/features/conversation/services/conversationService.ts
+++ b/frontend/src/features/conversation/services/conversationService.ts
@@ -153,6 +153,8 @@ export interface HttpMessage {
   body: string | null;
   bodyBinary: boolean;
   bodyDecompressed: boolean;
+  bodyEncoding: string | null;
+  bodyCompressedLength: number;
   bodyTruncated: boolean;
   bodyLength: number;
 }

--- a/frontend/src/utils/formatters/index.ts
+++ b/frontend/src/utils/formatters/index.ts
@@ -10,7 +10,8 @@ export const formatBytes = (bytes: number): string => {
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
-  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
+  const value = bytes / Math.pow(k, i);
+  return `${i === 0 ? value : value.toFixed(2)} ${sizes[i]}`;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds `deflate` decompression (zlib-wrapped, with raw deflate fallback) alongside the existing `gzip` support in `SessionReconstructionService`
- Tracks `bodyEncoding` (e.g. `"gzip"`, `"deflate"`) and `bodyCompressedLength` in the `HttpMessage` DTO so the frontend knows what was decoded and how large the compressed payload was
- Updates the decompression badge in the session view to show e.g. **`gzip decoded (105 B → 94 B)`** instead of just `"gzip decoded"`
- Fixes `formatBytes` to omit decimals for byte-sized values (`105 B` instead of `105.00 B`)

## Test plan

- Upload `sample-files/test_gzip_deflate.pcap` (included in repo — contains two HTTP exchanges, one gzip and one deflate)
- Open the session view for the `10.0.0.1:54321 ↔ 10.0.0.2:80` conversation
- Verify both response bodies are decoded and the badge shows the correct encoding and sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)