### PR TITLE
docs: document Network Monitor feature in Sphinx docs

### DIFF
--- a/docs/features/network-monitor.rst
+++ b/docs/features/network-monitor.rst
@@ -319,7 +319,7 @@ Change Events
      - List change events. Optional query params: ``changeType``, ``severity``.
    * - ``PATCH``
      - ``/api/monitor/networks/{networkId}/changes/{eventId}``
-     - Update ``reviewed`` (boolean) and/or ``notes`` (string) on an event.
+     - Update an event. Body: ``{ "reviewed": boolean, "notes": "string" }`` (both fields optional).
 
 Baseline Definitions
 ~~~~~~~~~~~~~~~~~~~~
@@ -336,7 +336,7 @@ Baseline Definitions
      - List all baseline definitions for a network.
    * - ``POST``
      - ``/api/monitor/networks/{networkId}/baseline/definitions``
-     - Create a definition. Body: ``{ "entryType": "DEVICE|IP_MAC_BINDING|GATEWAY|PROTOCOL|APP|VPN_FINGERPRINT", "entityKey": "string", "entityValue": "string", "notes": "string" }``.
+     - Create a definition. Body: ``{ "entryType": "DEVICE|IP_MAC_BINDING|GATEWAY|PROTOCOL|APP|VPN_FINGERPRINT", "entityKey": "string", "entityValue": "string?", "notes": "string?" }`` (``entityValue`` and ``notes`` are optional).
    * - ``DELETE``
      - ``/api/monitor/networks/{networkId}/baseline/definitions/{definitionId}``
      - Delete a baseline definition.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,8 +30,8 @@ TracePcap Documentation
    features/story-mode
    features/custom-signatures
    features/report-export
-   features/streaming-upload
    features/network-monitor
+   features/streaming-upload
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Closes #301

## Summary

- New page `docs/features/network-monitor.rst` covering the Network Monitor feature (PR #296)
- Added to `docs/index.rst` toctree under Features, positioned before `streaming-upload` (which is a companion feature for automating Monitor snapshot ingestion)
- Fixed baseline definition API field names (`entryType`, `entityValue`, `notes`) to match `CreateBaselineDefinitionRequest` DTO

## Test plan

- [ ] `make html` in `docs/` builds without warnings
- [ ] `network-monitor` page appears in the Features toctree, before `streaming-upload`
- [ ] API reference tables render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)