### PR TITLE
docs: document comparison, network intelligence, report export, STUN, media preview

### DIFF
--- a/docs/features/comparison.rst
+++ b/docs/features/comparison.rst
@@ -1,0 +1,77 @@
+Cross-PCAP Comparison
+=====================
+
+The **Multi-Analysis** feature lets you load two or more PCAP files into a
+single unified network topology diagram, so you can compare traffic patterns
+across captures side by side.
+
+Starting a Comparison
+---------------------
+
+1. From the **All Uploads** file list, check the checkboxes on two or more
+   fully-processed PCAP files.
+2. Click the **Multi-Analysis (N)** button that appears in the header.
+3. A modal appears with two options:
+
+   - **View Together** — navigates to ``/compare?files=id1,id2,…`` and
+     renders the merged topology immediately. The original files are unchanged.
+   - **Merge & Analyze** — permanently merges the selected PCAPs into a new
+     single file (named automatically or as you specify), runs the full
+     analysis pipeline on the merged file, and navigates to its analysis page.
+
+The Comparison View
+-------------------
+
+The comparison view is a React Flow graph identical to the single-file
+**Network Diagram**, with the following additions:
+
+Source-aware rendering
+~~~~~~~~~~~~~~~~~~~~~~
+
+Each node and edge carries a ``sources`` list recording which uploaded files
+contributed it:
+
+- **Solid border / solid edge** — present in the primary (first selected) file.
+- **Dashed border / dashed edge** — present only in a secondary file.
+- **Thick edge (2.5 px)** — present in two or more files simultaneously.
+- A ``bi-layers`` badge appears on nodes that exist in multiple captures.
+
+File toggle pills
+~~~~~~~~~~~~~~~~~
+
+A row of color-coded pills (one per file, labelled by filename) appears above
+the graph. Clicking a pill hides all nodes and edges that are exclusive to
+that file, letting you isolate traffic from a single capture.
+
+Filters and layout
+~~~~~~~~~~~~~~~~~~
+
+All filters available in the single-file Network Diagram (protocol, IP, port,
+risk, device type, grouping, layout algorithm) work identically in the
+comparison view. Filters apply to the merged dataset.
+
+Node merging logic
+~~~~~~~~~~~~~~~~~~
+
+Nodes are matched across files by **IP address**. If the same IP appears in
+two files with *different* MAC addresses (e.g. DHCP lease reuse), the backend
+keeps them as separate nodes rather than incorrectly merging them.
+
+Export
+------
+
+The **Export PDF** button in the comparison view captures the merged topology
+and includes it in the PDF report alongside any other active analysis sections.
+
+Permanent Merge
+---------------
+
+Choosing **Merge & Analyze** calls ``POST /api/files/merge``, which:
+
+1. Downloads all selected PCAP files from MinIO.
+2. Concatenates them with ``mergecap``.
+3. Uploads the result as a new file and triggers the standard analysis
+   pipeline (tshark parsing, nDPI, geolocation, file extraction).
+
+The merged file appears as a regular entry in the file list and can be
+analysed, compared, or deleted independently of the originals.

--- a/docs/features/comparison.rst
+++ b/docs/features/comparison.rst
@@ -13,7 +13,7 @@ Starting a Comparison
 2. Click the **Multi-Analysis (N)** button that appears in the header.
 3. A modal appears with two options:
 
-   - **View Together** — navigates to ``/compare?files=id1,id2,…`` and
+   - **View Together** — navigates to ``/compare?files=id1,id2,...`` and
      renders the merged topology immediately. The original files are unchanged.
    - **Merge & Analyze** — permanently merges the selected PCAPs into a new
      single file (named automatically or as you specify), runs the full
@@ -74,4 +74,4 @@ Choosing **Merge & Analyze** calls ``POST /api/files/merge``, which:
    pipeline (tshark parsing, nDPI, geolocation, file extraction).
 
 The merged file appears as a regular entry in the file list and can be
-analysed, compared, or deleted independently of the originals.
+analyzed, compared, or deleted independently of the originals.

--- a/docs/features/file-extraction.rst
+++ b/docs/features/file-extraction.rst
@@ -70,6 +70,29 @@ Go to the **Extracted Files** tab for a PCAP. Each file is listed with:
 - Source conversation (src IP : src port → dst IP : dst port)
 - Extraction method (``tshark_http`` / stream)
 
