### PR TITLE
fix: invert navbar toggler icon in dark mode

### DIFF
--- a/frontend/src/assets/styles/sgds-overrides.css
+++ b/frontend/src/assets/styles/sgds-overrides.css
@@ -385,6 +385,10 @@
   filter: invert(1) grayscale(100%) brightness(200%);
 }
 
+[data-theme='dark'] .navbar-toggler-icon {
+  filter: invert(1);
+}
+
 [data-theme='dark'] .btn-light {
   background-color: var(--tp-surface);
   border-color: var(--tp-border);

--- a/frontend/src/assets/styles/sgds-overrides.css
+++ b/frontend/src/assets/styles/sgds-overrides.css
@@ -386,7 +386,7 @@
 }
 
 [data-theme='dark'] .navbar-toggler-icon {
-  filter: invert(1);
+  filter: invert(1) grayscale(100%) brightness(200%);
 }
 
 [data-theme='dark'] .btn-light {


### PR DESCRIPTION
Closes #308

## Summary
- The `.navbar-toggler-icon` uses a hardcoded dark SVG background-image from Bootstrap/SGDS
- In dark mode the icon renders black and is invisible against the dark navbar background
- Adds `filter: invert(1)` under `[data-theme='dark']` in `sgds-overrides.css` to flip it white

## Test plan
- [ ] Switch to dark mode and resize the viewport to trigger the collapsed navbar
- [ ] Verify the hamburger icon is visible (white) against the dark background
- [ ] Verify the icon remains correct in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)