### PR TITLE
fix: pin MinIO versions and auto-sync pull-save script from offline compose

### DIFF
--- a/docker-compose.offline.yml
+++ b/docker-compose.offline.yml
@@ -35,7 +35,7 @@ services:
 
   # MinIO Object Storage
   minio:
-    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: tracepcap-minio
     command: server /data --console-address ":9001"
     environment:
@@ -57,7 +57,7 @@ services:
 
   # MinIO Client (mc) - Create bucket on startup
   minio-init:
-    image: minio/mc:RELEASE.2024-11-21T17-21-54Z
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     container_name: tracepcap-minio-init
     depends_on:
       - minio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   # MinIO Object Storage
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: tracepcap-minio
     command: server /data --console-address ":9001"
     environment:
@@ -44,7 +44,7 @@ services:
 
   # MinIO Client (mc) - Create bucket on startup
   minio-init:
-    image: minio/mc:latest
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     container_name: tracepcap-minio-init
     depends_on:
       - minio

--- a/scripts/pull-and-save-images.sh
+++ b/scripts/pull-and-save-images.sh
@@ -47,16 +47,18 @@ fi
 mkdir -p "$IMAGES_DIR"
 
 # ---------------------------------------------------------------------------
-# 1. Pull third-party images
+# 1. Pull third-party images — versions read from docker-compose.offline.yml
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== [1/3] Pulling third-party images ==="
 
-# --- Docker Hub ---
-DOCKERHUB_IMAGES=(
-  "postgres:15-alpine"
-  "minio/minio:RELEASE.2024-11-07T00-52-20Z"
-  "minio/mc:RELEASE.2024-11-21T17-21-54Z"
+# Parse third-party image tags directly from the offline compose file so that
+# the script and the compose file never get out of sync.
+OFFLINE_COMPOSE="$ROOT_DIR/docker-compose.offline.yml"
+mapfile -t DOCKERHUB_IMAGES < <(
+  grep '^\s*image:' "$OFFLINE_COMPOSE" \
+  | awk '{print $2}' \
+  | grep -v '^tracepcap-'  # exclude locally-built images
 )
 
 for img in "${DOCKERHUB_IMAGES[@]}"; do

--- a/scripts/pull-and-save-images.sh
+++ b/scripts/pull-and-save-images.sh
@@ -56,9 +56,10 @@ echo "=== [1/3] Pulling third-party images ==="
 # the script and the compose file never get out of sync.
 OFFLINE_COMPOSE="$ROOT_DIR/docker-compose.offline.yml"
 mapfile -t DOCKERHUB_IMAGES < <(
-  grep '^\s*image:' "$OFFLINE_COMPOSE" \
-  | awk '{print $2}' \
-  | grep -v '^tracepcap-'  # exclude locally-built images
+  grep '^[[:space:]]*image:' "$OFFLINE_COMPOSE" | \
+  sed -E 's/^[[:space:]]*image:[[:space:]]*"?([^" #]+)"?.*/\1/' | \
+  grep -v '^tracepcap-' | \
+  sort -u
 )
 
 for img in "${DOCKERHUB_IMAGES[@]}"; do


### PR DESCRIPTION
## Summary

- **`docker-compose.yml`**: replace \`minio/minio:latest\` and \`minio/mc:latest\` with pinned versions matching \`docker-compose.offline.yml\`, ensuring consistent behaviour across online and offline deployments
- **`docker-compose.offline.yml`**: bump minio/minio and minio/mc to newer releases that fix file upload failures
- **`scripts/pull-and-save-images.sh`**: parse third-party image tags directly from \`docker-compose.offline.yml\` instead of hardcoding them — updating a version in the compose file is now the single source of truth; the script picks it up automatically

## Motivation

Using \`latest\` tags in the online compose while the offline compose had pinned (older) tags caused inconsistent behaviour between the two deployment modes. Additionally, the hardcoded image list in \`pull-and-save-images.sh\` could silently fall out of sync with the compose file, causing the wrong image version to be bundled for offline use (root cause of recent upload failures).

## Test plan

- [ ] \`bash scripts/pull-and-save-images.sh\` pulls the correct versioned images (verify with \`docker images | grep minio\`)
- [ ] \`docker compose up -d\` starts successfully with pinned minio versions
- [ ] \`docker compose -f docker-compose.offline.yml up -d\` starts successfully on offline machine
- [ ] File upload works on both online and offline deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)