+MIME Type Filter
+~~~~~~~~~~~~~~~~
+
+A collapsible **Filters** panel above the file list shows pill buttons for
+every MIME type present in the loaded files. Select one or more to narrow the
+list. The file count badge updates to ``X / Y files`` while a filter is
+active. **Select All** and **Clear** shortcuts appear in the pill header.
+
+Media Preview
+~~~~~~~~~~~~~
+
+Files with a browser-natively playable MIME type (images, audio, video) show
+a **Preview** button. Clicking it opens an inline modal with the file rendered
+directly in the browser — no download required. The preview endpoint returns
+``Content-Disposition: inline`` so the browser handles rendering.
+
+Download Safety Disclaimer
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Clicking **Download** on any extracted file shows a safety disclaimer modal
+before the download begins, reminding you that extracted files may be
+malicious.
+
 Bulk Download
 -------------
 

--- a/docs/features/network-intelligence.rst
+++ b/docs/features/network-intelligence.rst
@@ -1,0 +1,97 @@
+Network Intelligence
+====================
+
+The **Network Intelligence** tab presents a high-level cluster graph that
+groups all IP addresses in a capture into named clusters, making it easier to
+understand traffic between organisations, countries, subnets, or device
+classes at a glance.
+
+Cluster Graph
+-------------
+
+Each cluster node represents a group of IPs. Edges between clusters represent
+observed conversations between IPs in those groups. Clicking a cluster opens
+a side panel listing the individual IPs it contains, with per-IP metrics and
+a conversation list.
+
+Grouping Strategies
+-------------------
+
+Select a strategy from the **Group by** dropdown:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Strategy
+     - How IPs are grouped
+   * - **ASN / Organization**
+     - Autonomous System Number from ipinfo.io geo enrichment. Only available
+       for IPs enriched online; offline DB-IP fallback does not provide ASN.
+   * - **Country**
+     - Country code from ipinfo.io (online) or DB-IP Lite (offline). Switches
+       the canvas to the SVG world map view (see `Country Map View`_ below).
+   * - **City**
+     - ``<CountryCode>:<CityName>`` from the DB-IP Lite City MMDB. Falls back
+       to ``unknown`` for unresolvable IPs.
+   * - **Subnet /24**
+     - First three octets of the IP (e.g. ``10.0.1.0/24``).
+   * - **Subnet /16**
+     - First two octets of the IP (e.g. ``10.0.0.0/16``).
+   * - **Device Type**
+     - Predicted device class from the multi-signal classifier (Router, Mobile,
+       Server, etc.) — see :doc:`geolocation` for the scoring algorithm.
+   * - **Network Labels ★**
+     - Custom CIDR-to-label mappings defined in the **Network Labels** tab of
+       the Custom Detection Rules modal — see :doc:`custom-signatures`. Only
+       conversations where at least one endpoint is a labelled IP are shown;
+       unlabelled-only traffic is suppressed.
+
+Color Modes
+-----------
+
+Two color modes are available via the **Color by** toggle:
+
+- **Traffic** — cluster nodes are shaded on a blue heatmap proportional to
+  their ``totalBytes`` relative to the busiest cluster. Darker = more traffic.
+- **Risk** — clusters with at least one nDPI risk flag show a red warning
+  badge. Nodes without risk flags are neutral grey.
+
+Cluster Side Panel
+------------------
+
+Clicking a cluster opens a panel on the right showing:
+
+- The cluster label and IP count.
+- A per-IP breakdown sortable by **Traffic** (bytes), **Conversations**,
+  **Risk flags**, or **Unique peers**.
+- A conversation list for the selected cluster, filtered by the active
+  Network Intelligence filters (same filter set as the Conversations tab).
+
+Filters
+-------
+
+The Network Intelligence tab exposes the full conversation filter panel
+(IP, port, protocol, application, country, device type, risk, custom
+signatures, etc.), identical to the Conversations tab. Filters apply to
+both the cluster graph and the side-panel conversation list.
+
+Country Map View
+----------------
+
+When **Group by = Country** is selected, the React Flow canvas is replaced
+with a static SVG world map rendered from a bundled Natural Earth 110m
+TopoJSON file (no tile server or internet connection required).
+
+- Each country with observed traffic displays a **cluster marker** positioned
+  at the country's geographic centroid.
+- Marker size and shade reflect traffic volume (heatmap) or risk presence,
+  consistent with the cluster graph color mode.
+- **Click a country marker** to drill down: the map fetches city-level
+  clusters for that country and displays them as smaller markers at their
+  city coordinates.
+- **Click a city marker** to open the cluster side panel for that city.
+- The **Internal Network** cluster (RFC-1918 addresses) floats as a fixed
+  card outside the map since it has no geographic position.
+- A back button exits the drilled-down city view and returns to the country
+  level.

