### PR TITLE
fix: tooltip z-index clipped by Traffic Overview card overflow hidden

### DIFF
--- a/frontend/src/pages/Monitor/NetworkDetailPage.tsx
+++ b/frontend/src/pages/Monitor/NetworkDetailPage.tsx
@@ -279,7 +279,7 @@ export const NetworkDetailPage = () => {
 
       {/* Traffic Overview Chart */}
       {snapshots.length >= 2 && (
-        <Card className="mb-4" style={{ overflow: 'hidden' }}>
+        <Card className="mb-4">
           <div className="card-header">
             <h6 className="mb-0">
               <i className="bi bi-bar-chart-line me-2"></i>Traffic Overview


### PR DESCRIPTION
Closes #305

## Summary
- Removed `overflow: 'hidden'` inline style from the Traffic Overview `<Card>` in `NetworkDetailPage.tsx`
- The card's overflow clipping was preventing the recharts tooltip from rendering outside the card bounds, even though the tooltip already had `wrapperStyle={{ zIndex: 9999 }}`

## Test plan
- [ ] Open a network with 2+ snapshots to see the Traffic Overview chart
- [ ] Hover over bars in the chart — tooltip should appear above the card without being clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)