### PR TITLE
docs: scaffold Sphinx documentation site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+  pull_request:
+    paths:
+      - "docs/**"
+
+# Allow only one concurrent deployment
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Sphinx dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build HTML docs
+        run: make -C docs html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html/
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -135,7 +135,18 @@ PCAP, PCAPNG, CAP (max 512MB default, configurable via `MAX_UPLOAD_SIZE_BYTES`)
 
 ## Documentation
 
-API documentation is available via Swagger UI at **http://localhost:80/swagger-ui.html** when the application is running.
+Comprehensive documentation is available in the [`docs/`](docs/) directory, built with Sphinx.
+
+**Build the docs locally:**
+```bash
+pip install -r docs/requirements.txt
+make -C docs html
+# Open docs/_build/html/index.html in your browser
+```
+
+Sections include getting started, feature guides, configuration reference, operations, and API reference.
+
+API documentation is also available via Swagger UI at **http://localhost:80/swagger-ui.html** when the application is running.
 
 ## Common Tasks
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,17 @@
+# Minimal Sphinx Makefile
+
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+.PHONY: help html clean
+
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+html:
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+
+clean:
+	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -1,0 +1,48 @@
+API Reference
+=============
+
+TracePcap exposes a RESTful API documented with **SpringDoc OpenAPI**
+(Swagger UI).
+
+Accessing Swagger UI
+--------------------
+
+When the application is running, navigate to:
+
+``http://localhost:80/swagger-ui.html``
+
+(Replace ``80`` with your configured ``NGINX_PORT``.)
+
+The Swagger UI provides:
+
+- A list of all available endpoints grouped by controller.
+- Request and response schemas.
+- An interactive "Try it out" panel to execute API calls directly from the
+  browser.
+
+OpenAPI Specification
+---------------------
+
+The raw OpenAPI JSON specification is available at:
+
+``http://localhost:80/v3/api-docs``
+
+You can import this into tools like Postman, Insomnia, or any OpenAPI-compatible
+client.
+
+Static API Documentation
+------------------------
+
+A static snapshot of the API documentation is committed to the repository at
+``docs/api/README.md`` for offline reference.
+
+Key Endpoint Groups
+-------------------
+
+- **PCAP files** — upload, list, delete, download, and trigger re-analysis.
+- **Conversations** — query, filter, sort, and export conversations.
+- **Extracted files** — list and download extracted file objects.
+- **Signatures** — read and update the custom signature rule set.
+- **Story** — generate and retrieve AI narrative summaries.
+- **Filters** — generate Wireshark/tcpdump filters from natural language.
+- **Health** — liveness and readiness probes.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,20 @@
+# Configuration file for the Sphinx documentation builder.
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+project = "TracePcap"
+copyright = "2025, TracePcap Contributors"
+author = "TracePcap Contributors"
+release = "1.0"
+
+extensions = []
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = []  # populate when screenshots are added under _static/
+html_logo = None
+html_theme_options = {
+    "navigation_depth": 4,
+    "titles_only": False,
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ copyright = "2025, TracePcap Contributors"
 author = "TracePcap Contributors"
 release = "1.0"
 
-extensions = []
+extensions = ["sphinx_rtd_theme"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -1,0 +1,114 @@
+Environment Variables
+=====================
+
+All configuration is driven by environment variables defined in the ``.env``
+file at the repository root. Copy ``.env.example`` to ``.env`` before starting.
+
+Upload Configuration
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Variable
+     - Default
+     - Description
+   * - ``MAX_UPLOAD_SIZE_BYTES``
+     - ``536870912``
+     - Maximum PCAP file size in bytes (default 512 MB). Applies to both the
+       Spring Boot backend and the nginx reverse proxy.
+
+Nginx Configuration
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Variable
+     - Default
+     - Description
+   * - ``NGINX_PORT``
+     - ``80``
+     - Host port on which nginx listens. Change if port 80 is already in use.
+
+LLM Configuration
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Variable
+     - Default
+     - Description
+   * - ``LLM_API_BASE_URL``
+     - ``http://localhost:1234/v1``
+     - Base URL of an OpenAI-compatible inference API. See
+       :doc:`llm-setup`.
+   * - ``LLM_API_KEY``
+     - *(empty)*
+     - API key sent in the ``Authorization: Bearer`` header. Leave empty for
+       local servers that don't require authentication.
+   * - ``LLM_MODEL``
+     - ``Qwen2.5-14B-Coder-Instruct``
+     - Model identifier passed in each API request. Must match a model loaded
+       on your inference server.
+   * - ``LLM_TEMPERATURE``
+     - ``0.7``
+     - Sampling temperature (0.0–2.0). Lower values produce more deterministic
+       output; higher values more creative output.
+   * - ``LLM_MAX_TOKENS``
+     - ``2000``
+     - Maximum number of tokens the LLM may generate per response.
+
+Map Configuration
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Variable
+     - Default
+     - Description
+   * - ``MAP_POLYGON_FIDELITY``
+     - *(auto)*
+     - Controls the detail level of country/region polygon boundaries rendered
+       on the map view. Higher values increase visual fidelity at the cost of
+       browser rendering time.
+
+Database Configuration (internal)
+----------------------------------
+
+The following variables configure the PostgreSQL connection. They are set
+automatically by Docker Compose and generally do not need to be changed unless
+you are connecting to an external database.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Variable
+     - Description
+   * - ``POSTGRES_DB``
+     - Database name
+   * - ``POSTGRES_USER``
+     - Database user
+   * - ``POSTGRES_PASSWORD``
+     - Database password — **change this in production**
+
+MinIO Configuration (internal)
+-------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Variable
+     - Description
+   * - ``MINIO_ROOT_USER``
+     - MinIO admin username (default ``minioadmin``) — **change in production**
+   * - ``MINIO_ROOT_PASSWORD``
+     - MinIO admin password (default ``minioadmin``) — **change in production**

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -98,6 +98,8 @@ you are connecting to an external database.
      - Database user
    * - ``POSTGRES_PASSWORD``
      - Database password — **change this in production**
+   * - ``SPRING_DATASOURCE_PASSWORD``
+     - Backend database connection password — must match ``POSTGRES_PASSWORD``
 
 MinIO Configuration (internal)
 -------------------------------

--- a/docs/configuration/llm-setup.rst
+++ b/docs/configuration/llm-setup.rst
@@ -1,0 +1,72 @@
+LLM Setup
+=========
+
+TracePcap's AI features (Story Mode and AI Filter Generator) require an
+OpenAI-compatible inference server. Any server that implements the
+``/v1/chat/completions`` endpoint works.
+
+Supported Servers
+-----------------
+
+**LM Studio** (recommended for offline use)
+
+1. Download and install `LM Studio <https://lmstudio.ai>`_.
+2. Download a model (e.g. ``Qwen2.5-14B-Coder-Instruct``).
+3. Start the local server on port ``1234`` (default).
+4. In ``.env``:
+
+   .. code-block:: ini
+
+      LLM_API_BASE_URL=http://localhost:1234/v1
+      LLM_API_KEY=
+      LLM_MODEL=Qwen2.5-14B-Coder-Instruct
+
+**Ollama**
+
+1. Install `Ollama <https://ollama.com>`_.
+2. Pull a model: ``ollama pull qwen2.5-coder:14b``
+3. Ollama serves on port ``11434`` by default.
+4. In ``.env``:
+
+   .. code-block:: ini
+
+      LLM_API_BASE_URL=http://localhost:11434/v1
+      LLM_API_KEY=ollama
+      LLM_MODEL=qwen2.5-coder:14b
+
+**OpenAI API** *(not suitable for offline deployments)*
+
+.. code-block:: ini
+
+   LLM_API_BASE_URL=https://api.openai.com/v1
+   LLM_API_KEY=sk-...
+   LLM_MODEL=gpt-4o
+
+Model Recommendations
+---------------------
+
+For best results with filter generation and narrative analysis, use a model
+with strong instruction-following and code understanding:
+
+- **Qwen2.5-14B-Coder-Instruct** — good balance of quality and speed on CPU.
+- **Qwen2.5-7B-Coder-Instruct** — lighter option for machines with less RAM.
+- **Llama-3.1-8B-Instruct** — general-purpose alternative.
+
+Testing the Connection
+-----------------------
+
+After configuring ``.env`` and restarting the stack, open the **AI Filter**
+tab. If the LLM server is reachable, the text input will be enabled. If it
+shows a warning, check:
+
+1. The inference server is running.
+2. ``LLM_API_BASE_URL`` is correct and reachable from inside the Docker
+   network (use the host's LAN IP, not ``localhost``, if the LLM runs on the
+   same machine but outside Docker).
+3. The model name in ``LLM_MODEL`` matches a loaded model on the server.
+
+.. note::
+
+   If TracePcap runs in Docker and the LLM server runs on the host machine,
+   use ``http://host.docker.internal:1234/v1`` (Docker Desktop) or the host's
+   LAN IP address instead of ``localhost``.

--- a/docs/configuration/signature-rules.rst
+++ b/docs/configuration/signature-rules.rst
@@ -62,7 +62,7 @@ Displayed in the UI as a tooltip on the badge.
 
 Required. One of: ``low``, ``medium``, ``high``, ``critical``.
 
-Controls badge colour. See :doc:`../features/custom-signatures` for the colour
+Controls badge color. See :doc:`../features/custom-signatures` for the color
 mapping.
 
 ``match.ip``

--- a/docs/configuration/signature-rules.rst
+++ b/docs/configuration/signature-rules.rst
@@ -1,0 +1,196 @@
+Signature Rule Authoring Guide
+================================
+
+This page is a deep-dive reference for writing TracePcap custom detection
+rules. For a quick overview, see :doc:`../features/custom-signatures`.
+
+Rule Structure
+--------------
+
+Each rule is a YAML mapping under the top-level ``signatures`` list:
+
+.. code-block:: yaml
+
+   signatures:
+     - name: <string>             # required
+       description: <string>      # optional, shown in UI tooltip
+       severity: <level>          # required: low | medium | high | critical
+       match:                     # optional: one or more match fields (AND)
+         <field>: <value>
+         ...
+       payload_contains:          # optional: payload byte patterns
+         - ascii: <string>
+         - hex: <hex-string>
+       match_all: <bool>          # optional: if true, all payload_contains entries must match
+       device_type: <string>      # optional: pin device type for matched IPs
+
+Execution Semantics
+--------------------
+
+A rule fires for a given conversation when **all** of the following hold:
+
+1. Every field in ``match`` matches the conversation's attributes.
+2. If ``payload_contains`` is present:
+
+   - Default (``match_all`` absent or ``false``): **at least one** pattern
+     matches the payload.
+   - With ``match_all: true``: **all** patterns match the payload.
+
+If both ``match`` and ``payload_contains`` are specified, both conditions
+must be satisfied (AND).
+
+Field Reference
+---------------
+
+``name``
+~~~~~~~~
+
+Required. The identifier shown as a badge in the UI.
+
+- Must be unique across all rules.
+- Use underscores instead of spaces (e.g. ``known_c2_ip``).
+- Avoid special characters.
+
+``description``
+~~~~~~~~~~~~~~~
+
+Optional. A human-readable sentence explaining what the rule detects.
+Displayed in the UI as a tooltip on the badge.
+
+``severity``
+~~~~~~~~~~~~
+
+Required. One of: ``low``, ``medium``, ``high``, ``critical``.
+
+Controls badge colour. See :doc:`../features/custom-signatures` for the colour
+mapping.
+
+``match.ip``
+~~~~~~~~~~~~
+
+Exact match against the conversation's ``srcIp`` **or** ``dstIp``.
+
+.. code-block:: yaml
+
+   match:
+     ip: "203.0.113.42"
+
+``match.cidr``
+~~~~~~~~~~~~~~
+
+CIDR range match against ``srcIp`` **or** ``dstIp``.
+
+.. code-block:: yaml
+
+   match:
+     cidr: "198.51.100.0/24"
+
+Both IPv4 and IPv6 CIDR notation are supported.
+
+``match.srcPort`` / ``match.dstPort``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Exact integer port match against the conversation's source or destination port.
+
+.. code-block:: yaml
+
+   match:
+     srcPort: 67
+     dstPort: 4444
+
+``match.ja3``
+~~~~~~~~~~~~~
+
+Exact match against the JA3S fingerprint hash recorded by nDPI.
+Only populated when nDPI analysis is enabled and a TLS ServerHello is observed.
+
+.. code-block:: yaml
+
+   match:
+     ja3: "82f0d8a75fa483d1cfe4b7085b784d7e"
+
+Obtain hashes from threat intelligence feeds. The ``demo_all_rules.pcap``
+sample file contains a crafted TLS exchange to test JA3 matching.
+
+``match.hostname``
+~~~~~~~~~~~~~~~~~~
+
+Match against the SNI (Server Name Indication) hostname extracted from the
+TLS ClientHello.
+
+- **Exact match**: ``"mobile.pipe.aria.microsoft.com"``
+- **Wildcard prefix**: ``"*.microsoft.com"`` — matches ``foo.microsoft.com``,
+  ``bar.baz.microsoft.com``, etc. (any depth).
+
+.. code-block:: yaml
+
+   match:
+     hostname: "*.evil.example.com"
+
+``match.app``
+~~~~~~~~~~~~~
+
+Case-insensitive match against the nDPI application name
+(e.g. ``"Telegram"``, ``"TOR"``, ``"DNS"``, ``"BitTorrent"``).
+
+``match.protocol``
+~~~~~~~~~~~~~~~~~~
+
+Case-insensitive match against the transport protocol
+(e.g. ``"TCP"``, ``"UDP"``, ``"ICMP"``).
+
+``payload_contains``
+~~~~~~~~~~~~~~~~~~~~
+
+List of byte pattern objects. Each entry has exactly one key:
+
+- ``ascii: "string"`` — search for the UTF-8 bytes of the given string.
+- ``hex: "deadbeef"`` — search for the given hex byte sequence.
+  The ``0x`` prefix and space separators are optional (``"0xDE 0xAD"`` is
+  equivalent to ``"dead"``).
+
+Patterns are searched across the **reassembled payload** of the conversation
+(not just individual packets).
+
+``match_all``
+~~~~~~~~~~~~~
+
+Boolean. Default ``false``. When ``true``, all ``payload_contains`` entries
+must match (AND semantics). When ``false`` or absent, any single entry
+matching is sufficient (OR semantics).
+
+``device_type``
+~~~~~~~~~~~~~~~
+
+Optional string. When the rule fires, all IP addresses involved in the
+matching conversation are assigned this device type in the Network
+Visualization and Conversations filter.
+
+Standard values: ``ROUTER``, ``MOBILE``, ``LAPTOP_DESKTOP``, ``SERVER``,
+``IOT``, ``UNKNOWN``.
+
+Custom strings are accepted (e.g. ``"PLC"``, ``"CCTV Camera"``).
+
+Editing Rules at Runtime
+-------------------------
+
+Rules can be edited without restarting TracePcap:
+
+1. Navigate to **Custom Detection Rules** in the navbar.
+2. Edit the YAML in the browser editor.
+3. Click **Save**.
+4. Re-analyse or upload a new PCAP — the updated rules are applied immediately.
+
+Alternatively, edit ``/app/config/signatures.yml`` directly inside the backend
+container. The file is read fresh on every analysis run.
+
+Validating Rules
+----------------
+
+The browser editor validates YAML syntax on save and highlights errors inline.
+Semantic errors (e.g. invalid severity, malformed CIDR) are reported in the
+backend logs:
+
+.. code-block:: bash
+
+   docker compose logs -f tracepcap-backend

--- a/docs/features/ai-filter-generator.rst
+++ b/docs/features/ai-filter-generator.rst
@@ -1,0 +1,48 @@
+AI Filter Generator
+===================
+
+The AI Filter Generator converts a **natural language query** into a ready-to-use
+**Wireshark display filter** or **tcpdump capture filter** using a locally-hosted
+LLM.
+
+Requirements
+------------
+
+A configured LLM server is required (see :doc:`../configuration/llm-setup`).
+The feature gracefully degrades — if the LLM is unavailable, the input box is
+disabled and a warning is shown.
+
+How to Use
+----------
+
+1. Open the **AI Filter** tab for a PCAP.
+2. Type your query in plain English, for example:
+
+   - *"Show all TLS traffic to external IPs"*
+   - *"Find DNS requests from 192.168.1.5"*
+   - *"Filter out ICMP and show only TCP on port 443"*
+
+3. Click **Generate**.
+4. The LLM returns:
+
+   - A **Wireshark display filter** (e.g. ``tls && !ip.dst == 10.0.0.0/8``).
+   - A **tcpdump capture filter** (e.g. ``port 443 and not net 10.0.0.0/8``).
+   - A **confidence score** (0–100%).
+   - A brief **explanation** of the filter logic.
+
+5. TracePcap immediately applies the generated filter against the PCAP data
+   and shows the **matching packet count** in the results panel below.
+
+Confidence Score
+----------------
+
+The confidence score reflects the LLM's self-assessed certainty that the
+generated filter correctly captures the intent of your query. Scores below
+~60% typically indicate ambiguous queries — consider refining your wording.
+
+Privacy
+-------
+
+Filter queries are sent to whatever ``LLM_API_BASE_URL`` you have configured.
+To keep queries private, use a local inference server (LM Studio, Ollama).
+No query data is sent to Anthropic or any third-party by TracePcap itself.

--- a/docs/features/conversations.rst
+++ b/docs/features/conversations.rst
@@ -1,0 +1,68 @@
+Conversations
+=============
+
+The Conversations tab lists every network flow (conversation) extracted from
+the PCAP file — one row per unique 5-tuple (src IP, dst IP, src port, dst port,
+protocol).
+
+Columns
+-------
+
+The column set is configurable via the **Column Picker** button. Default
+columns include:
+
+- Source IP / Destination IP
+- Source Port / Destination Port
+- Protocol
+- Application (nDPI)
+- Category (nDPI)
+- Risk flags
+- Country (src / dst)
+- Device type (src / dst)
+- Bytes transferred
+- Packet count
+- Start / end timestamp
+- Custom signature matches
+
+Filtering
+---------
+
+The filter bar supports simultaneous filtering on:
+
+- IP address (src, dst, or either)
+- Port (src, dst, or either)
+- Protocol (TCP, UDP, ICMP, …)
+- Application name (nDPI)
+- Risk level
+- Custom signature rule name
+- Device type
+- Country
+- Payload pattern (substring search across reconstructed payloads)
+
+Multiple filters combine with AND logic.
+
+Sorting
+-------
+
+Click any column header to sort ascending; click again for descending.
+Multi-column sorting is supported — hold **Shift** and click a second column.
+
+Pagination
+----------
+
+Results are paginated. The page size is configurable from 10 to 100 rows.
+
+Session Reconstruction
+-----------------------
+
+Click the **eye icon** on any row to open the session reconstruction viewer
+for that conversation — see :doc:`session-reconstruction`.
+
+Export Options
+--------------
+
+- **Per-conversation PCAP** — download a PCAP containing only the packets
+  for a single conversation via the row action menu.
+- **Bulk PCAP export** — select multiple rows (or all) and export them as
+  a combined PCAP.
+- **CSV export** — export the current filtered and sorted view to CSV.

--- a/docs/features/custom-signatures.rst
+++ b/docs/features/custom-signatures.rst
@@ -3,7 +3,7 @@ Custom Signature Rules
 
 TracePcap supports user-defined YAML detection rules that are matched against
 every conversation after nDPI analysis. Matched rule names appear as
-colour-coded badges in the Conversations tab and Overview, alongside nDPI's
+color-coded badges in the Conversations tab and Overview, alongside nDPI's
 built-in detections.
 
 How It Works

--- a/docs/features/custom-signatures.rst
+++ b/docs/features/custom-signatures.rst
@@ -1,0 +1,196 @@
+Custom Signature Rules
+======================
+
+TracePcap supports user-defined YAML detection rules that are matched against
+every conversation after nDPI analysis. Matched rule names appear as
+colour-coded badges in the Conversations tab and Overview, alongside nDPI's
+built-in detections.
+
+How It Works
+------------
+
+Rules are stored inside a Docker named volume (``config_data``) at
+``/app/config/signatures.yml`` inside the backend container. The file is
+reloaded on every analysis run — **no restart is required** after editing.
+
+Click **Custom Detection Rules** in the navbar to open the built-in YAML
+editor. Changes are saved immediately.
+
+.. tip::
+
+   ``signatures.sample.yml`` in the repository root is a reference template
+   covering every match field with annotated examples. Paste it into the
+   browser editor to get started, then modify to suit your environment.
+
+Rule Format
+-----------
+
+.. code-block:: yaml
+
+   signatures:
+     - name: rule_name_shown_in_ui   # badge label — use underscores, no spaces
+       description: Human-readable description
+       severity: low                  # low | medium | high | critical
+       match:
+         ip: "203.0.113.42"           # match against srcIp OR dstIp
+
+A rule fires when **all** specified ``match`` fields are satisfied.
+All fields are optional — mix and match as needed.
+
+Match Fields
+------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 12 45 25
+
+   * - Field
+     - Type
+     - Description
+     - Example
+   * - ``ip``
+     - string
+     - Exact match against srcIp or dstIp
+     - ``"203.0.113.42"``
+   * - ``cidr``
+     - string
+     - CIDR range match against srcIp or dstIp
+     - ``"10.0.0.0/8"``
+   * - ``srcPort``
+     - integer
+     - Exact source port
+     - ``67``
+   * - ``dstPort``
+     - integer
+     - Exact destination port
+     - ``4444``
+   * - ``ja3``
+     - string
+     - Exact JA3S fingerprint hash (nDPI 5.x)
+     - ``"82f0d8a75fa483d1cfe4b7085b784d7e"``
+   * - ``hostname``
+     - string
+     - Exact or wildcard SNI hostname. ``*.evil.com`` matches any subdomain
+       at any depth.
+     - ``"*.evil.com"``
+   * - ``app``
+     - string
+     - Case-insensitive nDPI application name
+     - ``"Telegram"``, ``"TOR"``, ``"DNS"``
+   * - ``protocol``
+     - string
+     - Case-insensitive transport protocol
+     - ``"TCP"``, ``"UDP"``, ``"ICMP"``
+
+Payload Matching
+----------------
+
+In addition to ``match`` fields, rules can search raw packet payloads:
+
+.. code-block:: yaml
+
+   payload_contains:
+     - ascii: "GET /admin"       # plain ASCII text
+     - hex: "255044462d"         # hex bytes (%PDF-)
+
+Multiple ``payload_contains`` entries are **OR-matched** by default. Set
+``match_all: true`` on the rule to require **all** patterns (AND):
+
+.. code-block:: yaml
+
+   - name: http_post_with_token
+     match_all: true
+     payload_contains:
+       - ascii: "POST /"
+       - ascii: "token"
+
+``payload_contains`` can be combined with ``match`` fields — both conditions
+must be satisfied for the rule to fire.
+
+Device Type Override
+--------------------
+
+A rule can pin the device type of all IPs involved in a matching conversation:
+
+.. code-block:: yaml
+
+   - name: cctv_camera
+     description: Known CCTV camera
+     severity: low
+     device_type: "CCTV Camera"
+     match:
+       ip: "192.168.1.50"
+
+Standard values: ``ROUTER``, ``MOBILE``, ``LAPTOP_DESKTOP``, ``SERVER``,
+``IOT``, ``UNKNOWN``. Custom strings (e.g. ``"PLC"``, ``"CCTV Camera"``) are
+also accepted.
+
+Severity Colors
+---------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Severity
+     - Badge color
+   * - ``critical``
+     - Red
+   * - ``high``
+     - Orange
+   * - ``medium``
+     - Amber / Yellow
+   * - ``low``
+     - Purple
+
+Examples
+--------
+
+.. code-block:: yaml
+
+   signatures:
+
+     # Flag a known C2 IP
+     - name: known_c2_ip
+       description: Known command-and-control server
+       severity: high
+       match:
+         ip: "203.0.113.42"
+
+     # Flag all traffic to a suspicious subnet
+     - name: flagged_subnet
+       severity: medium
+       match:
+         cidr: "198.51.100.0/24"
+
+     # Detect DNS over TCP (possible zone transfer or tunnelling)
+     - name: dns_over_tcp
+       severity: medium
+       match:
+         app: "DNS"
+         protocol: TCP
+
+     # Wildcard hostname match
+     - name: blocked_domain
+       severity: high
+       match:
+         hostname: "*.malware.example.com"
+
+     # JA3S fingerprint from a threat-intel feed
+     - name: suspicious_tls_fingerprint
+       severity: critical
+       match:
+         ja3: "a0e9f5d64349fb13191bc781f81f42e1"
+
+     # Cleartext credential detection
+     - name: cleartext_credentials
+       severity: critical
+       payload_contains:
+         - ascii: "Authorization: Basic"
+         - ascii: "password="
+
+See ``signatures.sample.yml`` for a full set of 17 annotated example rules
+covering every match field. The script ``sample-files/gen_demo.py`` generates
+a PCAP that triggers all demo rules at once.
+
+For a deep-dive rule authoring guide, see :doc:`../configuration/signature-rules`.

--- a/docs/features/file-extraction.rst
+++ b/docs/features/file-extraction.rst
@@ -1,0 +1,58 @@
+File Extraction
+===============
+
+File Extraction recovers objects transmitted over the network — images,
+documents, binaries, archives, and more — directly from PCAP payloads.
+
+Enabling Extraction
+-------------------
+
+Enable the **File Extraction** toggle in the upload dialog before submitting
+the PCAP file. Like nDPI analysis, it cannot be added retroactively.
+
+Extraction Methods
+------------------
+
+TracePcap uses two complementary extraction techniques:
+
+HTTP Object Extraction
+~~~~~~~~~~~~~~~~~~~~~~
+
+For HTTP/1.x conversations, the backend parses HTTP response headers and
+extracts the response body as a file object. The original filename (from
+``Content-Disposition``) and MIME type (from ``Content-Type``) are preserved
+where available.
+
+Stream Extraction (Aho-Corasick)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For non-HTTP traffic or when HTTP parsing fails, TracePcap scans raw TCP and
+UDP stream payloads using an **Aho-Corasick** multi-pattern search to locate
+known file magic bytes (e.g. ``%PDF-``, ``PK\x03\x04`` for ZIP, ``\xFF\xD8``
+for JPEG, …). Matching byte sequences are carved out as candidate files.
+
+MIME Detection
+--------------
+
+Every extracted file is passed through automatic MIME type detection based on
+its content (magic bytes), independent of any filename extension or HTTP
+header. This ensures correct identification even when headers are absent or
+misleading.
+
+Viewing Extracted Files
+-----------------------
+
+Go to the **Extracted Files** tab for a PCAP. Each file is listed with:
+
+- Filename (original or auto-generated)
+- MIME type
+- Size
+- Source conversation (src IP : src port → dst IP : dst port)
+- Extraction method (HTTP / stream)
+
+Bulk Download
+-------------
+
+Select multiple files and click **Download Selected** to receive them in a
+ZIP archive. Individual files can be downloaded directly via the row action
+button.

--- a/docs/features/geolocation.rst
+++ b/docs/features/geolocation.rst
@@ -1,0 +1,63 @@
+Geolocation & Device Classification
+=====================================
+
+Geolocation
+-----------
+
+TracePcap enriches every external (non-RFC-1918) IP address with country and
+ASN (Autonomous System Number) information.
+
+The geolocation database is bundled inside the Docker image — no internet
+connection is required at runtime.
+
+Data Shown
+~~~~~~~~~~
+
+- **Country** — ISO 3166-1 alpha-2 code and flag displayed inline.
+- **ASN** — Autonomous System number and organisation name.
+
+These fields appear in:
+
+- The **Conversations** tab (src country, dst country columns).
+- The **Network Visualization** — flag badge on external host nodes.
+- The **Node Detail Panel**.
+- The **Overview** tab — top countries by conversation count.
+
+Private / Reserved IPs
+~~~~~~~~~~~~~~~~~~~~~~~
+
+RFC-1918 addresses (``10.x.x.x``, ``172.16-31.x.x``, ``192.168.x.x``),
+loopback, link-local, and other reserved ranges are labelled **Private** and
+are not looked up in the geolocation database.
+
+Device Classification
+---------------------
+
+TracePcap predicts the **device type** of each observed IP address based on
+heuristics applied to traffic patterns, port behaviour, and protocol mix:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Device Type
+     - Heuristic signals
+   * - **Router**
+     - Observed forwarding traffic, TTL patterns, routing protocols
+   * - **Server**
+     - Mostly inbound connections, well-known server ports (80, 443, 22, …)
+   * - **IoT**
+     - Low-entropy traffic, known IoT protocol ports (MQTT, CoAP, …)
+   * - **Mobile**
+     - Mobile-specific app protocols, IMSI/IMEI patterns
+   * - **Laptop/Desktop**
+     - Mixed client traffic, browser fingerprints
+
+Device types are displayed as icons in the Network Visualization and as a
+filterable column in Conversations.
+
+Custom Signature Override
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Custom signature rules can pin an IP to a specific device type via the
+``device_type`` field — see :doc:`custom-signatures` for details.

--- a/docs/features/mac-lookup.rst
+++ b/docs/features/mac-lookup.rst
@@ -1,0 +1,34 @@
+MAC Manufacturer Lookup
+========================
+
+TracePcap integrates the **Wireshark OUI (Organizationally Unique Identifier)
+database** to resolve MAC address prefixes to vendor names.
+
+How It Works
+------------
+
+The first three octets of a MAC address identify the manufacturer (e.g.
+``00:50:56`` → VMware, ``b8:27:eb`` → Raspberry Pi Foundation). TracePcap
+looks up these prefixes against the bundled Wireshark OUI database, which
+is updated periodically and included in the Docker image — no internet
+connection is needed.
+
+Where Vendor Names Appear
+--------------------------
+
+- **Network Visualization** — shown in the Node Detail Panel when you click
+  a host node.
+- **Conversations** — a ``Vendor`` column (hidden by default; enable via
+  Column Picker).
+- **Overview** — top vendors by conversation count.
+
+Limitations
+-----------
+
+- MAC addresses are only visible for hosts on the **same Layer-2 segment**
+  as the capture point. Hosts routed across layer-3 boundaries will not have
+  a MAC address visible in the PCAP.
+- Locally-administered MAC addresses (randomised by modern OSes) cannot be
+  resolved to a meaningful vendor.
+- Virtual MAC addresses (VMware, VirtualBox, Docker bridge) resolve to the
+  hypervisor vendor, not the guest OS.

--- a/docs/features/ndpi-analysis.rst
+++ b/docs/features/ndpi-analysis.rst
@@ -1,0 +1,71 @@
+nDPI Security Analysis
+======================
+
+When **nDPI Analysis** is enabled at upload time, each conversation is
+inspected by **nDPI v5** (deep packet inspection library) in addition to
+standard Wireshark/tshark parsing.
+
+What nDPI Provides
+------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Data point
+     - Description
+   * - Application name
+     - Identified application (e.g. ``TLS``, ``HTTP``, ``DNS``, ``Telegram``,
+       ``TOR``, ``Dropbox``, …) — over 300 protocol/app signatures.
+   * - Category
+     - Traffic category (e.g. ``Web``, ``VPN``, ``Social Network``,
+       ``Malware``).
+   * - Risk flags
+     - Per-conversation risk alerts such as ``KNOWN_PROTOCOL_ON_NON_STD_PORT``,
+       ``SELF_SIGNED_CERTIFICATE``, ``SUSPICIOUS_DGA_DOMAIN``,
+       ``CLEAR_TEXT_CREDENTIALS``, and many others.
+   * - JA3 fingerprint
+     - Client TLS fingerprint (MD5 of TLS ClientHello parameters).
+   * - JA3S fingerprint
+     - Server TLS fingerprint (MD5 of TLS ServerHello parameters).
+   * - SNI (Server Name Indication)
+     - Hostname extracted from TLS ClientHello.
+   * - TLS certificate metadata
+     - Subject CN, issuer, validity dates, certificate version.
+
+Viewing nDPI Results
+--------------------
+
+nDPI data surfaces across multiple views:
+
+- **Overview tab** — summary counts of detected applications, categories,
+  and risk alerts.
+- **Conversations tab** — per-row columns for Application, Risk, JA3, JA3S,
+  and SNI; filterable by any of these fields.
+- **Node Detail Panel** — risk badges on individual host nodes in the network
+  graph.
+
+Risk Flags
+----------
+
+Risk flags are coloured badges displayed alongside conversations:
+
+- ``critical`` — red
+- ``high`` — orange
+- ``medium`` — amber / yellow
+- ``low`` — purple
+
+Custom signature rules (see :doc:`custom-signatures`) add additional badges
+to these nDPI-native detections.
+
+Enabling nDPI
+-------------
+
+nDPI analysis is opt-in per upload. Enable the **nDPI Analysis** toggle in the
+upload dialog before submitting the file. It cannot be added after upload —
+re-upload the file with the toggle enabled if needed.
+
+.. note::
+
+   nDPI analysis increases processing time proportionally to file size, but
+   runs fully offline inside the backend container.

--- a/docs/features/ndpi-analysis.rst
+++ b/docs/features/ndpi-analysis.rst
@@ -48,7 +48,7 @@ nDPI data surfaces across multiple views:
 Risk Flags
 ----------
 
-Risk flags are coloured badges displayed alongside conversations:
+Risk flags are colored badges displayed alongside conversations:
 
 - ``critical`` — red
 - ``high`` — orange

--- a/docs/features/network-visualization.rst
+++ b/docs/features/network-visualization.rst
@@ -1,0 +1,67 @@
+Network Visualization
+=====================
+
+The Network Visualization tab renders an interactive topology graph of all
+hosts and flows extracted from the PCAP file.
+
+Technology
+----------
+
+The graph is built with **React Flow** and laid out using the **ELK** (Eclipse
+Layout Kernel) automatic layout engine. No external tile servers or map
+services are used — the topology is a pure data-driven graph rendered in the
+browser.
+
+Nodes
+-----
+
+Each node represents a unique IP address (or MAC address for layer-2 traffic).
+Node appearance reflects:
+
+- **Device type** — icon and shape vary by predicted device class
+  (Router, Server, IoT, Mobile, Laptop/Desktop).
+- **Country** — a flag badge on external (non-RFC-1918) IPs.
+- **Risk** — nodes involved in risky conversations display a warning indicator.
+
+Click a node to open the **Node Detail Panel**, which shows:
+
+- IP address and MAC address
+- Vendor (from Wireshark OUI database)
+- Predicted device type
+- Country and ASN (for external IPs)
+- List of conversations involving this node
+
+Edges
+-----
+
+Edges represent observed conversations between two hosts. Edge thickness
+reflects relative traffic volume.
+
+Filter Panel
+------------
+
+The filter panel (left sidebar) lets you narrow the graph by:
+
+- Source / destination IP
+- Port
+- Device type
+- Protocol
+- Application (nDPI)
+- Risk level
+- Custom signature match
+- Country
+
+Filters are applied interactively — the graph updates without reloading.
+
+Layout Controls
+---------------
+
+- **Auto layout** — re-run ELK layout.
+- **Fullscreen toggle** — expand the graph to fill the viewport.
+- **Zoom controls** — zoom in/out and fit-to-screen buttons.
+
+Export
+------
+
+The topology can be captured as part of the PDF report via the **Export PDF**
+button (see :doc:`../operations/backup-restore`).

--- a/docs/features/pcap-upload.rst
+++ b/docs/features/pcap-upload.rst
@@ -1,0 +1,52 @@
+PCAP Upload & Management
+========================
+
+TracePcap accepts PCAP, PCAPNG, and CAP files via a drag-and-drop interface.
+Files are stored in MinIO object storage and analysed asynchronously.
+
+Supported Formats
+-----------------
+
+- ``.pcap`` — libpcap format
+- ``.pcapng`` — next-generation capture format
+- ``.cap`` — Wireshark capture format
+
+Upload Limit
+------------
+
+The default maximum file size is **512 MB**, configurable via the
+``MAX_UPLOAD_SIZE_BYTES`` environment variable (see
+:doc:`../configuration/environment-variables`).
+
+Upload Options
+--------------
+
+Before clicking **Upload** you can enable optional analysis modules:
+
+- **nDPI Analysis** — deep packet inspection for application identification,
+  risk detection, TLS metadata, and JA3/JA3S fingerprints
+  (see :doc:`ndpi-analysis`).
+- **File Extraction** — HTTP object extraction and raw stream extraction from
+  TCP/UDP payloads (see :doc:`file-extraction`).
+
+Duplicate Detection
+-------------------
+
+TracePcap computes an MD5 hash of each uploaded file. If a file with the same
+hash already exists, the upload is rejected and you are linked to the existing
+analysis. This prevents redundant processing and storage.
+
+Processing Progress
+-------------------
+
+After upload, you are redirected to a progress view showing each analysis
+stage (packet parsing, nDPI analysis, geolocation, file extraction, …) with
+a percentage indicator. You can navigate away; analysis continues in the
+background.
+
+Managing Uploads
+----------------
+
+The main file list shows all uploaded PCAPs with their status, size, upload
+date, and detected statistics. You can delete a file from this view, which
+removes both the database metadata and the object from MinIO.

--- a/docs/features/session-reconstruction.rst
+++ b/docs/features/session-reconstruction.rst
@@ -1,0 +1,48 @@
+Session Reconstruction
+======================
+
+Session Reconstruction decodes the application-layer payload of a TCP or UDP
+conversation and presents it in a side-by-side **hex + ASCII viewer**.
+
+Opening the Viewer
+------------------
+
+From the **Conversations** tab, click the eye icon on any conversation row.
+A panel slides in showing the reconstructed payload.
+
+Hex + ASCII Viewer
+------------------
+
+The viewer displays payload bytes in two columns:
+
+- **Hex** — raw bytes in hexadecimal, 16 bytes per row.
+- **ASCII** — printable ASCII representation of the same bytes; non-printable
+  bytes are shown as ``.``.
+
+Clicking a byte in either column highlights the corresponding byte in the
+other column.
+
+Payload Decompression
+---------------------
+
+If the payload is gzip- or deflate-compressed (e.g. HTTP responses with
+``Content-Encoding: gzip``), TracePcap automatically decompresses it before
+display so you see the plaintext content.
+
+Stream Direction
+----------------
+
+The viewer colour-codes bytes by direction:
+
+- **Blue** — client-to-server bytes.
+- **Green** — server-to-client bytes.
+
+Limitations
+-----------
+
+- Encrypted payloads (TLS, DTLS, etc.) cannot be decrypted without the
+  private key. The raw ciphertext is shown instead.
+- Fragmented IP packets are reassembled where possible; highly fragmented or
+  out-of-order streams may show gaps.
+- Very large payloads (>10 MB per stream) are truncated to protect browser
+  performance.

--- a/docs/features/session-reconstruction.rst
+++ b/docs/features/session-reconstruction.rst
@@ -32,7 +32,7 @@ display so you see the plaintext content.
 Stream Direction
 ----------------
 
-The viewer colour-codes bytes by direction:
+The viewer color-codes bytes by direction:
 
 - **Blue** — client-to-server bytes.
 - **Green** — server-to-client bytes.

--- a/docs/features/story-mode.rst
+++ b/docs/features/story-mode.rst
@@ -1,0 +1,60 @@
+Story Mode
+==========
+
+Story Mode uses an LLM to produce a human-readable **narrative reconstruction**
+of the network activity captured in a PCAP file, along with an interactive
+Q&A chat.
+
+Requirements
+------------
+
+A configured LLM server is required (see :doc:`../configuration/llm-setup`).
+
+What Story Mode Produces
+------------------------
+
+Narrative Summary
+~~~~~~~~~~~~~~~~~
+
+The LLM analyses conversation metadata (IPs, ports, protocols, applications,
+risk flags, timestamps, geolocation, custom signature matches) and generates
+a structured narrative that describes:
+
+- Who was communicating with whom.
+- What applications and protocols were used.
+- When notable events occurred.
+- Any detected anomalies or risk indicators.
+- A timeline of significant events.
+
+Story Timeline
+~~~~~~~~~~~~~~
+
+Below the narrative, a visual **timeline** marks the key events extracted from
+the story (e.g. "DNS lookup for evil.com", "TLS session established",
+"File download detected") in chronological order.
+
+Interactive LLM Q&A Chat
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After the narrative is generated, a chat panel allows you to ask follow-up
+questions about the PCAP, for example:
+
+- *"Which IP downloaded the most data?"*
+- *"Were there any connections to known threat IPs?"*
+- *"Summarise the DNS activity."*
+
+The LLM answers using the PCAP metadata as context.
+
+Custom Context
+~~~~~~~~~~~~~~
+
+You can provide additional context before generating the story — for example,
+a description of the network environment or the timeframe of an incident.
+This helps the LLM produce a more accurate and relevant narrative.
+
+Privacy
+-------
+
+Story generation sends conversation metadata (not raw packet payloads) to your
+configured ``LLM_API_BASE_URL``. Use a local LLM to keep this data fully
+within your infrastructure.

--- a/docs/features/timeline-analysis.rst
+++ b/docs/features/timeline-analysis.rst
@@ -1,0 +1,41 @@
+Timeline Analysis
+=================
+
+The Timeline tab provides a chronological view of network traffic, helping
+you understand when activity occurred and how traffic patterns evolved over
+the capture period.
+
+Chart Layout
+------------
+
+Traffic is visualised as a stacked bar chart:
+
+- The **X axis** represents time (divided into configurable buckets).
+- The **Y axis** represents packet count or byte volume (toggle between the
+  two using the view control).
+- Each bar is colour-coded by **protocol** so you can see the protocol mix
+  at a glance.
+
+Time Granularity
+----------------
+
+You can control how finely the time axis is divided:
+
+- **Auto** — TracePcap picks a suitable granularity based on the capture
+  duration (e.g. seconds for a 1-minute capture, minutes for a 1-hour
+  capture).
+- **Manual** — choose from: 1 s, 5 s, 30 s, 1 min, 5 min, 15 min, 1 hour.
+
+Protocol Breakdown
+------------------
+
+A legend below the chart lists every protocol colour. Clicking a legend entry
+toggles that protocol's visibility, letting you isolate specific traffic types.
+
+Interaction
+-----------
+
+- **Hover** over a bar to see an exact breakdown of protocols and volumes for
+  that time bucket.
+- **Click** a bar to filter the Conversations tab to only the conversations
+  active during that time bucket.

--- a/docs/features/timeline-analysis.rst
+++ b/docs/features/timeline-analysis.rst
@@ -13,7 +13,7 @@ Traffic is visualised as a stacked bar chart:
 - The **X axis** represents time (divided into configurable buckets).
 - The **Y axis** represents packet count or byte volume (toggle between the
   two using the view control).
-- Each bar is colour-coded by **protocol** so you can see the protocol mix
+- Each bar is color-coded by **protocol** so you can see the protocol mix
   at a glance.
 
 Time Granularity
@@ -29,7 +29,7 @@ You can control how finely the time axis is divided:
 Protocol Breakdown
 ------------------
 
-A legend below the chart lists every protocol colour. Clicking a legend entry
+A legend below the chart lists every protocol color. Clicking a legend entry
 toggles that protocol's visibility, letting you isolate specific traffic types.
 
 Interaction

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -1,0 +1,74 @@
+Installation
+============
+
+This guide walks you through a standard online Docker Compose installation.
+For air-gapped environments, see :doc:`offline-deployment`.
+
+1. Clone the Repository
+-----------------------
+
+.. code-block:: bash
+
+   git clone https://github.com/NotYuSheng/TracePcap.git
+   cd TracePcap
+
+2. Configure Environment Variables
+-----------------------------------
+
+Copy the example environment file and edit it:
+
+.. code-block:: bash
+
+   cp .env.example .env
+
+Open ``.env`` in your editor and configure at minimum:
+
+.. code-block:: ini
+
+   # Maximum PCAP upload size (bytes). Default: 512 MB.
+   MAX_UPLOAD_SIZE_BYTES=536870912
+
+   # Port on which nginx listens. Change if 80 is already in use.
+   NGINX_PORT=80
+
+   # LLM configuration — point to your local inference server.
+   LLM_API_BASE_URL=http://localhost:1234/v1
+   LLM_API_KEY=
+   LLM_MODEL=Qwen2.5-14B-Coder-Instruct
+   LLM_TEMPERATURE=0.7
+   LLM_MAX_TOKENS=2000
+
+See :doc:`../configuration/environment-variables` for a full reference.
+
+3. Start the Application
+------------------------
+
+.. code-block:: bash
+
+   docker compose up -d
+
+On first startup Docker will pull the required images and initialize
+PostgreSQL and MinIO. This may take a few minutes.
+
+4. Verify the Stack is Running
+-------------------------------
+
+.. code-block:: bash
+
+   docker compose ps
+
+All services — ``tracepcap-backend``, ``tracepcap-frontend``, ``postgres``,
+``minio``, and ``nginx`` — should report **healthy** or **running**.
+
+5. Open TracePcap
+-----------------
+
+Navigate to ``http://localhost:80`` in your browser (or the port you set in
+``NGINX_PORT``).
+
+Next Steps
+----------
+
+- Upload a sample PCAP from :doc:`../sample-files` to verify everything works.
+- Configure your LLM server — see :doc:`../configuration/llm-setup`.
+- Review :doc:`../features/pcap-upload` for upload options and limits.

--- a/docs/getting-started/offline-deployment.rst
+++ b/docs/getting-started/offline-deployment.rst
@@ -1,0 +1,66 @@
+Offline / Air-Gapped Deployment
+================================
+
+TracePcap is designed to run fully offline — no external API calls are made
+at runtime. This page covers the workflow for deploying to a machine that has
+no internet access.
+
+Overview
+--------
+
+1. On an **internet-connected** machine: pull all images and save them as
+   ``.tar`` files.
+2. **Transfer** the tarballs (plus a few scripts) to the offline machine.
+3. On the **offline machine**: load the images and start the stack.
+
+Step 1 — Pull and Save Images (online machine)
+----------------------------------------------
+
+.. code-block:: bash
+
+   bash scripts/pull-and-save-images.sh
+
+This creates an ``images/`` directory containing ``.tar`` files for every
+service (backend, frontend, postgres, minio, nginx, …).
+
+Step 2 — Transfer Files to the Offline Machine
+-----------------------------------------------
+
+Copy the following to the offline machine (USB drive, SCP, etc.):
+
+.. code-block:: text
+
+   images/                        # all .tar image archives
+   docker-compose.offline.yml
+   scripts/load-images.sh
+   .env                           # copy from .env.example and configure first
+
+Step 3 — Load Images and Start the Stack (offline machine)
+----------------------------------------------------------
+
+.. code-block:: bash
+
+   # Load all images into Docker
+   bash scripts/load-images.sh
+
+   # Start the stack using the offline compose file
+   docker compose -f docker-compose.offline.yml up -d
+
+LLM Configuration for Offline Use
+----------------------------------
+
+AI features (Story Mode, AI Filter Generator) require an OpenAI-compatible
+inference server. The offline compose file defaults to:
+
+.. code-block:: ini
+
+   LLM_API_BASE_URL=http://localhost:1234/v1
+
+Configure a locally-hosted LLM (e.g. `LM Studio <https://lmstudio.ai>`_ or
+`Ollama <https://ollama.com>`_) and set ``LLM_API_BASE_URL`` in your ``.env``
+before starting. See :doc:`../configuration/llm-setup` for details.
+
+.. note::
+
+   If no LLM server is available, TracePcap works fully without AI features —
+   only Story Mode and AI Filter Generator will be non-functional.

--- a/docs/getting-started/prerequisites.rst
+++ b/docs/getting-started/prerequisites.rst
@@ -1,0 +1,47 @@
+Prerequisites
+=============
+
+Software Requirements
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Software
+     - Version
+     - Purpose
+   * - Docker
+     - Latest
+     - Container runtime
+   * - Docker Compose
+     - Latest
+     - Multi-container orchestration
+   * - LLM Server *(optional)*
+     - Any OpenAI-compatible API
+     - AI filter generation and Story Mode (e.g. LM Studio, Ollama)
+
+Hardware Requirements
+---------------------
+
+**Minimum:**
+
+- RAM: 4 GB
+- Storage: 10 GB (database, PCAP files, object storage)
+
+**Recommended:**
+
+- RAM: 8 GB or more
+- Storage: 50 GB+ for large PCAP collections
+- CPU: 4+ cores for fast nDPI analysis
+
+.. note::
+
+   If you plan to run an LLM locally for AI features, allocate additional RAM
+   (8–16 GB typical for a 7B–14B parameter model).
+
+Operating System
+----------------
+
+TracePcap is Docker-based and runs on any OS that supports Docker Compose,
+including Linux, macOS, and Windows (via WSL2).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,52 @@
+TracePcap Documentation
+=======================
+
+**TracePcap** is an intelligent, self-hosted PCAP analysis platform with AI-powered insights and interactive network visualization. It runs entirely offline — no data leaves your infrastructure.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Getting Started
+
+   getting-started/prerequisites
+   getting-started/installation
+   getting-started/offline-deployment
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Features
+
+   features/pcap-upload
+   features/network-visualization
+   features/ndpi-analysis
+   features/conversations
+   features/session-reconstruction
+   features/file-extraction
+   features/geolocation
+   features/mac-lookup
+   features/timeline-analysis
+   features/ai-filter-generator
+   features/story-mode
+   features/custom-signatures
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Configuration
+
+   configuration/environment-variables
+   configuration/llm-setup
+   configuration/signature-rules
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Operations
+
+   operations/backup-restore
+   operations/logs-monitoring
+   operations/production-hardening
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference
+
+   api-reference
+   sample-files

--- a/docs/operations/backup-restore.rst
+++ b/docs/operations/backup-restore.rst
@@ -1,0 +1,74 @@
+Backup & Restore
+================
+
+TracePcap data lives in two places:
+
+- **PostgreSQL** — conversation metadata, analysis results, geolocation data.
+- **MinIO** — raw PCAP files (object storage).
+
+Backing Up
+----------
+
+Database Backup
+~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   docker exec tracepcap-postgres \
+     pg_dump -U tracepcap_user tracepcap > backup.sql
+
+MinIO Backup (PCAP files)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   docker exec tracepcap-minio \
+     mc mirror minio/tracepcap-files ./backup-pcaps/
+
+Full Volume Backup
+~~~~~~~~~~~~~~~~~~
+
+To back up all Docker named volumes at once:
+
+.. code-block:: bash
+
+   sudo tar -czf tracepcap_backup.tar.gz /var/lib/docker/volumes/tracepcap_*
+
+Custom Signature Rules Backup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The rules file is stored in the ``config_data`` volume. Back it up with:
+
+.. code-block:: bash
+
+   docker cp tracepcap-backend:/app/config/signatures.yml ./signatures.yml.bak
+
+Restoring
+---------
+
+Database Restore
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   docker exec -i tracepcap-postgres \
+     psql -U tracepcap_user tracepcap < backup.sql
+
+MinIO Restore
+~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   docker exec tracepcap-minio \
+     mc mirror ./backup-pcaps/ minio/tracepcap-files
+
+Export Options
+--------------
+
+From within the UI, you can also export data without accessing Docker directly:
+
+- **PDF report** — click **Export PDF** on any PCAP overview page. The report
+  includes a live capture of the network topology.
+- **CSV** — export the current Conversations view to a spreadsheet.
+- **PCAP** — download individual or bulk conversation PCAPs from the
+  Conversations tab.

--- a/docs/operations/logs-monitoring.rst
+++ b/docs/operations/logs-monitoring.rst
@@ -1,0 +1,80 @@
+Logs & Monitoring
+=================
+
+Viewing Logs
+------------
+
+All services log to stdout/stderr, captured by Docker Compose.
+
+**All services:**
+
+.. code-block:: bash
+
+   docker compose logs -f
+
+**Specific services:**
+
+.. code-block:: bash
+
+   docker compose logs -f tracepcap-backend
+   docker compose logs -f tracepcap-frontend
+   docker compose logs -f postgres
+   docker compose logs -f minio
+   docker compose logs -f nginx
+
+Log Levels
+----------
+
+The backend uses Spring Boot logging. To increase verbosity, add to your
+``docker-compose.yml`` or ``.env``:
+
+.. code-block:: yaml
+
+   environment:
+     LOGGING_LEVEL_ROOT: DEBUG
+
+For production, keep the default ``INFO`` level to avoid excessive log volume.
+
+Health Checks
+-------------
+
+Each service in ``docker-compose.yml`` defines a Docker health check. You can
+inspect health status with:
+
+.. code-block:: bash
+
+   docker compose ps
+
+A service in ``unhealthy`` state indicates a startup failure or runtime error.
+Check its logs first:
+
+.. code-block:: bash
+
+   docker compose logs tracepcap-backend --tail=100
+
+Restarting Services
+-------------------
+
+.. code-block:: bash
+
+   # Restart all services
+   docker compose restart
+
+   # Restart a specific service
+   docker compose restart tracepcap-backend
+
+Monitoring Disk Usage
+---------------------
+
+PCAP files can be large. Monitor MinIO storage with:
+
+.. code-block:: bash
+
+   docker exec tracepcap-minio mc du minio/tracepcap-files
+
+And PostgreSQL database size:
+
+.. code-block:: bash
+
+   docker exec tracepcap-postgres \
+     psql -U tracepcap_user tracepcap -c "\l+"

--- a/docs/operations/production-hardening.rst
+++ b/docs/operations/production-hardening.rst
@@ -1,0 +1,76 @@
+Production Hardening
+=====================
+
+The default TracePcap configuration is optimised for quick local testing.
+Before exposing the application to a wider audience, follow these steps.
+
+Change Default Credentials
+---------------------------
+
+**MinIO:**
+
+In ``docker-compose.yml``, change:
+
+.. code-block:: yaml
+
+   MINIO_ROOT_USER: minioadmin
+   MINIO_ROOT_PASSWORD: minioadmin
+
+to strong, unique credentials. Update any references in the backend service
+environment as well.
+
+**PostgreSQL:**
+
+Change ``POSTGRES_PASSWORD`` to a strong password and update the backend's
+``SPRING_DATASOURCE_PASSWORD`` to match.
+
+Add an Authentication Layer
+-----------------------------
+
+TracePcap has **no built-in user authentication**. For multi-user or
+internet-facing deployments, place an authentication layer in front of nginx:
+
+- **OAuth2 / OIDC proxy** — e.g. `oauth2-proxy <https://oauth2-proxy.github.io/oauth2-proxy/>`_
+  in front of nginx.
+- **Basic auth** — configure nginx ``auth_basic`` with an ``.htpasswd`` file.
+- **VPN / firewall** — restrict access to trusted IP ranges at the network
+  level.
+
+Configure SSL/TLS
+-----------------
+
+By default nginx serves HTTP. For production, terminate TLS at the nginx layer:
+
+1. Obtain a certificate (e.g. from your internal CA or Let's Encrypt on an
+   internet-connected machine).
+2. Mount the certificate and key into the nginx container.
+3. Update ``nginx/nginx.conf`` to add an HTTPS server block and redirect HTTP
+   to HTTPS.
+
+Adjust Upload Limits
+---------------------
+
+Set ``MAX_UPLOAD_SIZE_BYTES`` in ``.env`` appropriate for your storage
+capacity and user needs:
+
+.. code-block:: ini
+
+   MAX_UPLOAD_SIZE_BYTES=1073741824  # 1 GB
+
+Configure LLM Privacy
+---------------------
+
+If you use AI features, ensure ``LLM_API_BASE_URL`` points to a locally-hosted
+model. Do **not** configure a cloud API endpoint if your PCAP data is sensitive.
+
+Restrict MinIO Console Access
+-------------------------------
+
+The MinIO console is exposed on port ``9001`` by default. Remove or restrict
+this port in ``docker-compose.yml`` for production:
+
+.. code-block:: yaml
+
+   # Comment out or remove:
+   # ports:
+   #   - "9001:9001"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=7.0
+sphinx-rtd-theme>=2.0

--- a/docs/sample-files.rst
+++ b/docs/sample-files.rst
@@ -1,0 +1,61 @@
+Sample Files
+============
+
+The ``sample-files/`` directory contains example PCAP files and a generator
+script to help you test and explore TracePcap's features.
+
+Included Files
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - File
+     - Description
+   * - ``atm_capture1.cap``
+     - ATM network traffic sample. Useful for testing protocol parsing and
+       multi-protocol support.
+   * - ``free5gc.pcap``
+     - 5G core network (free5GC) traffic sample. Demonstrates TracePcap's
+       handling of GTP tunnelling and 5G control-plane protocols.
+   * - ``demo_all_rules.pcap``
+     - Crafted PCAP that triggers all 17 custom signature demo rules defined
+       in ``signatures.sample.yml``. Use this to verify that custom signature
+       matching is working correctly.
+
+Generating ``demo_all_rules.pcap``
+------------------------------------
+
+The generator script ``sample-files/gen_demo.py`` synthesises the demo PCAP
+programmatically using Scapy. To regenerate it:
+
+.. code-block:: bash
+
+   pip install scapy
+   python3 sample-files/gen_demo.py
+
+The script produces ``sample-files/demo_all_rules.pcap``.
+
+Walkthrough: Custom Signature Demo
+------------------------------------
+
+1. Copy ``signatures.sample.yml`` into the TracePcap browser editor:
+   Navigate to **Custom Detection Rules** → paste the file contents → **Save**.
+
+2. Upload ``demo_all_rules.pcap`` with **nDPI Analysis** enabled.
+
+3. Once analysis completes, open the **Conversations** tab. You should see
+   all 17 custom signature badges firing across the conversations.
+
+4. Open the **Overview** tab to see aggregate signature match counts.
+
+5. Explore the **Network Visualization** to see risk indicators on relevant
+   nodes.
+
+Adding Your Own PCAP Files
+--------------------------
+
+Place any ``.pcap``, ``.pcapng``, or ``.cap`` file in ``sample-files/`` and
+upload it via the TracePcap UI. There is no restriction on the content —
+any valid capture file is accepted.


### PR DESCRIPTION
Closes #247

## Summary
- Scaffolds a full Sphinx docs site under `docs/` using `sphinx-rtd-theme`
- 24 pages covering every feature, configuration reference, and operations guide
- Adds a GitHub Actions workflow (`.github/workflows/docs.yml`) that builds HTML on PRs and deploys to GitHub Pages on merge to `main`
- Updates README with build instructions linking to the docs

## Structure
```
docs/
├── getting-started/   prerequisites, installation, offline-deployment
├── features/          all 12 feature pages
├── configuration/     env vars, LLM setup, signature rule authoring
├── operations/        backup/restore, logs, production hardening
├── api-reference.rst
└── sample-files.rst
```

## Pre-requisite
In **Settings → Pages → Source**, set to **GitHub Actions** before merging so the deploy step has permission to publish.

## Test plan
- [ ] CI docs build passes (no warnings)
- [ ] After merge, GitHub Pages deployment succeeds and site is accessible
- [ ] All internal cross-references resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)