--- a/docs/features/network-intelligence.rst
+++ b/docs/features/network-intelligence.rst
@@ -41,7 +41,7 @@ Select a strategy from the **Group by** dropdown:
    * - **Device Type**
      - Predicted device class from the multi-signal classifier (Router, Mobile,
        Server, etc.) — see :doc:`geolocation` for the scoring algorithm.
-   * - **Network Labels ★**
+   * - **Network Labels**
      - Custom CIDR-to-label mappings defined in the **Network Labels** tab of
        the Custom Detection Rules modal — see :doc:`custom-signatures`. Only
        conversations where at least one endpoint is a labelled IP are shown;

--- a/docs/features/report-export.rst
+++ b/docs/features/report-export.rst
@@ -1,0 +1,108 @@
+PDF Report Export
+=================
+
+TracePcap can generate a self-contained PDF report for any analysed PCAP.
+The report is produced server-side and includes data from all analysis
+stages completed for that file.
+
+Generating a Report
+-------------------
+
+Click the **Export PDF** button in the top navigation bar of any analysis
+page. A progress modal tracks the steps:
+
+1. **Rendering network diagrams** — the frontend captures screenshots of
+   the network topology in both Force-directed and Hierarchical layouts,
+   using the currently active filters.
+2. **Building PDF** — the backend assembles the report from stored analysis
+   data and the captured diagram images.
+
+The PDF downloads automatically when complete.
+
+Report Sections
+---------------
+
+Sections are numbered consecutively. Optional sections are skipped (and
+renumbered) when no data is available.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Section
+     - Contents
+   * - **File Information**
+     - Filename, SHA-256 hash, capture start/end times, duration, file size.
+   * - **Executive Summary**
+     - High-level counts: total conversations, unique hosts, risk alerts,
+       protocols, applications, detected file types.
+   * - **Protocol Distribution**
+     - Bar chart and table of ``_ws.col.Protocol`` values by conversation
+       count and byte volume.
+   * - **Traffic Category Distribution**
+     - nDPI traffic categories (Web, VPN, Media, etc.) by conversation count.
+       Omitted if nDPI was not enabled.
+   * - **Applications Detected**
+     - nDPI application names ranked by conversation count. Omitted if nDPI
+       was not enabled.
+   * - **Detected L7 Protocols**
+     - ``tsharkProtocol`` (deepest Wireshark dissector label) ranked by
+       conversation count.
+   * - **Host Inventory**
+     - Table of all unique IPs with MAC address, vendor, device type,
+       country, ASN, and risk alert count.
+   * - **Risk & Signature Summary**
+     - Counts of nDPI risk flags and custom signature matches.
+   * - **Security Findings**
+     - Up to the top 20 conversations with nDPI risk flags, showing src/dst,
+       protocol, application, and risk names.
+   * - **TLS / HTTPS Analysis**
+     - Encrypted conversations with JA3/JA3S fingerprints, SNI, and
+       certificate subject/issuer/expiry.
+   * - **HTTP User Agents**
+     - Distinct ``User-Agent`` strings observed across all HTTP conversations.
+   * - **Top Conversations by Traffic**
+     - Top conversations ranked by ``totalBytes``, with protocol, application,
+       packet count, and byte volume.
+   * - **Extracted Files**
+     - List of files recovered by the extraction pipeline (filename, MIME
+       type, size, source conversation). Omitted if extraction was not enabled.
+   * - **Network Diagram — Active Filters**
+     - Note of any active filters applied to the topology diagrams below.
+   * - **Network Topology (Force-directed)**
+     - Screenshot of the React Flow graph in force-directed layout.
+   * - **Network Topology (Hierarchical)**
+     - Screenshot of the React Flow graph in ELK hierarchical layout.
+   * - **AI Narrative** *(if Story generated)*
+     - The LLM-written narrative from Story Mode.
+   * - **Deterministic Findings** *(if Story generated)*
+     - Typed findings from the 8 detector algorithms (Beacon, TLS Anomaly,
+       Volume, FanOut, etc.) with severity, affected IPs, and metrics.
+   * - **LLM Investigation** *(if Story generated)*
+     - Hypotheses, structured DB queries, and conversation evidence tables
+       from the LLM investigation phase.
+
+If Story Mode has not been run, a notice replaces the three story sections.
+
+Network Diagrams in the Report
+-------------------------------
+
+The diagrams embedded in the PDF reflect **exactly what you see on the
+Network Diagram tab** at the time you click Export PDF — including any active
+protocol, IP, port, device type, or risk filters. Active filters are listed
+in the preceding section so the report is self-documenting.
+
+If the Network Diagram tab has not been visited in the current session, the
+report fetches the raw graph and applies whatever filters are currently
+configured in the diagram tab's filter panel.
+
+The frontend temporarily switches to light mode before capturing screenshots,
+so diagrams always render on a white background regardless of the user's
+theme preference.
+
+Compare View Report
+-------------------
+
+The cross-PCAP comparison view (``/compare``) has its own **Export PDF**
+button that captures the merged topology diagram and includes it in a
+dedicated comparison report.

