### PR TITLE
docs: show version in page footer

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,0 +1,6 @@
+{% extends "!footer.html" %}
+{% block extrafooter %}
+<p class="tracepcap-version" style="margin-top:4px; font-size:0.85em; color:#999;">
+  TracePcap v{{ release }}
+</p>
+{% endblock %}

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,6 +1,4 @@
 {% extends "!footer.html" %}
 {% block extrafooter %}
-<p class="tracepcap-version" style="margin-top:4px; font-size:0.85em; color:#999;">
-  TracePcap v{{ release }}
-</p>
+<p class="tracepcap-version">TracePcap v{{ release }}</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- The RTD theme only renders the `version`/`release` from `conf.py` in the sidebar when hosted on ReadTheDocs.org (gated by `READTHEDOCS` env var). For self-hosted/locally built docs it was only visible in the browser `<title>` tag.
- Adds `docs/_templates/footer.html` extending the RTD base footer via the `extrafooter` block to render **TracePcap v1.0.1** at the bottom of every page.
- Version is templated from `{{ release }}` in `conf.py` — future version bumps only require updating `conf.py`.

## Test plan
- [ ] Run `sphinx-build -b html docs docs/_build/html` and open any page — version string appears in the footer
- [ ] Confirm no other footer content is affected (copyright, prev/next buttons still render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)