### PR TITLE
fix(extraction): discard oversized files instead of silently truncating

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,16 +135,7 @@ PCAP, PCAPNG, CAP (max 512MB default, configurable via `MAX_UPLOAD_SIZE_BYTES`)
 
 ## Documentation
 
-Comprehensive documentation is available in the [`docs/`](docs/) directory, built with Sphinx.
-
-**Build the docs locally:**
-```bash
-pip install -r docs/requirements.txt
-make -C docs html
-# Open docs/_build/html/index.html in your browser
-```
-
-Sections include getting started, feature guides, configuration reference, operations, and API reference.
+Full documentation is available at **https://notyusheng.github.io/TracePcap**.
 
 API documentation is also available via Swagger UI at **http://localhost:80/swagger-ui.html** when the application is running.
 

--- a/backend/src/main/java/com/tracepcap/analysis/controller/ExtractedFilesController.java
+++ b/backend/src/main/java/com/tracepcap/analysis/controller/ExtractedFilesController.java
@@ -67,6 +67,10 @@ public class ExtractedFilesController {
       throw new ResourceNotFoundException("Extracted file not found: " + extractionId);
     }
 
+    if (entity.getMinioPath() == null) {
+      throw new ResourceNotFoundException("Extracted file not available: " + extractionId);
+    }
+
     String mimeType =
         entity.getMimeType() != null ? entity.getMimeType() : "application/octet-stream";
 
@@ -107,6 +111,10 @@ public class ExtractedFilesController {
       throw new ResourceNotFoundException("Extracted file not found: " + extractionId);
     }
 
+    if (entity.getMinioPath() == null) {
+      throw new ResourceNotFoundException("Extracted file not available: " + extractionId);
+    }
+
     String filename = entity.getFilename() != null ? entity.getFilename() : "extracted-file";
     String mimeType =
         entity.getMimeType() != null ? entity.getMimeType() : "application/octet-stream";
@@ -135,6 +143,7 @@ public class ExtractedFilesController {
         .fileSize(e.getFileSize())
         .sha256(e.getSha256())
         .extractionMethod(e.getExtractionMethod())
+        .skippedReason(e.getSkippedReason())
         .createdAt(e.getCreatedAt())
         .build();
   }