--- a/docs/features/session-reconstruction.rst
+++ b/docs/features/session-reconstruction.rst
@@ -49,6 +49,41 @@ Truncation Limits
 - PCAP files larger than **500 MB** are excluded from session reconstruction
   to protect disk I/O.
 
+STUN Decoder
+------------
+
+When a conversation is identified as STUN (by nDPI, tshark metadata, the
+magic cookie ``0x2112A442``, or port heuristics — 3478/5349), a
+**STUN Messages** tab appears in the session toolbar alongside Raw Stream.
+It is selected automatically on load when STUN messages are present.
+
+Decoded fields include:
+
+- Message type and class (e.g. Binding Request, Binding Success Response,
+  Allocate Request).
+- Transaction ID.
+- Attributes: ``XOR-MAPPED-ADDRESS`` (with XOR un-masking applied),
+  ``MAPPED-ADDRESS``, ``USERNAME``, ``SOFTWARE``, ``ERROR-CODE``,
+  ``PRIORITY``, ``FINGERPRINT``, and ICE credentials.
+
+Both bare UDP datagrams and TCP-framed STUN (RFC 4571 two-byte length
+prefix) are supported.
+
+Media Detection Panel
+---------------------
+
+When the stream payload matches a known media signature, a
+**MediaInfo** panel appears above the raw/parsed view showing:
+
+- **Type** — ``AUDIO``, ``VIDEO``, or ``IMAGE``.
+- **Container** — detected container format (e.g. ``RTP``, ``MP4``,
+  ``WebM``, ``Ogg``, ``MPEG-TS``, ``JPEG``, ``PNG``, ``WebP``).
+- **Codec** — codec name where detectable.
+- **Sample rate** — for audio streams where extractable.
+
+Detected signatures include: RTP (audio/video), MP4, WebM, Ogg, JPEG, PNG,
+WebP, AAC, FLAC, MP3, and MPEG-TS.
+
 Limitations
 -----------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,8 @@ TracePcap Documentation
 
    features/pcap-upload
    features/network-visualization
+   features/network-intelligence
+   features/comparison
    features/ndpi-analysis
    features/conversations
    features/session-reconstruction
@@ -27,6 +29,7 @@ TracePcap Documentation
    features/ai-filter-generator
    features/story-mode
    features/custom-signatures
+   features/report-export
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Summary

Documents features present in merged PRs that were missing from Sphinx docs. All content validated against current source code before writing.

### New pages

- **`features/comparison.rst`** — Multi-Analysis (cross-PCAP comparison), source-aware rendering (dashed/shared edges, file toggle pills), node merging logic, Merge & Analyze permanent merge workflow
- **`features/network-intelligence.rst`** — Cluster graph, all 7 group-by strategies (ASN, Country, City, Subnet /24, Subnet /16, Device Type, Network Labels), traffic/risk color modes, cluster side panel IP metrics, country map view with drill-down to city markers
- **`features/report-export.rst`** — Full PDF report section table (14 standard + 3 story sections), network diagram capture behaviour, compare view report

### Updated pages

- **`features/session-reconstruction.rst`** — STUN decoder tab (decoded attributes, TCP-framed STUN support), media detection panel (type/container/codec/sample rate, detected signatures list)
- **`features/file-extraction.rst`** — MIME type filter pills, media preview modal, download safety disclaimer
- **`index.rst`** — 3 new pages added to toctree

### Intentionally excluded

- Dark mode — UI preference, not worth a dedicated docs page
- CSV/PCAP export from conversations — already documented in `conversations.rst`
- Minor fixes, refactors, and internal changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)