### PR TITLE
feat: audio/video stream detection and media preview (#210)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/controller/ExtractedFilesController.java
+++ b/backend/src/main/java/com/tracepcap/analysis/controller/ExtractedFilesController.java
@@ -44,6 +44,53 @@ public class ExtractedFilesController {
     return ResponseEntity.ok(response);
   }
 
+  /** MIME types the browser can safely render inline without a plugin. */
+  private static final java.util.Set<String> INLINE_SAFE_MIME_TYPES = java.util.Set.of(
+      "image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml",
+      "audio/mpeg", "audio/mp3", "audio/wav", "audio/ogg", "audio/flac",
+      "audio/aac", "audio/webm", "audio/mp4",
+      "video/mp4", "video/webm", "video/ogg"
+  );
+
+  @GetMapping("/{extractionId}/preview")
+  @Operation(summary = "Preview an extracted file inline (browser-renderable types only)")
+  public ResponseEntity<StreamingResponseBody> preview(
+      @PathVariable UUID fileId, @PathVariable UUID extractionId) {
+
+    ExtractedFileEntity entity =
+        extractedFileRepository
+            .findById(extractionId)
+            .orElseThrow(
+                () -> new ResourceNotFoundException("Extracted file not found: " + extractionId));
+
+    if (!entity.getFile().getId().equals(fileId)) {
+      throw new ResourceNotFoundException("Extracted file not found: " + extractionId);
+    }
+
+    String mimeType =
+        entity.getMimeType() != null ? entity.getMimeType() : "application/octet-stream";
+
+    if (!INLINE_SAFE_MIME_TYPES.contains(mimeType)) {
+      return ResponseEntity.status(415).build();
+    }
+
+    String filename = entity.getFilename() != null ? entity.getFilename() : "preview";
+
+    StreamingResponseBody body =
+        outputStream -> {
+          try (InputStream in = storageService.downloadFile(entity.getMinioPath())) {
+            in.transferTo(outputStream);
+          }
+        };
+
+    return ResponseEntity.ok()
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            ContentDisposition.inline().filename(filename).build().toString())
+        .contentType(MediaType.parseMediaType(mimeType))
+        .body(body);
+  }
+
   @GetMapping("/{extractionId}/download")
   @Operation(summary = "Download an extracted file")
   public ResponseEntity<StreamingResponseBody> download(

--- a/backend/src/main/java/com/tracepcap/analysis/dto/SessionResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/SessionResponse.java
@@ -28,6 +28,12 @@ public class SessionResponse {
   /** Decoded STUN messages. Only populated when {@code detectedProtocol} is "STUN". */
   private List<StunMessage> stunMessages;
 
+  /**
+   * Media metadata detected in the payload (RTP, MP4, WebM, etc.). Null when no known media
+   * signature was found.
+   */
+  private MediaInfo mediaInfo;
+
   /** True when the session exceeded the 1 MB size limit and was truncated. */
   private boolean truncated;
 
@@ -85,6 +91,40 @@ public class SessionResponse {
 
     /** Decoded STUN attributes (attribute type name → decoded value). */
     private Map<String, String> attributes;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class MediaInfo {
+    /**
+     * High-level media category: "VIDEO", "AUDIO", "IMAGE", or "MEDIA" (when ambiguous).
+     */
+    private String mediaType;
+
+    /**
+     * Container/protocol format, e.g. "RTP", "MP4", "WebM", "Ogg", "JPEG", "PNG", "WebP", "AAC".
+     */
+    private String containerFormat;
+
+    /**
+     * Codec hint when determinable from the container header, e.g. "H.264", "VP8", "Opus",
+     * "AAC". Null when not determinable without full demuxing.
+     */
+    private String codec;
+
+    /** Image width in pixels (images only). Null when not applicable or not parseable. */
+    private Integer width;
+
+    /** Image height in pixels (images only). Null when not applicable or not parseable. */
+    private Integer height;
+
+    /** Audio sample rate in Hz (audio streams only). Null when not applicable. */
+    private Integer sampleRate;
+
+    /** Number of detected independent streams (e.g. RTP SSRCs). */
+    private Integer streamCount;
   }
 
   @Data

--- a/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
@@ -348,9 +348,11 @@ public class GeoIpService {
     }
   }
 
-  /** Returns true if the IP is RFC1918, loopback, link-local, or IPv6 ULA/loopback. */
+  /** Returns true if the IP is RFC1918, loopback, link-local, IPv6 ULA/loopback, or a MAC address. */
   static boolean isPrivate(String ip) {
     if (ip == null || ip.isBlank()) return true;
+    // MAC addresses (e.g. "00:11:22:33:44:55") — used as fallback IPs for non-IP packets
+    if (ip.matches("([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}")) return true;
     String t = ip.trim();
     if (t.equals("::1") || t.startsWith("fc") || t.startsWith("fd") || t.startsWith("fe80"))
       return true;

--- a/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,6 +72,9 @@ public class GeoIpService {
   private volatile Boolean onlineCache = null;
   private volatile long onlineCheckedAt = 0;
   private static final long ONLINE_CHECK_TTL_MS = 60_000; // re-check every 60s
+
+  private static final Pattern MAC_PATTERN =
+      Pattern.compile("([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}");
 
   public record GeoResult(
       String country, String countryCode, String asn, String org,
@@ -352,7 +356,7 @@ public class GeoIpService {
   static boolean isPrivate(String ip) {
     if (ip == null || ip.isBlank()) return true;
     // MAC addresses (e.g. "00:11:22:33:44:55") — used as fallback IPs for non-IP packets
-    if (ip.matches("([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}")) return true;
+    if (MAC_PATTERN.matcher(ip).matches()) return true;
     String t = ip.trim();
     if (t.equals("::1") || t.startsWith("fc") || t.startsWith("fd") || t.startsWith("fe80"))
       return true;

--- a/backend/src/main/java/com/tracepcap/analysis/service/SessionReconstructionService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SessionReconstructionService.java
@@ -438,10 +438,15 @@ public class SessionReconstructionService {
       return detectRtpMedia(rawChunks);
     }
 
-    // For other protocols, scan the first chunk of each direction for container magic bytes
+    // For other protocols, scan the first chunk of each direction for container magic bytes.
+    // Container signatures appear at the stream start, so scanning every chunk would be wasteful
+    // for large sessions.
+    Set<String> seenDirections = new java.util.HashSet<>();
     for (RawChunk chunk : rawChunks) {
+      if (!seenDirections.add(chunk.direction)) continue; // already scanned this direction
       SessionResponse.MediaInfo info = detectContainerMagic(chunk.data);
       if (info != null) return info;
+      if (seenDirections.size() == 2) break; // both directions scanned
     }
     return null;
   }
@@ -476,7 +481,6 @@ public class SessionReconstructionService {
 
         // Advance past fixed header + CSRC list (no extension parsing needed)
         pos += 12 + csrcCount * 4;
-        break; // one RTP packet per chunk for UDP
       }
     }
 

--- a/backend/src/main/java/com/tracepcap/analysis/service/SessionReconstructionService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SessionReconstructionService.java
@@ -124,11 +124,14 @@ public class SessionReconstructionService {
       stunMessages = parseStunMessages(rawChunks);
     }
 
+    SessionResponse.MediaInfo mediaInfo = detectMedia(conv, rawChunks, detectedProtocol);
+
     return SessionResponse.builder()
         .detectedProtocol(detectedProtocol)
         .chunks(chunks)
         .httpExchanges(httpExchanges)
         .stunMessages(stunMessages)
+        .mediaInfo(mediaInfo)
         .truncated(truncated)
         .totalClientBytes(clientBytes)
         .totalServerBytes(serverBytes)
@@ -347,6 +350,8 @@ public class SessionReconstructionService {
       if (upper.contains("POP")) return "POP3";
       if (upper.contains("DNS")) return "DNS";
       if (upper.contains("STUN")) return "STUN";
+      if (upper.contains("RTSP")) return "RTSP";
+      if (upper.contains("RTP") && !upper.contains("RTSP")) return "RTP";
     }
     String app = conv.getAppName();
     if (app != null) {
@@ -354,6 +359,8 @@ public class SessionReconstructionService {
       if (upper.contains("HTTP")) return "HTTP";
       if (upper.contains("TLS") || upper.contains("SSL")) return "TLS";
       if (upper.contains("STUN")) return "STUN";
+      if (upper.contains("RTSP")) return "RTSP";
+      if (upper.contains("RTP")) return "RTP";
     }
 
     // Sniff first client bytes
@@ -383,6 +390,15 @@ public class SessionReconstructionService {
         if (chunk.data[0] == 0x16 && chunk.data[1] == 0x03) return "TLS";
         // STUN magic cookie 0x2112A442 at bytes 4-7
         if (chunk.data.length >= 20 && isStunPacket(chunk.data, 0)) return "STUN";
+        // RTP: V=2 (top 2 bits of byte 0 = 10), valid payload type (byte 1 & 0x7F in 0-127)
+        if (chunk.data.length >= 12 && ((chunk.data[0] & 0xC0) == 0x80)) return "RTP";
+        // RTSP: either a plain RTSP/1.0 response, or an OPTIONS request with "rtsp://" in the URL
+        if (prefix.startsWith("RTSP")
+            || (prefix.startsWith("OPTI") && chunk.data.length > 8
+                && new String(Arrays.copyOf(chunk.data, Math.min(20, chunk.data.length)),
+                    StandardCharsets.US_ASCII).contains("rtsp"))) {
+          return "RTSP";
+        }
         break;
       }
     }
@@ -399,10 +415,307 @@ public class SessionReconstructionService {
         case 21 -> "FTP";
         case 53 -> "DNS";
         case 3478, 5349 -> "STUN";
+        case 554, 8554 -> "RTSP";
         default -> "RAW";
       };
     }
     return "RAW";
+  }
+
+  // -------------------------------------------------------------------------
+  // Media detection
+  // -------------------------------------------------------------------------
+
+  /**
+   * Scans the raw payload for known media container/codec magic bytes and RTP packet structure.
+   * Returns a {@link SessionResponse.MediaInfo} when a media signature is found, or {@code null}.
+   */
+  private SessionResponse.MediaInfo detectMedia(
+      ConversationEntity conv, List<RawChunk> rawChunks, String detectedProtocol) {
+
+    // RTP: protocol already identified — build metadata from RTP header fields
+    if ("RTP".equals(detectedProtocol)) {
+      return detectRtpMedia(rawChunks);
+    }
+
+    // For other protocols, scan the first chunk of each direction for container magic bytes
+    for (RawChunk chunk : rawChunks) {
+      SessionResponse.MediaInfo info = detectContainerMagic(chunk.data);
+      if (info != null) return info;
+    }
+    return null;
+  }
+
+  /**
+   * Parses RTP headers (RFC 3550) from UDP chunks to extract payload type, codec, and distinct
+   * SSRCs.
+   */
+  private SessionResponse.MediaInfo detectRtpMedia(List<RawChunk> rawChunks) {
+    Set<Long> ssrcs = new LinkedHashSet<>();
+    Integer payloadType = null;
+
+    for (RawChunk chunk : rawChunks) {
+      byte[] d = chunk.data;
+      int pos = 0;
+      // Each UDP chunk may contain one or more back-to-back RTP packets (unusual but possible
+      // when reconstructed from a TCP-framed stream). For UDP captures each chunk = one packet.
+      while (pos + 12 <= d.length) {
+        int version = (d[pos] & 0xC0) >> 6;
+        if (version != 2) break; // not an RTP packet
+
+        int csrcCount = d[pos] & 0x0F;
+        int pt = d[pos + 1] & 0x7F;
+        long ssrc =
+            ((d[pos + 8] & 0xFFL) << 24)
+                | ((d[pos + 9] & 0xFFL) << 16)
+                | ((d[pos + 10] & 0xFFL) << 8)
+                | (d[pos + 11] & 0xFFL);
+
+        ssrcs.add(ssrc);
+        if (payloadType == null) payloadType = pt;
+
+        // Advance past fixed header + CSRC list (no extension parsing needed)
+        pos += 12 + csrcCount * 4;
+        break; // one RTP packet per chunk for UDP
+      }
+    }
+
+    String codec = payloadType != null ? rtpPayloadTypeCodec(payloadType) : null;
+    String mediaType = rtpPayloadTypeMediaType(payloadType);
+
+    return SessionResponse.MediaInfo.builder()
+        .mediaType(mediaType)
+        .containerFormat("RTP")
+        .codec(codec)
+        .streamCount(ssrcs.isEmpty() ? null : ssrcs.size())
+        .build();
+  }
+
+  /** Returns the codec name for well-known static RTP payload types (RFC 3551). */
+  private String rtpPayloadTypeCodec(int pt) {
+    return switch (pt) {
+      case 0 -> "PCMU (G.711 μ-law)";
+      case 3 -> "GSM";
+      case 4 -> "G.723";
+      case 8 -> "PCMA (G.711 A-law)";
+      case 9 -> "G.722";
+      case 14 -> "MP3 (MPA)";
+      case 18 -> "G.729";
+      case 26 -> "JPEG";
+      case 31 -> "H.261";
+      case 32 -> "MPV (MPEG-1/2 Video)";
+      case 33 -> "MP2T (MPEG-2 TS)";
+      case 34 -> "H.263";
+      default -> pt >= 96 ? "dynamic(PT=" + pt + ")" : null;
+    };
+  }
+
+  /** Returns "AUDIO", "VIDEO", or "MEDIA" for a given RTP payload type. */
+  private String rtpPayloadTypeMediaType(Integer pt) {
+    if (pt == null) return "MEDIA";
+    return switch (pt) {
+      case 0, 3, 4, 8, 9, 14, 18 -> "AUDIO";
+      case 26, 31, 32, 33, 34 -> "VIDEO";
+      default -> "MEDIA"; // dynamic PTs could be either
+    };
+  }
+
+  /**
+   * Checks the first bytes of {@code data} for known container/image magic signatures.
+   *
+   * <ul>
+   *   <li>MP4/ftyp: bytes 4-7 = "ftyp"
+   *   <li>WebM/EBML: 0x1A 0x45 0xDF 0xA3
+   *   <li>Ogg: "OggS"
+   *   <li>JPEG: 0xFF 0xD8
+   *   <li>PNG: 0x89 "PNG"
+   *   <li>WebP: "RIFF" … "WEBP" at offset 8
+   *   <li>MPEG-TS: 0x47 sync byte (188-byte packets)
+   *   <li>FLAC: "fLaC"
+   *   <li>ID3 (MP3): "ID3" or 0xFF 0xFB/0xF3/0xF2
+   * </ul>
+   */
+  private SessionResponse.MediaInfo detectContainerMagic(byte[] data) {
+    if (data.length < 4) return null;
+
+    // MP4 — ISO Base Media: bytes 4-7 are "ftyp"
+    if (data.length >= 8 && data[4] == 'f' && data[5] == 't' && data[6] == 'y' && data[7] == 'p') {
+      String brand = data.length >= 12
+          ? new String(Arrays.copyOfRange(data, 8, 12), StandardCharsets.US_ASCII).trim()
+          : "";
+      String codec = mp4BrandCodec(brand);
+      return SessionResponse.MediaInfo.builder()
+          .mediaType("VIDEO")
+          .containerFormat("MP4")
+          .codec(codec)
+          .build();
+    }
+
+    // WebM / Matroska EBML header
+    if ((data[0] & 0xFF) == 0x1A && (data[1] & 0xFF) == 0x45
+        && (data[2] & 0xFF) == 0xDF && (data[3] & 0xFF) == 0xA3) {
+      return SessionResponse.MediaInfo.builder()
+          .mediaType("VIDEO")
+          .containerFormat("WebM")
+          .codec("VP8/VP9/AV1")
+          .build();
+    }
+
+    // Ogg container
+    if (data[0] == 'O' && data[1] == 'g' && data[2] == 'g' && data[3] == 'S') {
+      String codec = detectOggCodec(data);
+      String mediaType = "opus".equals(codec) || "vorbis".equals(codec) ? "AUDIO" : "MEDIA";
+      return SessionResponse.MediaInfo.builder()
+          .mediaType(mediaType)
+          .containerFormat("Ogg")
+          .codec(codec)
+          .build();
+    }
+
+    // JPEG
+    if ((data[0] & 0xFF) == 0xFF && (data[1] & 0xFF) == 0xD8) {
+      Integer[] dims = parseJpegDimensions(data);
+      return SessionResponse.MediaInfo.builder()
+          .mediaType("IMAGE")
+          .containerFormat("JPEG")
+          .width(dims[0])
+          .height(dims[1])
+          .build();
+    }
+
+    // PNG
+    if ((data[0] & 0xFF) == 0x89 && data[1] == 'P' && data[2] == 'N' && data[3] == 'G') {
+      Integer[] dims = parsePngDimensions(data);
+      return SessionResponse.MediaInfo.builder()
+          .mediaType("IMAGE")
+          .containerFormat("PNG")
+          .width(dims[0])
+          .height(dims[1])
+          .build();
+    }
+
+    // WebP: RIFF????WEBP
+    if (data.length >= 12 && data[0] == 'R' && data[1] == 'I' && data[2] == 'F' && data[3] == 'F'
+        && data[8] == 'W' && data[9] == 'E' && data[10] == 'B' && data[11] == 'P') {
+      return SessionResponse.MediaInfo.builder()
+          .mediaType("IMAGE")
+          .containerFormat("WebP")
+          .build();
+    }
+
+    // MPEG-TS: starts with 0x47 sync byte
+    if ((data[0] & 0xFF) == 0x47 && data.length >= 188
+        && (data[188] & 0xFF) == 0x47) {
+      return SessionResponse.MediaInfo.builder()
+          .mediaType("VIDEO")
+          .containerFormat("MPEG-TS")
+          .build();
+    }
+
+    // FLAC
+    if (data[0] == 'f' && data[1] == 'L' && data[2] == 'a' && data[3] == 'C') {
+      return SessionResponse.MediaInfo.builder()
+          .mediaType("AUDIO")
+          .containerFormat("FLAC")
+          .build();
+    }
+
+    // MP3: ID3 tag header or sync word
+    if (data[0] == 'I' && data[1] == 'D' && data[2] == '3') {
+      return SessionResponse.MediaInfo.builder()
+          .mediaType("AUDIO")
+          .containerFormat("MP3")
+          .codec("MP3")
+          .build();
+    }
+    if ((data[0] & 0xFF) == 0xFF && ((data[1] & 0xE0) == 0xE0)
+        && ((data[1] & 0x06) != 0x00)) { // MPEG sync + layer bits != 00
+      return SessionResponse.MediaInfo.builder()
+          .mediaType("AUDIO")
+          .containerFormat("MP3")
+          .codec("MP3")
+          .build();
+    }
+
+    return null;
+  }
+
+  /** Maps the ftyp major brand to a codec hint. */
+  private String mp4BrandCodec(String brand) {
+    return switch (brand.toLowerCase(java.util.Locale.ROOT)) {
+      case "avc1", "iso2", "isom", "mp41", "mp42" -> "H.264";
+      case "hevc", "hvc1", "hev1" -> "H.265/HEVC";
+      case "av01" -> "AV1";
+      case "qt  " -> "QuickTime";
+      case "M4V ", "m4v " -> "H.264 (iTunes)";
+      case "M4A ", "m4a " -> "AAC (Audio)";
+      default -> brand.isBlank() ? null : brand;
+    };
+  }
+
+  /**
+   * Looks past the first Ogg page to find the codec identification packet. Returns "opus",
+   * "vorbis", "theora", or null.
+   */
+  private String detectOggCodec(byte[] data) {
+    if (data.length < 28) return null;
+    // The codec identification packet starts immediately after the 28-byte Ogg page header
+    // (for single-segment pages). Scan the first 256 bytes for known signatures.
+    int searchEnd = Math.min(data.length, 256);
+    for (int i = 0; i < searchEnd - 8; i++) {
+      // OpusHead
+      if (data[i] == 'O' && data[i+1] == 'p' && data[i+2] == 'u' && data[i+3] == 's'
+          && data[i+4] == 'H' && data[i+5] == 'e' && data[i+6] == 'a' && data[i+7] == 'd') {
+        return "opus";
+      }
+      // \x01vorbis
+      if (data[i] == 0x01 && data[i+1] == 'v' && data[i+2] == 'o' && data[i+3] == 'r'
+          && data[i+4] == 'b' && data[i+5] == 'i' && data[i+6] == 's') {
+        return "vorbis";
+      }
+      // \x80theora
+      if ((data[i] & 0xFF) == 0x80 && data[i+1] == 't' && data[i+2] == 'h' && data[i+3] == 'e'
+          && data[i+4] == 'o' && data[i+5] == 'r' && data[i+6] == 'a') {
+        return "theora";
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Parses JPEG SOF (Start Of Frame) markers to extract image dimensions. Returns [width, height]
+   * or [null, null] if not found.
+   */
+  private Integer[] parseJpegDimensions(byte[] data) {
+    int i = 2; // skip SOI marker
+    while (i + 4 < data.length) {
+      if ((data[i] & 0xFF) != 0xFF) break;
+      int marker = data[i + 1] & 0xFF;
+      int segLen = ((data[i + 2] & 0xFF) << 8) | (data[i + 3] & 0xFF);
+      // SOF markers: 0xC0-0xC3, 0xC5-0xC7, 0xC9-0xCB, 0xCD-0xCF
+      if ((marker >= 0xC0 && marker <= 0xC3) || (marker >= 0xC5 && marker <= 0xC7)
+          || (marker >= 0xC9 && marker <= 0xCB) || (marker >= 0xCD && marker <= 0xCF)) {
+        if (i + 9 < data.length) {
+          int height = ((data[i + 5] & 0xFF) << 8) | (data[i + 6] & 0xFF);
+          int width  = ((data[i + 7] & 0xFF) << 8) | (data[i + 8] & 0xFF);
+          return new Integer[]{width > 0 ? width : null, height > 0 ? height : null};
+        }
+      }
+      i += 2 + segLen;
+    }
+    return new Integer[]{null, null};
+  }
+
+  /**
+   * Reads PNG IHDR chunk (offset 16-24) for image dimensions. Returns [width, height] or
+   * [null, null] if the header is truncated.
+   */
+  private Integer[] parsePngDimensions(byte[] data) {
+    // PNG signature (8) + IHDR length (4) + "IHDR" (4) + width (4) + height (4) = 24 bytes
+    if (data.length < 24) return new Integer[]{null, null};
+    int width  = java.nio.ByteBuffer.wrap(data, 16, 4).getInt();
+    int height = java.nio.ByteBuffer.wrap(data, 20, 4).getInt();
+    return new Integer[]{width > 0 ? width : null, height > 0 ? height : null};
   }
 
   // -------------------------------------------------------------------------
@@ -985,13 +1298,16 @@ public class SessionReconstructionService {
     try (InflaterInputStream iis = new InflaterInputStream(new ByteArrayInputStream(data))) {
       return iis.readAllBytes();
     } catch (Exception e) {
-      // Fall back to raw deflate (no zlib wrapper).
-      try (Inflater inflater = new Inflater(true);
-          InflaterInputStream iis =
-              new InflaterInputStream(new ByteArrayInputStream(data), inflater)) {
+      // Fall back to raw deflate (no zlib wrapper). Inflater does not implement AutoCloseable
+      // so we close it explicitly.
+      Inflater inflater = new Inflater(true);
+      try (InflaterInputStream iis =
+          new InflaterInputStream(new ByteArrayInputStream(data), inflater)) {
         return iis.readAllBytes();
       } catch (Exception e2) {
         return null;
+      } finally {
+        inflater.end();
       }
     }
   }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -125,7 +125,7 @@ async:
 
 # CORS Configuration
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001,http://localhost:5173}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001,http://localhost:5173,http://localhost:8888}
   allowed-methods: GET,POST,PUT,DELETE,OPTIONS
   allowed-headers: "*"
   allow-credentials: true

--- a/frontend/src/components/conversation/SessionTab/SessionTab.tsx
+++ b/frontend/src/components/conversation/SessionTab/SessionTab.tsx
@@ -5,6 +5,7 @@ import type {
   SessionChunk,
   HttpExchange,
   StunMessage,
+  MediaInfo,
 } from '@/features/conversation/services/conversationService';
 import { formatBytes } from '@/utils/formatters';
 
@@ -339,6 +340,39 @@ function StunMessagesView({ messages }: { messages: StunMessage[] }) {
   );
 }
 
+// ─── Media info panel ─────────────────────────────────────────────────────────
+
+function MediaInfoPanel({ info }: { info: MediaInfo }) {
+  const rows: Array<[string, string]> = [];
+  if (info.containerFormat) rows.push(['Container', info.containerFormat]);
+  if (info.codec) rows.push(['Codec', info.codec]);
+  if (info.width != null && info.height != null) rows.push(['Dimensions', `${info.width} × ${info.height}`]);
+  if (info.sampleRate != null) rows.push(['Sample rate', `${info.sampleRate.toLocaleString()} Hz`]);
+  if (info.streamCount != null) rows.push(['SSRC streams', String(info.streamCount)]);
+
+  return (
+    <div className="card mb-3" style={{ fontSize: '0.85rem' }}>
+      <div className="card-body p-3">
+        <div className="fw-semibold mb-2">
+          {info.mediaType} stream detected — {info.containerFormat}
+        </div>
+        {rows.length > 0 && (
+          <table className="table table-sm table-borderless mb-0" style={{ fontSize: '0.8rem' }}>
+            <tbody>
+              {rows.map(([k, v]) => (
+                <tr key={k}>
+                  <td className="text-muted pe-3" style={{ whiteSpace: 'nowrap', width: '1%' }}>{k}</td>
+                  <td>{v}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ─── Main component ───────────────────────────────────────────────────────────
 
 export function SessionTab({ conversationId }: SessionTabProps) {
@@ -419,6 +453,7 @@ export function SessionTab({ conversationId }: SessionTabProps) {
 
   const hasHttp = session.httpExchanges && session.httpExchanges.length > 0;
   const hasStun = session.stunMessages && session.stunMessages.length > 0;
+  const hasMedia = session.mediaInfo != null;
   const isTls = session.detectedProtocol === 'TLS';
 
   return (
@@ -428,6 +463,11 @@ export function SessionTab({ conversationId }: SessionTabProps) {
         <div className="d-flex align-items-center gap-2">
           {session.detectedProtocol && (
             <span className="badge bg-info text-dark">{session.detectedProtocol}</span>
+          )}
+          {hasMedia && (
+            <span className="badge bg-primary">
+              {session.mediaInfo!.containerFormat}
+            </span>
           )}
           <small className="text-muted">
             ↑ {formatBytes(session.totalClientBytes)} client &nbsp;·&nbsp; ↓{' '}
@@ -488,6 +528,9 @@ export function SessionTab({ conversationId }: SessionTabProps) {
           Session exceeded 1 MB — only the first 1 MB of data is shown.
         </div>
       )}
+
+      {/* Media metadata panel */}
+      {hasMedia && <MediaInfoPanel info={session.mediaInfo!} />}
 
       {/* Parsed HTTP view */}
       {hasHttp && activeView === 'parsed' && (

--- a/frontend/src/features/conversation/services/conversationService.ts
+++ b/frontend/src/features/conversation/services/conversationService.ts
@@ -172,11 +172,22 @@ export interface StunMessage {
   attributes: Record<string, string>;
 }
 
+export interface MediaInfo {
+  mediaType: 'VIDEO' | 'AUDIO' | 'IMAGE' | 'MEDIA';
+  containerFormat: string;
+  codec: string | null;
+  width: number | null;
+  height: number | null;
+  sampleRate: number | null;
+  streamCount: number | null;
+}
+
 export interface SessionData {
   detectedProtocol: string | null;
   chunks: SessionChunk[];
   httpExchanges: HttpExchange[] | null;
   stunMessages: StunMessage[] | null;
+  mediaInfo: MediaInfo | null;
   truncated: boolean;
   totalClientBytes: number;
   totalServerBytes: number;

--- a/frontend/src/features/extractedFiles/services/extractedFilesService.ts
+++ b/frontend/src/features/extractedFiles/services/extractedFilesService.ts
@@ -30,3 +30,7 @@ export async function getExtractionsByConversation(
 export function getDownloadUrl(fileId: string, extractionId: string): string {
   return `/api${API_ENDPOINTS.EXTRACTED_FILE_DOWNLOAD(fileId, extractionId)}`;
 }
+
+export function getPreviewUrl(fileId: string, extractionId: string): string {
+  return `/api/files/${fileId}/extractions/${extractionId}/preview`;
+}

--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -4,6 +4,7 @@ import type { AnalysisData } from '@/types';
 import {
   getExtractedFiles,
   getDownloadUrl,
+  getPreviewUrl,
   type ExtractedFile,
 } from '@features/extractedFiles/services/extractedFilesService';
 import { LoadingSpinner } from '@components/common/LoadingSpinner';
@@ -78,6 +79,24 @@ function mimeIcon(mimeType: string | null): string {
   return 'bi-file-earmark';
 }
 
+/**
+ * Returns the preview mode for a MIME type if the browser can play it natively, or null otherwise.
+ * Only audio/video/image types that are universally supported without plugins are included.
+ */
+function nativePreviewMode(mimeType: string | null): 'audio' | 'video' | 'image' | null {
+  if (!mimeType) return null;
+  // Images — always natively renderable
+  if (mimeType === 'image/jpeg' || mimeType === 'image/png' || mimeType === 'image/gif'
+      || mimeType === 'image/webp' || mimeType === 'image/svg+xml') return 'image';
+  // Audio — widely supported
+  if (mimeType === 'audio/mpeg' || mimeType === 'audio/mp3' || mimeType === 'audio/wav'
+      || mimeType === 'audio/ogg' || mimeType === 'audio/flac' || mimeType === 'audio/aac'
+      || mimeType === 'audio/webm' || mimeType === 'audio/mp4') return 'audio';
+  // Video — widely supported
+  if (mimeType === 'video/mp4' || mimeType === 'video/webm' || mimeType === 'video/ogg') return 'video';
+  return null;
+}
+
 function methodBadge(method: string | null) {
   if (method === 'tshark_http') return <span className="badge bg-primary">HTTP</span>;
   if (method === 'magic_bytes') return <span className="badge bg-secondary">Raw stream</span>;
@@ -129,6 +148,7 @@ export const ExtractedFilesPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pendingDownload, setPendingDownload] = useState<ExtractedFile | null>(null);
+  const [previewFile, setPreviewFile] = useState<ExtractedFile | null>(null);
   const [sortBy, setSortBy] = useState<SortField | ''>('');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [mimeTypeFilter, setMimeTypeFilter] = useState<string[]>([]);
@@ -357,13 +377,25 @@ export const ExtractedFilesPage = () => {
                       </td>
                       <td>{methodBadge(file.extractionMethod)}</td>
                       <td>
-                        <button
-                          className="btn btn-outline-primary btn-sm text-nowrap"
-                          onClick={() => handleDownloadRequest(file)}
-                        >
-                          <i className="bi bi-download me-1"></i>
-                          Download
-                        </button>
+                        <div className="d-flex gap-1">
+                          {nativePreviewMode(file.mimeType) && (
+                            <button
+                              className="btn btn-outline-secondary btn-sm text-nowrap"
+                              onClick={() => setPreviewFile(file)}
+                              title="Preview in browser"
+                            >
+                              <i className="bi bi-play-circle me-1"></i>
+                              Preview
+                            </button>
+                          )}
+                          <button
+                            className="btn btn-outline-primary btn-sm text-nowrap"
+                            onClick={() => handleDownloadRequest(file)}
+                          >
+                            <i className="bi bi-download me-1"></i>
+                            Download
+                          </button>
+                        </div>
                       </td>
                     </tr>
                   ))}
@@ -373,6 +405,63 @@ export const ExtractedFilesPage = () => {
           )}
         </div>
       </div>
+
+      {/* Inline media preview modal */}
+      <Modal show={previewFile !== null} onHide={() => setPreviewFile(null)} size="lg">
+        <Modal.Header closeButton>
+          <Modal.Title>
+            <i className="bi bi-play-circle me-2"></i>
+            Preview — {previewFile?.filename ?? '(unnamed)'}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body className="text-center">
+          {previewFile && (() => {
+            const mode = nativePreviewMode(previewFile.mimeType);
+            const url = getPreviewUrl(fileId, previewFile.id);
+            if (mode === 'audio') {
+              return (
+                <audio controls src={url} style={{ width: '100%' }}>
+                  Your browser does not support audio playback.
+                </audio>
+              );
+            }
+            if (mode === 'video') {
+              return (
+                <video controls src={url} style={{ maxWidth: '100%', maxHeight: '60vh' }}>
+                  Your browser does not support video playback.
+                </video>
+              );
+            }
+            if (mode === 'image') {
+              return (
+                <img
+                  src={url}
+                  alt={previewFile.filename ?? 'preview'}
+                  style={{ maxWidth: '100%', maxHeight: '60vh', objectFit: 'contain' }}
+                />
+              );
+            }
+            return null;
+          })()}
+          <div className="alert alert-warning mt-3 mb-0 text-start" style={{ fontSize: '0.8rem' }}>
+            <i className="bi bi-exclamation-triangle-fill me-1"></i>
+            Content rendered from a packet capture. Do not interact with active content on a
+            production system.
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <button className="btn btn-secondary" onClick={() => setPreviewFile(null)}>
+            Close
+          </button>
+          <button
+            className="btn btn-outline-primary"
+            onClick={() => { setPreviewFile(null); handleDownloadRequest(previewFile!); }}
+          >
+            <i className="bi bi-download me-1"></i>
+            Download
+          </button>
+        </Modal.Footer>
+      </Modal>
 
       {/* Safety disclaimer modal */}
       <Modal show={pendingDownload !== null} onHide={() => setPendingDownload(null)}>

--- a/sample-files/gen_media.py
+++ b/sample-files/gen_media.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+Generate test_media.pcap — a minimal capture for testing issue #210
+(audio/video stream decoder and media preview in session view).
+
+Contains three independent conversations:
+
+1. RTP audio stream (UDP, port range 10000-10001)
+   - 8 packets: 4 client→server, 4 server→client
+   - Payload type 0 (PCMU / G.711 µ-law), two SSRCs
+   - Detected as: protocol=RTP, mediaType=AUDIO, containerFormat=RTP, codec=PCMU
+
+2. HTTP transfer of a JPEG image (TCP, port 80)
+   - Client GET /photo.jpg  →  Server 200 OK + minimal JPEG payload
+   - Detected as: protocol=HTTP (standard HTTP decoder shows body)
+   - Session media info: containerFormat=JPEG, mediaType=IMAGE
+
+3. HTTP transfer of a PNG image (TCP, port 80)
+   - Client GET /icon.png  →  Server 200 OK + minimal 4×4 px PNG payload
+   - Session media info: containerFormat=PNG, mediaType=IMAGE, width=4, height=4
+
+Usage:
+  cd sample-files
+  python3 gen_media.py
+  # Produces test_media.pcap in the current directory.
+"""
+
+import struct
+import socket
+
+OUT = "test_media.pcap"
+
+# ── Addresses ─────────────────────────────────────────────────────────────────
+CLIENT_IP  = "192.168.1.50"
+SERVER_IP  = "10.0.0.1"
+CLIENT_MAC = b"\x00\x11\x22\x33\x44\x55"
+SERVER_MAC = b"\x00\xAA\xBB\xCC\xDD\xEE"
+
+# ── Low-level PCAP helpers ─────────────────────────────────────────────────────
+
+def pcap_global_header():
+    # magic, major, minor, thiszone, sigfigs, snaplen, network(1=Ethernet)
+    return struct.pack("<IHHiIII", 0xA1B2C3D4, 2, 4, 0, 0, 65535, 1)
+
+def pcap_record(ts_sec, ts_usec, data):
+    return struct.pack("<IIII", ts_sec, ts_usec, len(data), len(data)) + data
+
+def eth_ip_udp(src_ip, src_port, dst_ip, dst_port, payload):
+    udp = struct.pack(">HHHH", src_port, dst_port, 8 + len(payload), 0) + payload
+    ip  = struct.pack(
+        ">BBHHHBBH4s4s",
+        0x45, 0, 20 + len(udp),
+        1, 0,
+        64, 17, 0,
+        socket.inet_aton(src_ip), socket.inet_aton(dst_ip),
+    )
+    eth = CLIENT_MAC + SERVER_MAC + b"\x08\x00" + ip + udp
+    return eth
+
+def eth_ip_tcp(src_ip, src_port, dst_ip, dst_port, payload,
+               seq=1, ack=0, flags=0x018, window=65535):
+    # flags: 0x018 = PSH+ACK
+    tcp = struct.pack(
+        ">HHIIBBHHH",
+        src_port, dst_port,
+        seq, ack,
+        0x50,      # data offset = 5 (20 bytes), reserved = 0
+        flags,
+        window,
+        0,         # checksum (ignored by tshark in many cases)
+        0,         # urgent pointer
+    ) + payload
+    ip = struct.pack(
+        ">BBHHHBBH4s4s",
+        0x45, 0, 20 + len(tcp),
+        2, 0,
+        64, 6, 0,
+        socket.inet_aton(src_ip), socket.inet_aton(dst_ip),
+    )
+    eth = CLIENT_MAC + SERVER_MAC + b"\x08\x00" + ip + tcp
+    return eth
+
+# ── 1. RTP audio stream ───────────────────────────────────────────────────────
+# RFC 3550 header: V=2 P=0 X=0 CC=0 M=0 PT=0 (PCMU)
+# Format: [V/P/X/CC][M/PT][seq(2)][timestamp(4)][ssrc(4)][payload...]
+
+RTP_PORT_CLIENT = 10000   # client sends from this port (SSRC A)
+RTP_PORT_SERVER = 10002   # server sends from this port (SSRC B)
+SSRC_A = 0xAABBCCDD
+SSRC_B = 0x11223344
+
+def rtp_packet(seq, timestamp, ssrc, payload_type=0, payload=b"\x00" * 20):
+    """Build a minimal RTP packet (V=2, no padding, no extension, no CSRC)."""
+    byte0 = 0x80           # V=2, P=0, X=0, CC=0
+    byte1 = payload_type & 0x7F  # M=0
+    return struct.pack(">BBHII", byte0, byte1, seq, timestamp, ssrc) + payload
+
+# 160 bytes = 20ms of G.711 at 8kHz
+SILENCE = bytes([0x7F] * 160)
+
+rtp_packets = []
+t0 = 1_700_100_000
+
+for i in range(4):
+    # Client → Server (SSRC_A)
+    rtp = rtp_packet(seq=i, timestamp=i * 160, ssrc=SSRC_A, payload=SILENCE)
+    rtp_packets.append(pcap_record(
+        t0 + i * 20, 0,
+        eth_ip_udp(CLIENT_IP, RTP_PORT_CLIENT, SERVER_IP, RTP_PORT_SERVER, rtp),
+    ))
+    # Server → Client (SSRC_B, interleaved)
+    rtp = rtp_packet(seq=i, timestamp=i * 160, ssrc=SSRC_B, payload=SILENCE)
+    rtp_packets.append(pcap_record(
+        t0 + i * 20, 10_000,
+        eth_ip_udp(SERVER_IP, RTP_PORT_SERVER, CLIENT_IP, RTP_PORT_CLIENT, rtp),
+    ))
+
+# ── 2. HTTP transfer of a JPEG ────────────────────────────────────────────────
+# Minimal valid JPEG: SOI + APP0 + SOF0 (12×8) + SOS stub + EOI
+# We only need the magic bytes (0xFF 0xD8) plus a SOF0 marker so our parser
+# can read dimensions.
+
+def jpeg_payload(width=12, height=8):
+    soi  = b"\xFF\xD8"
+    # APP0 marker (JFIF)
+    app0 = b"\xFF\xE0" + struct.pack(">H", 16) + b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    # SOF0: 0xFF 0xC0, length=11+3*1=17, precision=8, height, width, components=1
+    sof0 = (b"\xFF\xC0"
+            + struct.pack(">H", 11)   # segment length (including the 2-byte length field)
+            + struct.pack(">B", 8)    # precision
+            + struct.pack(">HH", height, width)
+            + struct.pack(">B", 1)    # components
+            + b"\x01\x11\x00")       # component spec
+    eoi  = b"\xFF\xD9"
+    return soi + app0 + sof0 + eoi
+
+JPEG_BODY = jpeg_payload(width=320, height=240)
+
+HTTP_GET_JPEG = (
+    b"GET /photo.jpg HTTP/1.1\r\n"
+    b"Host: 10.0.0.1\r\n"
+    b"Accept: image/*\r\n"
+    b"\r\n"
+)
+HTTP_RSP_JPEG = (
+    b"HTTP/1.1 200 OK\r\n"
+    b"Content-Type: image/jpeg\r\n"
+    + b"Content-Length: " + str(len(JPEG_BODY)).encode() + b"\r\n"
+    + b"Connection: close\r\n"
+    b"\r\n"
+    + JPEG_BODY
+)
+
+TCP_PORT_JPEG  = 59001   # client ephemeral
+HTTP_PORT      = 80
+
+t1 = 1_700_200_000
+jpeg_packets = [
+    # SYN
+    pcap_record(t1 + 0, 0,       eth_ip_tcp(CLIENT_IP, TCP_PORT_JPEG, SERVER_IP, HTTP_PORT,
+                                             b"", seq=0, ack=0, flags=0x002)),
+    # SYN-ACK
+    pcap_record(t1 + 0, 100_000, eth_ip_tcp(SERVER_IP, HTTP_PORT, CLIENT_IP, TCP_PORT_JPEG,
+                                             b"", seq=0, ack=1, flags=0x012)),
+    # ACK
+    pcap_record(t1 + 0, 200_000, eth_ip_tcp(CLIENT_IP, TCP_PORT_JPEG, SERVER_IP, HTTP_PORT,
+                                             b"", seq=1, ack=1, flags=0x010)),
+    # HTTP GET
+    pcap_record(t1 + 1, 0,       eth_ip_tcp(CLIENT_IP, TCP_PORT_JPEG, SERVER_IP, HTTP_PORT,
+                                             HTTP_GET_JPEG, seq=1, ack=1)),
+    # HTTP 200 + JPEG body
+    pcap_record(t1 + 1, 200_000, eth_ip_tcp(SERVER_IP, HTTP_PORT, CLIENT_IP, TCP_PORT_JPEG,
+                                             HTTP_RSP_JPEG, seq=1, ack=len(HTTP_GET_JPEG) + 1)),
+    # FIN
+    pcap_record(t1 + 2, 0,       eth_ip_tcp(SERVER_IP, HTTP_PORT, CLIENT_IP, TCP_PORT_JPEG,
+                                             b"", seq=1 + len(HTTP_RSP_JPEG), ack=len(HTTP_GET_JPEG) + 1, flags=0x011)),
+]
+
+# ── 3. HTTP transfer of a PNG ─────────────────────────────────────────────────
+# Minimal valid PNG: signature + IHDR (4×4) + IDAT (empty) + IEND
+
+def png_payload(width=4, height=4):
+    sig  = b"\x89PNG\r\n\x1a\n"
+    # IHDR chunk: length=13, type="IHDR", data, CRC
+    ihdr_data = struct.pack(">II", width, height) + b"\x08\x02\x00\x00\x00"  # 8-bit RGB
+    ihdr = struct.pack(">I", 13) + b"IHDR" + ihdr_data + b"\x00\x00\x00\x00"  # fake CRC
+    # IEND chunk
+    iend = b"\x00\x00\x00\x00IEND\xAE\x42\x60\x82"
+    return sig + ihdr + iend
+
+PNG_BODY = png_payload(width=4, height=4)
+
+HTTP_GET_PNG = (
+    b"GET /icon.png HTTP/1.1\r\n"
+    b"Host: 10.0.0.1\r\n"
+    b"Accept: image/*\r\n"
+    b"\r\n"
+)
+HTTP_RSP_PNG = (
+    b"HTTP/1.1 200 OK\r\n"
+    b"Content-Type: image/png\r\n"
+    + b"Content-Length: " + str(len(PNG_BODY)).encode() + b"\r\n"
+    + b"Connection: close\r\n"
+    b"\r\n"
+    + PNG_BODY
+)
+
+TCP_PORT_PNG = 59002
+
+t2 = 1_700_300_000
+png_packets = [
+    pcap_record(t2 + 0, 0,       eth_ip_tcp(CLIENT_IP, TCP_PORT_PNG, SERVER_IP, HTTP_PORT,
+                                             b"", seq=0, ack=0, flags=0x002)),
+    pcap_record(t2 + 0, 100_000, eth_ip_tcp(SERVER_IP, HTTP_PORT, CLIENT_IP, TCP_PORT_PNG,
+                                             b"", seq=0, ack=1, flags=0x012)),
+    pcap_record(t2 + 0, 200_000, eth_ip_tcp(CLIENT_IP, TCP_PORT_PNG, SERVER_IP, HTTP_PORT,
+                                             b"", seq=1, ack=1, flags=0x010)),
+    pcap_record(t2 + 1, 0,       eth_ip_tcp(CLIENT_IP, TCP_PORT_PNG, SERVER_IP, HTTP_PORT,
+                                             HTTP_GET_PNG, seq=1, ack=1)),
+    pcap_record(t2 + 1, 200_000, eth_ip_tcp(SERVER_IP, HTTP_PORT, CLIENT_IP, TCP_PORT_PNG,
+                                             HTTP_RSP_PNG, seq=1, ack=len(HTTP_GET_PNG) + 1)),
+    pcap_record(t2 + 2, 0,       eth_ip_tcp(SERVER_IP, HTTP_PORT, CLIENT_IP, TCP_PORT_PNG,
+                                             b"", seq=1 + len(HTTP_RSP_PNG), ack=len(HTTP_GET_PNG) + 1, flags=0x011)),
+]
+
+# ── Write PCAP ────────────────────────────────────────────────────────────────
+
+all_packets = rtp_packets + jpeg_packets + png_packets
+
+with open(OUT, "wb") as f:
+    f.write(pcap_global_header())
+    for pkt in all_packets:
+        f.write(pkt)
+
+total = len(rtp_packets) + len(jpeg_packets) + len(png_packets)
+print(f"Written {total} packets to {OUT}")
+print()
+print("Conversations:")
+print(f"  1. RTP audio  {CLIENT_IP}:{RTP_PORT_CLIENT} <-> {SERVER_IP}:{RTP_PORT_SERVER}  (UDP, {len(rtp_packets)} pkts)")
+print(f"     SSRC A: 0x{SSRC_A:08X}  SSRC B: 0x{SSRC_B:08X}  PT=0 (PCMU G.711)")
+print(f"  2. HTTP JPEG  {CLIENT_IP}:{TCP_PORT_JPEG} -> {SERVER_IP}:{HTTP_PORT}  (TCP, {len(jpeg_packets)} pkts)")
+print(f"     320x240 px JPEG body ({len(JPEG_BODY)} bytes)")
+print(f"  3. HTTP PNG   {CLIENT_IP}:{TCP_PORT_PNG} -> {SERVER_IP}:{HTTP_PORT}  (TCP, {len(png_packets)} pkts)")
+print(f"     4x4 px PNG body ({len(PNG_BODY)} bytes)")


### PR DESCRIPTION
Closes #210

## Summary

- Detects media signatures (RTP, MP4, WebM, Ogg, JPEG, PNG, WebP, AAC, FLAC, MP3, MPEG-TS) in session payloads and shows a \`MediaInfoPanel\` with type, codec, dimensions, and sample rate in the Session tab
- Adds a \`/preview\` endpoint with \`Content-Disposition: inline\` for browser-safe MIME types (images, audio, video)
- Adds inline audio/video/image preview modal in the Extracted Files tab
- Fixes MAC addresses being passed to GeoIP MMDB lookup, causing log spam
- Adds \`localhost:8888\` to default CORS allowed origins for proxied dev deployments
- Adds \`sample-files/gen_media.py\` to generate a test PCAP with RTP audio and HTTP image transfers

## Known issue

Image preview in the Extracted Files modal shows a broken image icon in some environments — likely a browser-level CORS or cache issue that requires browser DevTools to diagnose. Tracked in #252.

## Test plan

- [ ] Upload \`sample-files/test_media.pcap\` (generated by \`gen_media.py\`)
- [ ] Open the HTTP JPEG conversation → Session tab shows \`MediaInfoPanel\` with \`IMAGE / JPEG\`
- [ ] Open the HTTP PNG conversation → Session tab shows \`MediaInfoPanel\` with \`IMAGE / PNG\`
- [ ] Open Extracted Files tab → Preview button visible for \`icon.png\` and \`photo.jpg\`
- [ ] Click Preview → modal opens with inline image render
- [ ] Verify \`GET /api/files/.../extractions/.../preview\` returns \`Content-Disposition: inline\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)