--- a/backend/src/main/java/com/tracepcap/analysis/dto/ExtractedFileResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/ExtractedFileResponse.java
@@ -20,5 +20,6 @@ public class ExtractedFileResponse {
   private Long fileSize;
   private String sha256;
   private String extractionMethod;
+  private String skippedReason;
   private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/com/tracepcap/analysis/entity/ExtractedFileEntity.java
+++ b/backend/src/main/java/com/tracepcap/analysis/entity/ExtractedFileEntity.java
@@ -42,11 +42,15 @@ public class ExtractedFileEntity {
   @Column(name = "sha256", length = 64)
   private String sha256;
 
-  @Column(name = "minio_path", length = 1000, nullable = false)
+  @Column(name = "minio_path", length = 1000)
   private String minioPath;
 
   @Column(name = "extraction_method", length = 50)
   private String extractionMethod;
+
+  /** Non-null when the file was detected but not stored (e.g. "exceeds_size_limit"). */
+  @Column(name = "skipped_reason", length = 100)
+  private String skippedReason;
 
   @CreationTimestamp
   @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
@@ -44,6 +44,16 @@ public class FileExtractionService {
   /** Maximum size of a single extracted file stored in MinIO (50 MB). */
   private static final int MAX_EXTRACTED_FILE_BYTES = 50 * 1024 * 1024;
 
+  /**
+   * Maximum bytes buffered per raw stream during reassembly (200 MB). This is intentionally larger
+   * than {@link #MAX_EXTRACTED_FILE_BYTES} so that magic-byte scanning can still find files near
+   * the end of a large stream, while preventing a single runaway stream from exhausting heap.
+   */
+  private static final int MAX_STREAM_BUFFER_BYTES = 200 * 1024 * 1024;
+
+  /** Skipped-reason value written to DB when a file exceeds the per-file size limit. */
+  private static final String REASON_EXCEEDS_SIZE_LIMIT = "exceeds_size_limit";
+
   /** Maximum number of non-HTTP conversations to scan for embedded files. */
   private static final int MAX_RAW_STREAM_CONVERSATIONS = 50;
 
@@ -700,7 +710,7 @@ public class FileExtractionService {
             String hexLine = line.stripLeading();
             if (!hexLine.isEmpty()) {
               byte[] chunk = hexToBytes(hexLine);
-              if (chunk != null) {
+              if (chunk != null && currentBuf.size() + chunk.length <= MAX_STREAM_BUFFER_BYTES) {
                 currentBuf.write(chunk);
               }
             }
@@ -946,7 +956,7 @@ public class FileExtractionService {
             .filename(filename)
             .fileSize(rawSize)
             .extractionMethod(method)
-            .skippedReason("exceeds_size_limit")
+            .skippedReason(REASON_EXCEEDS_SIZE_LIMIT)
             .build();
 
     extractedFileRepository.save(entity);

--- a/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
@@ -520,16 +520,26 @@ public class FileExtractionService {
     List<MagicMatch> segments = findMagicMatches(streamBytes);
     for (MagicMatch seg : segments) {
       int start = seg.start();
-      int end = Math.min(seg.end(), start + MAX_EXTRACTED_FILE_BYTES);
+      int end = seg.end();
       if (end <= start) continue;
+      long segSize = (long) end - start;
+      String ext = seg.ext();
+      String name = "stream-" + conv.getId().toString().substring(0, 8) + "-" + start + "." + ext;
+      if (segSize > MAX_EXTRACTED_FILE_BYTES) {
+        log.warn(
+            "Skipping magic-byte extracted file {} ({} bytes) — exceeds {} MB limit",
+            name,
+            segSize,
+            MAX_EXTRACTED_FILE_BYTES / 1024 / 1024);
+        recordSkippedFile(file, conv.getId(), name, segSize, "magic_bytes");
+        continue;
+      }
       byte[] fileData = Arrays.copyOfRange(streamBytes, start, end);
 
       String sha256 = sha256Hex(fileData);
       if (extractedFileRepository.existsByFileIdAndSha256(file.getId(), sha256)) continue;
 
       String mime = detectMime(fileData);
-      String ext = seg.ext();
-      String name = "stream-" + conv.getId().toString().substring(0, 8) + "-" + start + "." + ext;
       storeExtractedFile(file, conv.getId(), fileData, name, mime, sha256, "magic_bytes");
     }
   }
@@ -690,7 +700,7 @@ public class FileExtractionService {
             String hexLine = line.stripLeading();
             if (!hexLine.isEmpty()) {
               byte[] chunk = hexToBytes(hexLine);
-              if (chunk != null && currentBuf.size() + chunk.length <= MAX_EXTRACTED_FILE_BYTES) {
+              if (chunk != null) {
                 currentBuf.write(chunk);
               }
             }
@@ -867,11 +877,18 @@ public class FileExtractionService {
 
   private void processLocalFile(FileEntity file, UUID conversationId, File localFile, String method)
       throws Exception {
-    byte[] data = Files.readAllBytes(localFile.toPath());
-    if (data.length == 0) return;
-    if (data.length > MAX_EXTRACTED_FILE_BYTES) {
-      data = Arrays.copyOf(data, MAX_EXTRACTED_FILE_BYTES);
+    long rawSize = localFile.length();
+    if (rawSize == 0) return;
+    if (rawSize > MAX_EXTRACTED_FILE_BYTES) {
+      log.warn(
+          "Skipping extracted file {} ({} bytes) — exceeds {} MB limit",
+          localFile.getName(),
+          rawSize,
+          MAX_EXTRACTED_FILE_BYTES / 1024 / 1024);
+      recordSkippedFile(file, conversationId, localFile.getName(), rawSize, method);
+      return;
     }
+    byte[] data = Files.readAllBytes(localFile.toPath());
     String sha256 = sha256Hex(data);
     if (extractedFileRepository.existsByFileIdAndSha256(file.getId(), sha256)) return;
 
@@ -913,6 +930,26 @@ public class FileExtractionService {
 
     extractedFileRepository.save(entity);
     log.info("Stored extracted file: {} ({} bytes, sha256={})", filename, data.length, sha256);
+  }
+
+  private void recordSkippedFile(
+      FileEntity file, UUID conversationId, String filename, long rawSize, String method) {
+    ConversationEntity convRef =
+        conversationId != null
+            ? entityManager.getReference(ConversationEntity.class, conversationId)
+            : null;
+
+    ExtractedFileEntity entity =
+        ExtractedFileEntity.builder()
+            .file(file)
+            .conversation(convRef)
+            .filename(filename)
+            .fileSize(rawSize)
+            .extractionMethod(method)
+            .skippedReason("exceeds_size_limit")
+            .build();
+
+    extractedFileRepository.save(entity);
   }
 
   // -------------------------------------------------------------------------

--- a/backend/src/main/resources/db/migration/V3__extracted_files_skipped_reason.sql
+++ b/backend/src/main/resources/db/migration/V3__extracted_files_skipped_reason.sql
@@ -1,0 +1,6 @@
+-- Allow extracted_files rows to represent files that were detected but not stored
+-- (e.g. exceeded the 50 MB per-file size limit). minio_path becomes nullable so
+-- these sentinel rows don't need a placeholder value.
+ALTER TABLE extracted_files
+    ALTER COLUMN minio_path DROP NOT NULL,
+    ADD COLUMN skipped_reason VARCHAR(100);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 TracePcap Documentation
 =======================
 
-**TracePcap** is an intelligent, self-hosted PCAP analysis platform with AI-powered insights and interactive network visualization. It runs entirely offline — no data leaves your infrastructure.
+**TracePcap** is an intelligent, self-hosted PCAP analysis platform with AI-powered insights and interactive network visualization. Designed for air-gapped and offline deployments — GeoIP lookups use a bundled offline database by default, with optional enrichment via ipinfo.io when internet access is available.
 
 .. toctree::
    :maxdepth: 2

--- a/frontend/src/features/extractedFiles/services/extractedFilesService.ts
+++ b/frontend/src/features/extractedFiles/services/extractedFilesService.ts
@@ -9,6 +9,7 @@ export interface ExtractedFile {
   fileSize: number | null;
   sha256: string | null;
   extractionMethod: string | null;
+  skippedReason: string | null;
   createdAt: string;
 }
 

--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -60,7 +60,10 @@ const ExtractionInfoCard = () => {
           </ul>
           <p className="mb-0">
             All extracted files are stored as raw bytes only — no execution or active-content
-            rendering occurs. A safety disclaimer is shown before each download.
+            rendering occurs. A safety disclaimer is shown before each download. Individual files
+            larger than 50 MB are not stored; they appear in this list with a{' '}
+            <span className="badge bg-warning text-dark" style={{ fontSize: '0.85em' }}>Too large</span>{' '}
+            badge so you can see they were detected but skipped.
           </p>
         </div>
       )}
@@ -329,8 +332,10 @@ export const ExtractedFilesPage = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {sorted.map(file => (
-                    <tr key={file.id}>
+                  {sorted.map(file => {
+                    const isSkipped = file.skippedReason != null;
+                    return (
+                    <tr key={file.id} className={isSkipped ? 'text-muted' : undefined}>
                       <td>
                         <i className={`bi ${mimeIcon(file.mimeType)} me-2 text-secondary`}></i>
                         <span className="font-monospace" style={{ fontSize: '0.85em' }}>
@@ -377,28 +382,39 @@ export const ExtractedFilesPage = () => {
                       </td>
                       <td>{methodBadge(file.extractionMethod)}</td>
                       <td>
-                        <div className="d-flex gap-1">
-                          {nativePreviewMode(file.mimeType) && (
-                            <button
-                              className="btn btn-outline-secondary btn-sm text-nowrap"
-                              onClick={() => setPreviewFile(file)}
-                              title="Preview in browser"
-                            >
-                              <i className="bi bi-play-circle me-1"></i>
-                              Preview
-                            </button>
-                          )}
-                          <button
-                            className="btn btn-outline-primary btn-sm text-nowrap"
-                            onClick={() => handleDownloadRequest(file)}
+                        {isSkipped ? (
+                          <span
+                            className="badge bg-warning text-dark"
+                            title="File exceeds the 50 MB size limit and was not stored"
                           >
-                            <i className="bi bi-download me-1"></i>
-                            Download
-                          </button>
-                        </div>
+                            <i className="bi bi-slash-circle me-1"></i>
+                            Too large
+                          </span>
+                        ) : (
+                          <div className="d-flex gap-1">
+                            {nativePreviewMode(file.mimeType) && (
+                              <button
+                                className="btn btn-outline-secondary btn-sm text-nowrap"
+                                onClick={() => setPreviewFile(file)}
+                                title="Preview in browser"
+                              >
+                                <i className="bi bi-play-circle me-1"></i>
+                                Preview
+                              </button>
+                            )}
+                            <button
+                              className="btn btn-outline-primary btn-sm text-nowrap"
+                              onClick={() => handleDownloadRequest(file)}
+                            >
+                              <i className="bi bi-download me-1"></i>
+                              Download
+                            </button>
+                          </div>
+                        )}
                       </td>
                     </tr>
-                  ))}
+                    );
+                  })}
                 </tbody>
               </table>
             </ScrollableTable>


### PR DESCRIPTION
Closes #262

## Summary

- Files over 50 MB were being **silently truncated** at three points in `FileExtractionService` and stored as broken/incomplete data in MinIO — now they are **discarded** entirely
- A **warning is logged** with filename and byte count at each discard site
- A **DB sentinel row** is saved with `skipped_reason = 'exceeds_size_limit'` and no `minio_path`, so the detection event is visible without storing corrupt data
- Download/preview endpoints now return **404** if `minio_path` is null
- `skipped_reason` is **exposed in the API response** DTO
- Frontend renders a yellow **"Too large" badge** for skipped rows instead of Download/Preview buttons, and the info card documents the limit
- Flyway migration V3: makes `minio_path` nullable, adds `skipped_reason VARCHAR(100)`

Also:
- README docs section now links to GitHub Pages instead of local Sphinx build instructions
- Corrects the inaccurate "runs entirely offline — no data leaves your infrastructure" claim in `docs/index.rst` (ipinfo.io is contacted when internet is available)

## Test plan
- [ ] Upload a PCAP containing an HTTP object or raw stream file > 50 MB — verify it appears in the Extracted Files table with a "Too large" badge and no Download button
- [ ] Verify a warning log line appears: `Skipping extracted file ... exceeds 50 MB limit`
- [ ] Verify the DB row has `minio_path = NULL` and `skipped_reason = 'exceeds_size_limit'`
- [ ] Attempt to GET the download/preview endpoint for the skipped row — expect 404
- [ ] Normal files under 50 MB still extract and download correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)