### PR TITLE
docs: add Star History section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,18 @@ The [`sample-files/`](sample-files/) directory contains example PCAP files:
 
 These files can be used to test the application's analysis capabilities.
 
+## Star History
+
+If you find TracePcap useful, consider giving it a star! ⭐
+
+<a href="https://star-history.com/#NotYuSheng/TracePcap&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=NotYuSheng/TracePcap&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=NotYuSheng/TracePcap&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=NotYuSheng/TracePcap&type=Date" />
+  </picture>
+</a>
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -525,7 +525,12 @@ export function NetworkControls({
                         <InfoPopover
                           id="nc-info-cat"
                           title="Category"
-                          body="Broad traffic category assigned by nDPI (e.g. Web, Media, VPN). Select multiple to show any of them."
+                          body={
+                            <>
+                              Broad traffic category assigned by <strong>nDPI</strong> (e.g. Web,
+                              Media, VPN). Select multiple to show any of them.
+                            </>
+                          }
                         />
                       }
                       onSelectAll={() =>
@@ -568,7 +573,13 @@ export function NetworkControls({
                         <InfoPopover
                           id="nc-info-risk"
                           title="Risk Type"
-                          body="Filter by nDPI risk flags assigned to a conversation. Examples: clear-text credentials, unsafe protocols, known malicious signatures."
+                          body={
+                            <>
+                              Filter by <strong>nDPI</strong> risk flags assigned to a conversation.
+                              Examples: clear-text credentials, unsafe protocols, known malicious
+                              signatures.
+                            </>
+                          }
                         />
                       }
                       onSelectAll={() =>

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -525,20 +525,7 @@ export function NetworkControls({
                         <InfoPopover
                           id="nc-info-cat"
                           title="Category"
-                          body={
-                            <>
-                              Broad traffic category assigned by <strong>nDPI</strong> (e.g. Web,
-                              Media, VPN). Select multiple to show any of them.
-                              <br />
-                              <a
-                                href="/ndpi-reference.html"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                View protocol reference →
-                              </a>
-                            </>
-                          }
+                          body="Broad traffic category assigned by nDPI (e.g. Web, Media, VPN). Select multiple to show any of them."
                         />
                       }
                       onSelectAll={() =>
@@ -581,21 +568,7 @@ export function NetworkControls({
                         <InfoPopover
                           id="nc-info-risk"
                           title="Risk Type"
-                          body={
-                            <>
-                              Filter by <strong>nDPI</strong> risk flags assigned to a conversation.
-                              Examples: clear-text credentials, unsafe protocols, known malicious
-                              signatures.
-                              <br />
-                              <a
-                                href="/ndpi-reference.html"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                View protocol reference →
-                              </a>
-                            </>
-                          }
+                          body="Filter by nDPI risk flags assigned to a conversation. Examples: clear-text credentials, unsafe protocols, known malicious signatures."
                         />
                       }
                       onSelectAll={() =>


### PR DESCRIPTION
Closes #269

## Summary
- Adds a `## Star History` section to the README above the License section
- Embeds a star-history.com chart with responsive light/dark mode support
- Matches the pattern already used in the MeetMemo project

## Test plan
- [ ] Verify the chart renders correctly on the GitHub README (light and dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)