### PR TITLE
fix: remove incorrect protocol reference link from Category and Risk Type popovers (#267)

### DIFF
--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -525,7 +525,12 @@ export function NetworkControls({
                         <InfoPopover
                           id="nc-info-cat"
                           title="Category"
-                          body="Broad traffic category assigned by nDPI (e.g. Web, Media, VPN). Select multiple to show any of them."
+                          body={
+                            <>
+                              Broad traffic category assigned by <strong>nDPI</strong> (e.g. Web,
+                              Media, VPN). Select multiple to show any of them.
+                            </>
+                          }
                         />
                       }
                       onSelectAll={() =>
@@ -568,7 +573,13 @@ export function NetworkControls({
                         <InfoPopover
                           id="nc-info-risk"
                           title="Risk Type"
-                          body="Filter by nDPI risk flags assigned to a conversation. Examples: clear-text credentials, unsafe protocols, known malicious signatures."
+                          body={
+                            <>
+                              Filter by <strong>nDPI</strong> risk flags assigned to a conversation.
+                              Examples: clear-text credentials, unsafe protocols, known malicious
+                              signatures.
+                            </>
+                          }
                         />
                       }
                       onSelectAll={() =>

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -525,20 +525,7 @@ export function NetworkControls({
                         <InfoPopover
                           id="nc-info-cat"
                           title="Category"
-                          body={
-                            <>
-                              Broad traffic category assigned by <strong>nDPI</strong> (e.g. Web,
-                              Media, VPN). Select multiple to show any of them.
-                              <br />
-                              <a
-                                href="/ndpi-reference.html"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                View protocol reference →
-                              </a>
-                            </>
-                          }
+                          body="Broad traffic category assigned by nDPI (e.g. Web, Media, VPN). Select multiple to show any of them."
                         />
                       }
                       onSelectAll={() =>
@@ -581,21 +568,7 @@ export function NetworkControls({
                         <InfoPopover
                           id="nc-info-risk"
                           title="Risk Type"
-                          body={
-                            <>
-                              Filter by <strong>nDPI</strong> risk flags assigned to a conversation.
-                              Examples: clear-text credentials, unsafe protocols, known malicious
-                              signatures.
-                              <br />
-                              <a
-                                href="/ndpi-reference.html"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                View protocol reference →
-                              </a>
-                            </>
-                          }
+                          body="Filter by nDPI risk flags assigned to a conversation. Examples: clear-text credentials, unsafe protocols, known malicious signatures."
                         />
                       }
                       onSelectAll={() =>


### PR DESCRIPTION
Closes #267

## Problem

In `NetworkControls.tsx` (the Network Diagram filter panel), the **Category** and **Risk Type** info popovers both included a "View protocol reference →" link pointing to `/ndpi-reference.html`. That page lists nDPI application/protocol names — it is relevant to the **Application** filter, but not to categories or risk flags.

## Fix

Removed the link from the Category and Risk Type popovers in `NetworkControls.tsx`. The popover text is unchanged. This matches the existing correct behaviour in `ConversationFilterPanel.tsx`, where only the Application popover has the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)