### PR TITLE
fix: remove card-header bottom border when ExtractionInfoCard is collapsed

### DIFF
--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -29,7 +29,7 @@ const ExtractionInfoCard = () => {
     <div className="card mb-3">
       <div
         className="card-header d-flex align-items-center justify-content-between"
-        style={{ cursor: 'pointer', userSelect: 'none' }}
+        style={{ cursor: 'pointer', userSelect: 'none', borderBottom: collapsed ? 'none' : undefined }}
         onClick={() => setCollapsed(c => !c)}
       >
         <h6 className="mb-0">


### PR DESCRIPTION
Closes #259

## Summary
- Bootstrap's `.card-header` has a default `border-bottom` that shows as a visible horizontal line when the card body is hidden (collapsed state)
- Added `borderBottom: collapsed ? 'none' : undefined` to suppress the border when collapsed and defer to Bootstrap styles when expanded

## Test plan
- [ ] Open the Extracted Files page
- [ ] Verify the info card shows no horizontal line at the bottom when collapsed
- [ ] Expand the card and verify the header/body separator renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)