### PR TITLE
chore: replace raw Bootstrap class strings with SGDS components

### DIFF
--- a/frontend/src/components/analysis/CategoryBreakdown/CategoryBreakdownChart.tsx
+++ b/frontend/src/components/analysis/CategoryBreakdown/CategoryBreakdownChart.tsx
@@ -2,7 +2,7 @@ import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recha
 import type { CategoryStat } from '@/types';
 import { getCategoryColor } from '@/utils/appColors';
 import { formatBytes } from '@/utils/formatters';
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Button, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 
 const categoryInfoPopover = (
   <Popover id="category-info" style={{ maxWidth: '310px' }}>
@@ -49,14 +49,15 @@ export const CategoryBreakdownChart = ({ categoryStats }: CategoryBreakdownChart
       <h3 className="breakdown-title d-flex align-items-center gap-2">
         Category Distribution
         <OverlayTrigger trigger="click" placement="right" overlay={categoryInfoPopover} rootClose>
-          <button
+          <Button
             type="button"
-            className="btn btn-link p-0 text-muted"
+            variant="link"
+            className="p-0 text-muted"
             style={{ lineHeight: 1 }}
             aria-label="About category detection accuracy"
           >
             <i className="bi bi-info-circle fs-6"></i>
-          </button>
+          </Button>
         </OverlayTrigger>
       </h3>
 

--- a/frontend/src/components/analysis/ProtocolBreakdown/ProtocolBreakdownChart.tsx
+++ b/frontend/src/components/analysis/ProtocolBreakdown/ProtocolBreakdownChart.tsx
@@ -1,6 +1,6 @@
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
 import type { ProtocolStats } from '@/types';
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Button, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import './ProtocolBreakdownChart.css';
 
 interface ProtocolBreakdownChartProps {
@@ -58,14 +58,15 @@ export const ProtocolBreakdownChart = ({ protocolStats }: ProtocolBreakdownChart
       <h3 className="breakdown-title d-flex align-items-center gap-2">
         Protocol Distribution
         <OverlayTrigger trigger="click" placement="right" overlay={protocolInfoPopover} rootClose>
-          <button
+          <Button
             type="button"
-            className="btn btn-link p-0 text-muted"
+            variant="link"
+            className="p-0 text-muted"
             style={{ lineHeight: 1 }}
             aria-label="About protocol detection accuracy"
           >
             <i className="bi bi-info-circle fs-6"></i>
-          </button>
+          </Button>
         </OverlayTrigger>
       </h3>
 

--- a/frontend/src/components/common/DeviceClassificationPopup/DeviceClassificationPopup.tsx
+++ b/frontend/src/components/common/DeviceClassificationPopup/DeviceClassificationPopup.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { Badge } from '@govtechsg/sgds-react';
 import { deviceTypeLabel, deviceTypeColor, confidenceLevel, buildDeviceSignals } from '@/utils/deviceType';
 import { portToServiceLabel } from '@/utils/portUtils';
 import { useClickOutside } from '@/utils/useClickOutside';
@@ -88,7 +89,7 @@ export function DeviceClassificationPopup({ info, onClose }: DeviceClassificatio
                 Type
               </span>
               <div>
-                <span className="badge bg-secondary">{typeLabel}</span>
+                <Badge bg="secondary">{typeLabel}</Badge>
                 {typeNote && (
                   <div className="mt-1 text-muted" style={{ fontSize: '0.75rem' }}>
                     {typeNote}
@@ -105,9 +106,9 @@ export function DeviceClassificationPopup({ info, onClose }: DeviceClassificatio
             Device
           </span>
           <div style={{ flex: 1 }}>
-            <span className="badge" style={{ backgroundColor: badgeBg, color: '#fff' }}>
+            <Badge style={{ backgroundColor: badgeBg, color: '#fff' }}>
               {deviceTypeLabel(info.deviceType)}
-            </span>
+            </Badge>
             {signals.length > 0 && (
               <ul className="mb-1 ps-3 mt-1 text-muted" style={{ fontSize: '0.75rem' }}>
                 {signals.map((s, i) => (
@@ -148,9 +149,9 @@ export function DeviceClassificationPopup({ info, onClose }: DeviceClassificatio
               Role
             </span>
             <div>
-              <span className={`badge ${info.role === 'client' ? 'bg-primary' : 'bg-success'}`}>
+              <Badge bg={info.role === 'client' ? 'primary' : 'success'}>
                 {info.role.charAt(0).toUpperCase() + info.role.slice(1)}
-              </span>
+              </Badge>
               <div className="mt-1 text-muted" style={{ fontSize: '0.75rem' }}>
                 {info.role === 'client'
                   ? 'Initiated this conversation'

--- a/frontend/src/components/common/ErrorMessage/ErrorMessage.tsx
+++ b/frontend/src/components/common/ErrorMessage/ErrorMessage.tsx
@@ -1,3 +1,4 @@
+import { Alert, Button } from '@govtechsg/sgds-react';
 import './ErrorMessage.css';
 
 interface ErrorMessageProps {
@@ -9,7 +10,7 @@ interface ErrorMessageProps {
 export const ErrorMessage = ({ title = 'Error', message, onRetry }: ErrorMessageProps) => {
   return (
     <div className="error-message-container">
-      <div className="alert alert-danger" role="alert">
+      <Alert variant="danger" role="alert">
         <div className="error-icon">
           <i className="bi bi-exclamation-triangle-fill"></i>
         </div>
@@ -17,12 +18,12 @@ export const ErrorMessage = ({ title = 'Error', message, onRetry }: ErrorMessage
           <h5 className="error-title">{title}</h5>
           <p className="error-text">{message}</p>
           {onRetry && (
-            <button type="button" className="btn btn-sm btn-outline-danger" onClick={onRetry}>
+            <Button size="sm" variant="outline-danger" onClick={onRetry}>
               <i className="bi bi-arrow-clockwise"></i> Retry
-            </button>
+            </Button>
           )}
         </div>
-      </div>
+      </Alert>
     </div>
   );
 };

--- a/frontend/src/components/common/Layout/MainLayout.tsx
+++ b/frontend/src/components/common/Layout/MainLayout.tsx
@@ -1,6 +1,7 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect } from 'react';
 import { Link, Outlet, useLocation } from 'react-router-dom';
-import { Container, Row, Col, Navbar, Nav } from '@govtechsg/sgds-react';
+import { Button, Container, Row, Col, Navbar, Nav } from '@govtechsg/sgds-react';
 import { Activity } from 'lucide-react';
 import { SignaturesModal } from '@components/signatures/SignaturesModal';
 import { useStore } from '@/store';
@@ -85,7 +86,7 @@ export const MainLayout = () => {
       <Outlet />
     ) : (
       <div className="d-flex flex-column align-items-center justify-content-center gap-3 py-5 text-muted">
-        <div className="spinner-border text-primary" role="status" aria-hidden="true" />
+        <Spinner animation="border" className="text-primary" />
         <div className="text-center">
           <p className="mb-1 fw-semibold">Backend is starting up…</p>
           <small>This may take up to a minute on first launch.</small>
@@ -122,22 +123,24 @@ export const MainLayout = () => {
               </Nav>
 
               <div className="d-flex align-items-center gap-2 ms-auto">
-                <button
+                <Button
                   type="button"
-                  className="btn btn-sm btn-outline-secondary"
+                  size="sm"
+                  variant="outline-secondary"
                   onClick={cycleTheme}
                   aria-label={THEME_LABELS[themeMode]}
                   title={THEME_LABELS[themeMode]}
                 >
                   <i className={`bi ${THEME_ICONS[themeMode]}`}></i>
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
-                  className="btn btn-sm btn-outline-secondary"
+                  size="sm"
+                  variant="outline-secondary"
                   onClick={() => setShowSignatures(true)}
                 >
                   <i className="bi bi-shield-check me-1"></i>Custom Detection Rules
-                </button>
+                </Button>
               </div>
             </Navbar.Collapse>
           </Container>

--- a/frontend/src/components/common/NodeClassificationPopup/NodeClassificationPopup.tsx
+++ b/frontend/src/components/common/NodeClassificationPopup/NodeClassificationPopup.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { Badge } from '@govtechsg/sgds-react';
 import type { NodeType, NodeTypeEvidence } from '@/features/network/types';
 import type { DeviceType } from '@/types';
 import { deviceTypeLabel, deviceTypeColor, confidenceLevel, buildDeviceSignals } from '@/utils/deviceType';
@@ -114,7 +115,7 @@ export function NodeClassificationPopup({ info, onClose }: Props) {
             Type
           </span>
           <div>
-            <span className={`badge ${info.typeBadgeClass}`}>{info.typeLabel}</span>
+            <Badge className={info.typeBadgeClass}>{info.typeLabel}</Badge>
             {evText && (
               <div className="text-muted mt-1" style={{ fontSize: '0.75rem' }}>
                 {evText}
@@ -130,9 +131,9 @@ export function NodeClassificationPopup({ info, onClose }: Props) {
               Device
             </span>
             <div style={{ flex: 1 }}>
-              <span className="badge" style={{ backgroundColor: deviceBg, color: '#fff' }}>
+              <Badge style={{ backgroundColor: deviceBg, color: '#fff' }}>
                 {deviceTypeLabel(info.deviceType)}
-              </span>
+              </Badge>
               {deviceSignals.length > 0 && (
                 <ul className="mb-1 ps-3 mt-1" style={{ fontSize: '0.75rem', color: 'var(--tp-text-muted)' }}>
                   {deviceSignals.map((s, i) => (
@@ -173,9 +174,9 @@ export function NodeClassificationPopup({ info, onClose }: Props) {
             Role
           </span>
           <div>
-            <span className="badge bg-secondary">
+            <Badge bg="secondary">
               {info.role.charAt(0).toUpperCase() + info.role.slice(1)}
-            </span>
+            </Badge>
             <div className="text-muted mt-1" style={{ fontSize: '0.75rem' }}>
               {info.initiated} initiated · {info.received} received
             </div>

--- a/frontend/src/components/common/Pagination/Pagination.tsx
+++ b/frontend/src/components/common/Pagination/Pagination.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pagination as SgdsPagination } from '@govtechsg/sgds-react';
+import { Form, Pagination as SgdsPagination } from '@govtechsg/sgds-react';
 import './Pagination.css';
 
 interface PaginationProps {
@@ -50,12 +50,11 @@ export const Pagination: React.FC<PaginationProps> = ({
 
         {showPageSizeSelector && onPageSizeChange && (
           <div className="page-size-selector">
-            <label htmlFor="pageSize" className="form-label">
+            <Form.Label htmlFor="pageSize">
               Items per page:
-            </label>
-            <select
+            </Form.Label>
+            <Form.Select
               id="pageSize"
-              className="form-select"
               value={pageSize}
               onChange={handlePageSizeChange}
             >
@@ -64,7 +63,7 @@ export const Pagination: React.FC<PaginationProps> = ({
                   {size}
                 </option>
               ))}
-            </select>
+            </Form.Select>
           </div>
         )}
       </div>

--- a/frontend/src/components/common/Spinner/Spinner.tsx
+++ b/frontend/src/components/common/Spinner/Spinner.tsx
@@ -1,0 +1,13 @@
+interface SpinnerProps {
+  animation?: 'border' | 'grow';
+  size?: 'sm';
+  className?: string;
+  style?: React.CSSProperties;
+  role?: string;
+}
+
+export function Spinner({ animation = 'border', size, className, style, role }: SpinnerProps) {
+  const sizeClass = size === 'sm' ? `spinner-${animation}-sm` : '';
+  const cls = [`spinner-${animation}`, sizeClass, className].filter(Boolean).join(' ');
+  return <div className={cls} style={style} role={role ?? 'status'} aria-hidden="true" />;
+}

--- a/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
+++ b/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
+import { Badge, Button, Card } from '@govtechsg/sgds-react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import type { Conversation, ConversationGeoInfo, Packet, HostClassification } from '@/types';
@@ -75,13 +76,13 @@ function GeoSourceBadge({ source }: { source?: string }) {
 
   return (
     <>
-      <span
-        className="ms-2 badge"
+      <Badge
+        className="ms-2"
         style={{ backgroundColor: info.bg, color: '#fff', fontSize: '0.7em', cursor: 'pointer' }}
         onClick={handleClick}
       >
         {info.label}
-      </span>
+      </Badge>
       {popoverPos && createPortal(
         <div
           style={{
@@ -103,7 +104,7 @@ function GeoSourceBadge({ source }: { source?: string }) {
           <div className="fw-semibold mb-1" style={{ fontSize: 12 }}>{info.title}</div>
           <div className="text-muted">{info.description}</div>
           <div className="text-end mt-2">
-            <button className="btn btn-sm btn-outline-secondary" style={{ fontSize: 10, padding: '1px 8px' }} onClick={() => setPopoverPos(null)}>Close</button>
+            <Button size="sm" variant="outline-secondary" style={{ fontSize: 10, padding: '1px 8px' }} onClick={() => setPopoverPos(null)}>Close</Button>
           </div>
         </div>,
         document.body
@@ -226,20 +227,21 @@ export const ConversationDetail = ({
   return (
     <div className="conversation-detail">
       <div className="card mb-4">
-        <div className="card-header d-flex align-items-center justify-content-between">
+        <Card.Header className="d-flex align-items-center justify-content-between">
           <h5 className="mb-0">Conversation Details</h5>
           {extractedCount != null && extractedCount > 0 && fileId && (
-            <button
-              className="btn btn-sm btn-outline-warning"
+            <Button
+              size="sm"
+              variant="outline-warning"
               onClick={() => navigate(`/analysis/${fileId}/extracted-files`)}
               title="Files extracted from this conversation's stream"
             >
               <i className="bi bi-file-earmark-arrow-down me-1"></i>
               {extractedCount} extracted file{extractedCount !== 1 ? 's' : ''}
-            </button>
+            </Button>
           )}
-        </div>
-        <div className="card-body">
+        </Card.Header>
+        <Card.Body>
           <div className="row">
             <div className="col-md-6">
               <dl className="row mb-0">
@@ -247,8 +249,8 @@ export const ConversationDetail = ({
                 <dd className="col-sm-8">
                   {formatIpPort(source.ip, source.port)}
                   {srcClass && (
-                    <span
-                      className="ms-2 badge"
+                    <Badge
+                      className="ms-2"
                       style={{
                         backgroundColor: deviceTypeColor(srcClass.deviceType),
                         color: '#fff',
@@ -259,15 +261,15 @@ export const ConversationDetail = ({
                       onClick={e => openDevicePopup(srcClass, source.ip, 'client', e)}
                     >
                       {deviceTypeLabel(srcClass.deviceType)}
-                    </span>
+                    </Badge>
                   )}
                 </dd>
                 <dt className="col-sm-4">Destination:</dt>
                 <dd className="col-sm-8">
                   {formatIpPort(destination.ip, destination.port)}
                   {dstClass && (
-                    <span
-                      className="ms-2 badge"
+                    <Badge
+                      className="ms-2"
                       style={{
                         backgroundColor: deviceTypeColor(dstClass.deviceType),
                         color: '#fff',
@@ -278,7 +280,7 @@ export const ConversationDetail = ({
                       onClick={e => openDevicePopup(dstClass, destination.ip, 'server', e)}
                     >
                       {deviceTypeLabel(dstClass.deviceType)}
-                    </span>
+                    </Badge>
                   )}
                   {conversation.hostname && (
                     <small className="text-info d-block">{conversation.hostname}</small>
@@ -291,12 +293,9 @@ export const ConversationDetail = ({
                   {(() => {
                     const bg = getProtocolColor(conversation.protocol.name);
                     return (
-                      <span
-                        className="badge"
-                        style={{ backgroundColor: bg, color: getTextColor(bg) }}
-                      >
+                      <Badge style={{ backgroundColor: bg, color: getTextColor(bg) }}>
                         {conversation.protocol.name}
-                      </span>
+                      </Badge>
                     );
                   })()}
                 </dd>
@@ -307,12 +306,9 @@ export const ConversationDetail = ({
                       {(() => {
                         const bg = getL7ProtocolColor(conversation.tsharkProtocol!);
                         return (
-                          <span
-                            className="badge"
-                            style={{ backgroundColor: bg, color: getTextColor(bg) }}
-                          >
+                          <Badge style={{ backgroundColor: bg, color: getTextColor(bg) }}>
                             {conversation.tsharkProtocol}
-                          </span>
+                          </Badge>
                         );
                       })()}
                     </dd>
@@ -325,12 +321,9 @@ export const ConversationDetail = ({
                       {(() => {
                         const bg = getAppColor(conversation.appName!);
                         return (
-                          <span
-                            className="badge"
-                            style={{ backgroundColor: bg, color: getTextColor(bg) }}
-                          >
+                          <Badge style={{ backgroundColor: bg, color: getTextColor(bg) }}>
                             {conversation.appName}
-                          </span>
+                          </Badge>
                         );
                       })()}
                     </dd>
@@ -342,9 +335,8 @@ export const ConversationDetail = ({
                     <dd className="col-sm-8">
                       <div className="d-flex flex-wrap gap-1">
                         {conversation.flowRisks.map(risk => (
-                          <span
+                          <Badge
                             key={risk}
-                            className="badge"
                             style={{
                               backgroundColor: RISK_BADGE.bg,
                               color: RISK_BADGE.text,
@@ -352,7 +344,7 @@ export const ConversationDetail = ({
                             }}
                           >
                             {risk}
-                          </span>
+                          </Badge>
                         ))}
                       </div>
                     </dd>
@@ -366,13 +358,12 @@ export const ConversationDetail = ({
                         {conversation.customSignatures.map(rule => {
                           const { bg, text } = getSeverityColor(signatureSeverities[rule]);
                           return (
-                            <span
+                            <Badge
                               key={rule}
-                              className="badge"
                               style={{ backgroundColor: bg, color: text, whiteSpace: 'nowrap' }}
                             >
                               {rule.replace(/_/g, ' ')}
-                            </span>
+                            </Badge>
                           );
                         })}
                       </div>
@@ -446,7 +437,7 @@ export const ConversationDetail = ({
                       >
                         {formatTimestamp(conversation.tlsNotAfter)}
                         {conversation.tlsNotAfter < Date.now() && (
-                          <span className="ms-1 badge bg-danger">Expired</span>
+                          <Badge bg="danger" className="ms-1">Expired</Badge>
                         )}
                       </small>
                     </dd>
@@ -467,11 +458,11 @@ export const ConversationDetail = ({
               </dl>
             </div>
           </div>
-        </div>
+        </Card.Body>
       </div>
 
       <div className="card">
-        <div className="card-header">
+        <Card.Header>
           <ul className="nav nav-tabs card-header-tabs">
             <li className="nav-item">
               <button
@@ -479,9 +470,9 @@ export const ConversationDetail = ({
                 onClick={() => setActiveTab('packets')}
               >
                 Packets
-                <span className="badge bg-secondary ms-2" style={{ fontSize: '0.65rem' }}>
+                <Badge bg="secondary" className="ms-2" style={{ fontSize: '0.65rem' }}>
                   {conversation.packets?.length || 0}
-                </span>
+                </Badge>
               </button>
             </li>
             <li className="nav-item">
@@ -493,10 +484,10 @@ export const ConversationDetail = ({
               </button>
             </li>
           </ul>
-        </div>
+        </Card.Header>
 
         {activeTab === 'packets' && (
-          <div className="card-body p-0">
+          <Card.Body className="p-0">
             <div className="px-3 py-2 border-bottom d-flex justify-content-end">
               <small className="text-muted">Click a row to view hex payload</small>
             </div>
@@ -575,13 +566,14 @@ export const ConversationDetail = ({
                           <td style={{ whiteSpace: 'nowrap' }}>{packet.size} B</td>
                           <td>
                             {packet.detectedFileType ? (
-                              <span
-                                className="badge bg-info text-dark"
+                              <Badge
+                                bg="info"
+                                text="dark"
                                 style={{ fontSize: '0.65rem' }}
                                 title={`Magic bytes match: ${packet.detectedFileType}`}
                               >
                                 {packet.detectedFileType}
-                              </span>
+                              </Badge>
                             ) : (
                               <span className="text-muted">—</span>
                             )}
@@ -591,12 +583,14 @@ export const ConversationDetail = ({
                               {packet.info ?? packet.protocol.name}
                             </small>
                             {asciiPacketIds.has(packet.id) && (
-                              <span
-                                className="badge bg-warning text-dark ms-1"
+                              <Badge
+                                bg="warning"
+                                text="dark"
+                                className="ms-1"
                                 style={{ fontSize: '0.65rem' }}
                               >
                                 ASCII
-                              </span>
+                              </Badge>
                             )}
                           </td>
                         </tr>
@@ -626,13 +620,13 @@ export const ConversationDetail = ({
                 </tbody>
               </table>
             </div>
-          </div>
+          </Card.Body>
         )}
 
         {activeTab === 'session' && (
-          <div className="card-body">
+          <Card.Body>
             <SessionTab conversationId={conversation.id} protocol={conversation.protocol.name} />
-          </div>
+          </Card.Body>
         )}
       </div>
 

--- a/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
+++ b/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { PillSectionHeader } from '@components/common/PillSectionHeader/PillSectionHeader';
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Badge, Button, Card, Form, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import type { ConversationFilters } from '@/features/conversation/types';
 import { COLUMN_DEFS } from '@/features/conversation/constants';
 import type { ColumnKey } from '@/features/conversation/constants';
@@ -57,14 +57,15 @@ function InfoPopover({ id, title, body }: { id: string; title: string; body: Rea
   );
   return (
     <OverlayTrigger trigger="click" placement="right" overlay={popover} rootClose>
-      <button
+      <Button
         type="button"
-        className="btn btn-link p-0 text-muted ms-1"
+        variant="link"
+        className="p-0 text-muted ms-1"
         style={{ lineHeight: 1 }}
         aria-label={`About ${title}`}
       >
         <i className="bi bi-info-circle" style={{ fontSize: '0.8rem' }}></i>
-      </button>
+      </Button>
     </OverlayTrigger>
   );
 }
@@ -147,24 +148,24 @@ export function ConversationFilterPanel({
     <div className="conversation-filter-panel mb-3">
       {/* Toggle button */}
       <div className="d-flex align-items-center gap-2">
-        <button
-          type="button"
-          className="btn btn-outline-secondary btn-sm"
+        <Button
+          size="sm"
+          variant="outline-secondary"
           onClick={() => setIsOpen(o => !o)}
         >
           <i className="bi bi-funnel me-1"></i>
           Filters
           {activeFilterCount > 0 && (
-            <span className="badge bg-primary ms-2">{activeFilterCount}</span>
+            <Badge bg="primary" className="ms-2">{activeFilterCount}</Badge>
           )}
           <i className={`bi ms-2 ${isOpen ? 'bi-chevron-up' : 'bi-chevron-down'}`}></i>
-        </button>
+        </Button>
       </div>
 
       {/* Collapsible panel */}
       {isOpen && (
         <div className="card mt-2 filter-panel-body">
-          <div className="card-body p-3">
+          <Card.Body className="p-3">
             <div className="row g-3">
               {/* IP / Hostname */}
               <div className="col-md-4">
@@ -180,21 +181,19 @@ export function ConversationFilterPanel({
                   <span className="input-group-text">
                     <i className="bi bi-search"></i>
                   </span>
-                  <input
+                  <Form.Control
                     type="text"
-                    className="form-control"
                     placeholder="e.g. 192.168.1.1"
                     value={ipInput}
                     onChange={e => handleIpChange(e.target.value)}
                   />
                   {ipInput && (
-                    <button
-                      type="button"
-                      className="btn btn-outline-secondary"
+                    <Button
+                      variant="outline-secondary"
                       onClick={() => handleIpChange('')}
                     >
                       ×
-                    </button>
+                    </Button>
                   )}
                 </div>
               </div>
@@ -210,22 +209,20 @@ export function ConversationFilterPanel({
                   />
                 </label>
                 <div className="input-group input-group-sm">
-                  <input
+                  <Form.Control
                     type="text"
                     inputMode="numeric"
-                    className="form-control"
                     placeholder="e.g. 443"
                     value={portInput}
                     onChange={e => handlePortChange(e.target.value)}
                   />
                   {portInput && (
-                    <button
-                      type="button"
-                      className="btn btn-outline-secondary"
+                    <Button
+                      variant="outline-secondary"
                       onClick={() => handlePortChange('')}
                     >
                       ×
-                    </button>
+                    </Button>
                   )}
                 </div>
               </div>
@@ -251,37 +248,33 @@ export function ConversationFilterPanel({
                   <span className="input-group-text">
                     <i className="bi bi-search"></i>
                   </span>
-                  <input
+                  <Form.Control
                     type="text"
-                    className="form-control"
                     placeholder="e.g. GET /admin or 0x474554"
                     value={payloadInput}
                     onChange={e => handlePayloadChange(e.target.value)}
                   />
                   {payloadInput && (
-                    <button
-                      type="button"
-                      className="btn btn-outline-secondary"
+                    <Button
+                      variant="outline-secondary"
                       onClick={() => handlePayloadChange('')}
                     >
                       ×
-                    </button>
+                    </Button>
                   )}
                 </div>
               </div>
 
               {/* Security risks toggle */}
               <div className="col-md-2 d-flex align-items-end">
-                <div className="form-check mb-0">
-                  <input
-                    type="checkbox"
-                    className="form-check-input"
+                <Form.Check className="mb-0">
+                  <Form.Check.Input
                     id="hasRisksCheck"
                     checked={filters.hasRisks}
                     onChange={e => onFiltersChange({ hasRisks: e.target.checked })}
                   />
-                  <label
-                    className="form-check-label small d-inline-flex align-items-center"
+                  <Form.Check.Label
+                    className="small d-inline-flex align-items-center"
                     htmlFor="hasRisksCheck"
                   >
                     Security risks only
@@ -290,8 +283,8 @@ export function ConversationFilterPanel({
                       title="Security risks"
                       body="Shows only conversations flagged with at least one nDPI risk indicator, such as unsafe protocols, clear-text credentials, or suspicious traffic patterns."
                     />
-                  </label>
-                </div>
+                  </Form.Check.Label>
+                </Form.Check>
               </div>
 
               {/* Protocol pills */}
@@ -712,18 +705,15 @@ export function ConversationFilterPanel({
                   </label>
                   <div className="d-flex flex-wrap gap-2">
                     {COLUMN_DEFS.map(({ key, label }) => (
-                      <div key={key} className="form-check form-check-inline mb-0">
-                        <input
-                          type="checkbox"
-                          className="form-check-input"
-                          id={`col-${key}`}
-                          checked={visibleColumns.has(key)}
-                          onChange={() => onToggleColumn(key)}
-                        />
-                        <label className="form-check-label small" htmlFor={`col-${key}`}>
-                          {label}
-                        </label>
-                      </div>
+                      <Form.Check
+                        key={key}
+                        inline
+                        className="mb-0"
+                        id={`col-${key}`}
+                        label={label}
+                        checked={visibleColumns.has(key)}
+                        onChange={() => onToggleColumn(key)}
+                      />
                     ))}
                   </div>
                 </div>
@@ -732,16 +722,16 @@ export function ConversationFilterPanel({
 
             {activeFilterCount > 0 && (
               <div className="mt-3 pt-2 border-top">
-                <button
-                  type="button"
-                  className="btn btn-sm btn-outline-secondary"
+                <Button
+                  size="sm"
+                  variant="outline-secondary"
                   onClick={onClearAll}
                 >
                   <i className="bi bi-x-circle me-1"></i>Clear filters
-                </button>
+                </Button>
               </div>
             )}
-          </div>
+          </Card.Body>
         </div>
       )}
     </div>

--- a/frontend/src/components/conversation/ConversationList/ConversationList.tsx
+++ b/frontend/src/components/conversation/ConversationList/ConversationList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Badge } from '@govtechsg/sgds-react';
 import { ScrollableTable } from '@components/common/ScrollableTable';
 import type { Conversation, ConversationGeoInfo, HostClassification } from '@/types';
 import type { SortField, SortDir } from '@/features/conversation/types';
@@ -268,13 +269,14 @@ export const ConversationList = ({
                       conversation.detectedFileTypes.length > 0 ? (
                         <div className="d-inline-flex flex-wrap gap-1">
                           {conversation.detectedFileTypes.map(ft => (
-                            <span
+                            <Badge
                               key={ft}
-                              className="badge bg-info text-dark"
+                              bg="info"
+                              text="dark"
                               style={{ whiteSpace: 'nowrap' }}
                             >
                               {ft}
-                            </span>
+                            </Badge>
                           ))}
                         </div>
                       ) : (

--- a/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
+++ b/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
@@ -1,5 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Alert, Badge, Button, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import { tracerService, type TracerStep, type TracerStepsResponse } from '@/features/tracer/tracerService';
 import { conversationService } from '@/features/conversation/services/conversationService';
 
@@ -25,14 +26,15 @@ function AiExplanationInfoPopover() {
   );
   return (
     <OverlayTrigger trigger="click" placement="right" overlay={popover} rootClose>
-      <button
+      <Button
         type="button"
-        className="btn btn-link p-0 text-muted"
+        variant="link"
+        className="p-0 text-muted"
         style={{ lineHeight: 1, flexShrink: 0 }}
         aria-label="About AI Explanation"
       >
         <i className="bi bi-info-circle" style={{ fontSize: '0.85rem' }}></i>
-      </button>
+      </Button>
     </OverlayTrigger>
   );
 }
@@ -255,9 +257,9 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
               <div className="fw-semibold" style={{ fontSize: 14 }}>Conversation Tracer</div>
               <div style={{ fontSize: 11, color: 'var(--tp-text-muted)', fontFamily: 'monospace' }}>{title}</div>
               {tracer?.protocol && (
-                <span className="badge bg-secondary ms-0 mt-1" style={{ fontSize: 10 }}>
+                <Badge bg="secondary" className="ms-0 mt-1" style={{ fontSize: 10 }}>
                   {tracer.protocol}{tracer.appName ? ` / ${tracer.appName}` : ''}
-                </span>
+                </Badge>
               )}
             </div>
             <button className="btn-close" onClick={onClose} />
@@ -265,12 +267,12 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
 
           {loading && (
             <div className="d-flex align-items-center justify-content-center p-5">
-              <span className="spinner-border text-primary me-2" />
+              <Spinner animation="border" className="text-primary me-2" />
               <span>Loading packets…</span>
             </div>
           )}
 
-          {error && <div className="alert alert-danger m-3">{error}</div>}
+          {error && <Alert variant="danger" className="m-3">{error}</Alert>}
 
           {!loading && !error && tracer && (
             <>
@@ -400,19 +402,20 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
 
               {/* Navigation */}
               <div style={{ padding: '10px 16px', borderBottom: '1px solid var(--tp-border)', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12 }}>
-                <button className="btn btn-sm btn-outline-secondary" onClick={prev} disabled={currentStep === 0}>‹ Prev</button>
+                <Button size="sm" variant="outline-secondary" onClick={prev} disabled={currentStep === 0}>‹ Prev</Button>
                 <span style={{ fontSize: 12, color: 'var(--tp-text-muted)', minWidth: 90, textAlign: 'center' }}>
                   Step {currentStep + 1} / {tracer.steps.length}
                 </span>
-                <button className="btn btn-sm btn-outline-secondary" onClick={next} disabled={currentStep >= tracer.steps.length - 1}>Next ›</button>
-                <button
-                  className={`btn btn-sm ${isPlaying ? 'btn-warning' : 'btn-outline-primary'}`}
+                <Button size="sm" variant="outline-secondary" onClick={next} disabled={currentStep >= tracer.steps.length - 1}>Next ›</Button>
+                <Button
+                  size="sm"
+                  variant={isPlaying ? 'warning' : 'outline-primary'}
                   onClick={togglePlay}
                   disabled={currentStep >= tracer.steps.length - 1}
                   title={isPlaying ? 'Pause' : 'Auto-play'}
                 >
                   <i className={`bi ${isPlaying ? 'bi-pause-fill' : 'bi-play-fill'}`} />
-                </button>
+                </Button>
               </div>
 
               {/* Packet list */}

--- a/frontend/src/components/conversation/SessionTab/SessionTab.tsx
+++ b/frontend/src/components/conversation/SessionTab/SessionTab.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState } from 'react';
+import { Alert, Badge, Button, ButtonGroup, Card } from '@govtechsg/sgds-react';
 import { conversationService } from '@/features/conversation/services/conversationService';
 import type {
   SessionData,
@@ -135,24 +137,26 @@ function HttpMessageBlock({
         </span>
         <code style={{ fontSize: '0.8rem', color: '#fff', flex: 1 }}>{message.firstLine}</code>
         {message.bodyDecompressed && (
-          <span className="badge bg-light text-dark" style={{ fontSize: '0.65rem' }}>
+          <Badge bg="light" text="dark" style={{ fontSize: '0.65rem' }}>
             {message.bodyEncoding ?? 'compressed'} decoded
             {message.bodyCompressedLength > 0 &&
               ` (${formatBytes(message.bodyCompressedLength)} → ${formatBytes(message.bodyLength)})`}
-          </span>
+          </Badge>
         )}
       </div>
 
       <div style={{ padding: '0.5rem 0.75rem' }}>
         {headerEntries.length > 0 && (
           <div className="mb-2">
-            <button
-              className="btn btn-link btn-sm p-0 text-muted"
+            <Button
+              variant="link"
+              size="sm"
+              className="p-0 text-muted"
               onClick={() => setShowHeaders(h => !h)}
               style={{ fontSize: '0.75rem', textDecoration: 'none' }}
             >
               {showHeaders ? '▾' : '▸'} Headers ({headerEntries.length})
-            </button>
+            </Button>
             {showHeaders && (
               <table
                 className="table table-sm table-borderless mb-0 mt-1"
@@ -178,14 +182,16 @@ function HttpMessageBlock({
 
         {message.bodyLength > 0 && (
           <div>
-            <button
-              className="btn btn-link btn-sm p-0 text-muted"
+            <Button
+              variant="link"
+              size="sm"
+              className="p-0 text-muted"
               onClick={() => setShowBody(b => !b)}
               style={{ fontSize: '0.75rem', textDecoration: 'none' }}
             >
               {showBody ? '▾' : '▸'} Body ({formatBytes(message.bodyLength)}
               {message.bodyTruncated ? ', truncated' : ''})
-            </button>
+            </Button>
             {showBody && (
               <pre
                 className="tp-stream-pane"
@@ -219,8 +225,10 @@ function HttpExchangeBlock({ exchange, index }: { exchange: HttpExchange; index:
 
   return (
     <div className="mb-3">
-      <button
-        className="btn btn-link btn-sm p-0 text-muted mb-2"
+      <Button
+        variant="link"
+        size="sm"
+        className="p-0 text-muted mb-2"
         onClick={() => setCollapsed(c => !c)}
         style={{ fontSize: '0.8rem', textDecoration: 'none' }}
       >
@@ -230,7 +238,7 @@ function HttpExchangeBlock({ exchange, index }: { exchange: HttpExchange; index:
             {exchange.request.firstLine.split(' ').slice(0, 2).join(' ')}
           </code>
         )}
-      </button>
+      </Button>
       {!collapsed && (
         <div style={{ paddingLeft: '0.5rem' }}>
           {exchange.request && (
@@ -255,8 +263,10 @@ function StunMessageBlock({ msg, index }: { msg: StunMessage; index: number }) {
 
   return (
     <div className="mb-2">
-      <button
-        className="btn btn-link btn-sm p-0 text-muted mb-1"
+      <Button
+        variant="link"
+        size="sm"
+        className="p-0 text-muted mb-1"
         onClick={() => setCollapsed(c => !c)}
         style={{ fontSize: '0.8rem', textDecoration: 'none' }}
       >
@@ -270,7 +280,7 @@ function StunMessageBlock({ msg, index }: { msg: StunMessage; index: number }) {
         <code className="ms-2" style={{ fontSize: '0.78rem' }}>
           {msg.messageType}
         </code>
-      </button>
+      </Button>
       {!collapsed && (
         <div
           style={{
@@ -351,8 +361,8 @@ function MediaInfoPanel({ info }: { info: MediaInfo }) {
   if (info.streamCount != null) rows.push(['SSRC streams', String(info.streamCount)]);
 
   return (
-    <div className="card mb-3" style={{ fontSize: '0.85rem' }}>
-      <div className="card-body p-3">
+    <Card className="mb-3" style={{ fontSize: '0.85rem' }}>
+      <Card.Body className="p-3">
         <div className="fw-semibold mb-2">
           {info.mediaType} stream detected — {info.containerFormat}
         </div>
@@ -368,8 +378,8 @@ function MediaInfoPanel({ info }: { info: MediaInfo }) {
             </tbody>
           </table>
         )}
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   );
 }
 
@@ -409,9 +419,9 @@ export function SessionTab({ conversationId }: SessionTabProps) {
         <p className="text-muted mb-3">
           Reconstruct the full application-layer byte stream for this conversation.
         </p>
-        <button className="btn btn-primary" onClick={handleReconstruct}>
+        <Button variant="primary" onClick={handleReconstruct}>
           Reconstruct Session
-        </button>
+        </Button>
       </div>
     );
   }
@@ -419,7 +429,7 @@ export function SessionTab({ conversationId }: SessionTabProps) {
   if (loading) {
     return (
       <div className="text-center py-5">
-        <div className="spinner-border text-primary" role="status" />
+        <Spinner animation="border" className="text-primary" role="status" />
         <p className="text-muted mt-3">Reconstructing session…</p>
       </div>
     );
@@ -429,9 +439,9 @@ export function SessionTab({ conversationId }: SessionTabProps) {
     return (
       <div className="text-center py-4">
         <p className="text-danger mb-3">{error}</p>
-        <button className="btn btn-outline-primary btn-sm" onClick={handleReconstruct}>
+        <Button size="sm" variant="outline-primary" onClick={handleReconstruct}>
           Retry
-        </button>
+        </Button>
       </div>
     );
   }
@@ -441,10 +451,10 @@ export function SessionTab({ conversationId }: SessionTabProps) {
   if (session.errorMessage) {
     return (
       <div className="py-4">
-        <div className="alert alert-warning mb-3">{session.errorMessage}</div>
-        <button className="btn btn-outline-primary btn-sm" onClick={handleReconstruct}>
+        <Alert variant="warning" className="mb-3">{session.errorMessage}</Alert>
+        <Button size="sm" variant="outline-primary" onClick={handleReconstruct}>
           Retry
-        </button>
+        </Button>
       </div>
     );
   }
@@ -462,71 +472,73 @@ export function SessionTab({ conversationId }: SessionTabProps) {
       <div className="d-flex align-items-center gap-3 mb-3 flex-wrap">
         <div className="d-flex align-items-center gap-2">
           {session.detectedProtocol && (
-            <span className="badge bg-info text-dark">{session.detectedProtocol}</span>
+            <Badge bg="info" text="dark">{session.detectedProtocol}</Badge>
           )}
           {hasMedia && (
-            <span className="badge bg-primary">
+            <Badge bg="primary">
               {session.mediaInfo!.containerFormat}
-            </span>
+            </Badge>
           )}
           <small className="text-muted">
             ↑ {formatBytes(session.totalClientBytes)} client &nbsp;·&nbsp; ↓{' '}
             {formatBytes(session.totalServerBytes)} server
           </small>
           {session.truncated && (
-            <span className="badge bg-warning text-dark" title="Session truncated at 1 MB">
+            <Badge bg="warning" text="dark" title="Session truncated at 1 MB">
               Truncated
-            </span>
+            </Badge>
           )}
         </div>
 
         {(hasHttp || hasStun) && (
-          <div className="btn-group btn-group-sm">
+          <ButtonGroup size="sm">
             {hasHttp && (
-              <button
-                className={`btn btn-outline-secondary${activeView === 'parsed' ? ' active' : ''}`}
+              <Button
+                variant={activeView === 'parsed' ? 'secondary' : 'outline-secondary'}
                 onClick={() => setActiveView('parsed')}
               >
                 Parsed HTTP
-              </button>
+              </Button>
             )}
             {hasStun && (
-              <button
-                className={`btn btn-outline-secondary${activeView === 'stun' ? ' active' : ''}`}
+              <Button
+                variant={activeView === 'stun' ? 'secondary' : 'outline-secondary'}
                 onClick={() => setActiveView('stun')}
               >
                 STUN Messages
-              </button>
+              </Button>
             )}
-            <button
-              className={`btn btn-outline-secondary${activeView === 'raw' ? ' active' : ''}`}
+            <Button
+              variant={activeView === 'raw' ? 'secondary' : 'outline-secondary'}
               onClick={() => setActiveView('raw')}
             >
               Raw Stream
-            </button>
-          </div>
+            </Button>
+          </ButtonGroup>
         )}
 
-        <button
-          className="btn btn-outline-secondary btn-sm ms-auto"
+        <Button
+          size="sm"
+          variant="outline-secondary"
+          className="ms-auto"
           onClick={handleReconstruct}
           title="Re-run reconstruction"
         >
           ↺ Refresh
-        </button>
+        </Button>
       </div>
 
       {isTls && (
-        <div className="alert alert-secondary py-2 mb-3" style={{ fontSize: '0.85rem' }}>
+        <Alert variant="secondary" className="py-2 mb-3" style={{ fontSize: '0.85rem' }}>
           This session uses TLS encryption — payload content cannot be decoded without the private
           key.
-        </div>
+        </Alert>
       )}
 
       {session.truncated && (
-        <div className="alert alert-warning py-2 mb-3" style={{ fontSize: '0.85rem' }}>
+        <Alert variant="warning" className="py-2 mb-3" style={{ fontSize: '0.85rem' }}>
           Session exceeded 1 MB — only the first 1 MB of data is shown.
-        </div>
+        </Alert>
       )}
 
       {/* Media metadata panel */}

--- a/frontend/src/components/intelligence/ClusterGraph/ClusterGraph.tsx
+++ b/frontend/src/components/intelligence/ClusterGraph/ClusterGraph.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { Alert, Badge, Button, Form } from '@govtechsg/sgds-react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -94,13 +96,14 @@ function GeoSourceBadge({ source }: { source?: string | null }) {
         >
           <strong style={{ fontSize: 12 }}>{info.title}</strong>
           <p style={{ margin: '4px 0 0' }}>{info.description}</p>
-          <button
+          <Button
+            size="sm"
+            variant="outline-secondary"
             style={{ marginTop: 6, fontSize: 10, padding: '1px 6px', cursor: 'pointer' }}
-            className="btn btn-sm btn-outline-secondary"
             onClick={() => setPopoverPos(null)}
           >
             Close
-          </button>
+          </Button>
         </div>,
         document.body
       )}
@@ -550,7 +553,7 @@ function ClusterPanel({ cluster, fileId, onClose }: ClusterPanelProps) {
         {cluster.dominantProtocols.length > 0 && (
           <div className="d-flex flex-wrap gap-1 mb-1">
             {cluster.dominantProtocols.map(p => (
-              <span key={p} className="badge bg-primary-subtle text-primary-emphasis" style={{ fontSize: 10 }}>{p}</span>
+              <Badge key={p} className="bg-primary-subtle text-primary-emphasis" style={{ fontSize: 10 }}>{p}</Badge>
             ))}
           </div>
         )}
@@ -559,8 +562,8 @@ function ClusterPanel({ cluster, fileId, onClose }: ClusterPanelProps) {
           <div className="mt-1">
             <div className="d-flex align-items-center justify-content-between mb-1">
               <small className="text-muted">Top hosts by</small>
-              <select
-                className="form-select form-select-sm"
+              <Form.Select
+                size="sm"
                 style={{ width: 120, fontSize: 10, padding: '1px 4px' }}
                 value={ipMetric}
                 onChange={e => setIpMetric(e.target.value as IpMetric)}
@@ -569,7 +572,7 @@ function ClusterPanel({ cluster, fileId, onClose }: ClusterPanelProps) {
                 <option value="conversations">Conversations</option>
                 <option value="risks">Risk flags</option>
                 <option value="peers">Unique peers</option>
-              </select>
+              </Form.Select>
             </div>
             {[...cluster.sampleIps]
               .sort((a, b) => {
@@ -605,7 +608,7 @@ function ClusterPanel({ cluster, fileId, onClose }: ClusterPanelProps) {
       <div style={{ borderTop: '1px solid var(--tp-border, #dee2e6)', flex: 1, overflowY: 'auto' }}>
         <div className="px-3 py-2 d-flex align-items-center gap-2">
           <small className="fw-semibold text-muted" style={{ fontSize: 10, letterSpacing: '0.04em' }}>TOP CONVERSATIONS</small>
-          {convosLoading && <span className="spinner-border spinner-border-sm text-secondary" style={{ width: 12, height: 12, borderWidth: 2 }} />}
+          {convosLoading && <Spinner animation="border" size="sm" className="text-secondary" style={{ width: 12, height: 12, borderWidth: 2 }} />}
         </div>
         {convos.length === 0 && !convosLoading && (
           <p className="text-muted small px-3">No conversations found.</p>
@@ -627,15 +630,17 @@ function ClusterPanel({ cluster, fileId, onClose }: ClusterPanelProps) {
                   {c.protocol.name}{c.appName ? ` / ${c.appName}` : ''} · {formatBytes(c.totalBytes)}
                 </div>
               </div>
-              <button
-                className="btn btn-outline-primary btn-sm flex-shrink-0"
+              <Button
+                variant="outline-primary"
+                size="sm"
+                className="flex-shrink-0"
                 style={{ fontSize: 10, padding: '2px 8px' }}
                 onClick={() => navigate(`/analysis/${fileId}/conversations?highlight=${c.id}`)}
                 title="View this conversation"
               >
                 <i className="bi bi-arrow-right-circle me-1" />
                 View
-              </button>
+              </Button>
             </div>
           );
         })}
@@ -766,9 +771,9 @@ export const ClusterGraph = ({ data, loading, groupBy, onGroupByChange, fileId, 
     <div className="intel-cluster-graph-wrapper">
       {/* Controls bar */}
       <div className="d-flex align-items-center gap-3 mb-3">
-        <label className="form-label mb-0 text-muted small">Group by</label>
-        <select
-          className="form-select form-select-sm"
+        <Form.Label className="mb-0 text-muted small">Group by</Form.Label>
+        <Form.Select
+          size="sm"
           style={{ width: 200 }}
           value={groupBy}
           onChange={e => onGroupByChange(e.target.value as GroupBy)}
@@ -777,11 +782,11 @@ export const ClusterGraph = ({ data, loading, groupBy, onGroupByChange, fileId, 
           {GROUP_BY_OPTIONS.map(o => (
             <option key={o.value} value={o.value}>{o.label}</option>
           ))}
-        </select>
+        </Form.Select>
 
-        <label className="form-label mb-0 text-muted small ms-2">Color by</label>
-        <select
-          className="form-select form-select-sm"
+        <Form.Label className="mb-0 text-muted small ms-2">Color by</Form.Label>
+        <Form.Select
+          size="sm"
           style={{ width: 160 }}
           value={colorMode}
           onChange={e => setColorMode(e.target.value as ColorMode)}
@@ -789,7 +794,7 @@ export const ClusterGraph = ({ data, loading, groupBy, onGroupByChange, fileId, 
           {COLOR_MODE_OPTIONS.map(o => (
             <option key={o.value} value={o.value}>{o.label}</option>
           ))}
-        </select>
+        </Form.Select>
 
         {data && !loading && (
           <div className="d-flex align-items-center gap-2">
@@ -798,32 +803,32 @@ export const ClusterGraph = ({ data, loading, groupBy, onGroupByChange, fileId, 
               {data.edges.length} connection{data.edges.length !== 1 ? 's' : ''}
             </small>
             {data.hiddenClusters > 0 && (
-              <span
-                className="badge bg-secondary"
+              <Badge
+                bg="secondary"
                 style={{ fontSize: 10 }}
                 title="Showing top clusters by traffic volume"
               >
                 +{data.hiddenClusters} smaller hidden
-              </span>
+              </Badge>
             )}
           </div>
         )}
 
         {(loading || layoutLoading) && (
-          <span className="spinner-border spinner-border-sm text-primary" role="status" />
+          <Spinner animation="border" size="sm" className="text-primary" role="status" />
         )}
       </div>
 
       {/* Hint for Network Labels grouping */}
       {groupBy === 'customOrg' && (
-        <div className="alert alert-info py-2 mb-3 d-flex align-items-center gap-2" style={{ fontSize: 13 }}>
+        <Alert variant="info" className="py-2 mb-3 d-flex align-items-center gap-2" style={{ fontSize: 13 }}>
           <i className="bi bi-tag-fill flex-shrink-0" />
           <span>
             Network Labels are defined in{' '}
             <strong>Custom Detection Rules</strong> — open it from the navigation bar and go to the{' '}
             <strong>Network Labels</strong> tab to add or edit IP ranges.
           </span>
-        </div>
+        </Alert>
       )}
 
       {/* Hint when geo-based grouping yields only internal traffic */}
@@ -831,17 +836,17 @@ export const ClusterGraph = ({ data, loading, groupBy, onGroupByChange, fileId, 
         (groupBy === 'asn' || groupBy === 'country' || groupBy === 'city') &&
         data.clusters.length <= 2 &&
         data.clusters.every(c => c.label.startsWith('Internal')) && (
-        <div className="alert alert-info py-2 mb-3 d-flex align-items-center gap-2" style={{ fontSize: 13 }}>
+        <Alert variant="info" className="py-2 mb-3 d-flex align-items-center gap-2" style={{ fontSize: 13 }}>
           <i className="bi bi-info-circle-fill" />
           <span>
             All hosts are on an internal/private network — {groupBy === 'asn' ? 'ASN' : groupBy === 'country' ? 'Country' : 'City'} grouping
             has no external data to show. Try{' '}
             <strong>Subnet /24</strong> or <strong>Device Type</strong> for a meaningful view.
           </span>
-          <button className="btn btn-sm btn-info ms-auto" onClick={() => onGroupByChange('subnet24')}>
+          <Button size="sm" variant="info" className="ms-auto" onClick={() => onGroupByChange('subnet24')}>
             Switch to Subnet /24
-          </button>
-        </div>
+          </Button>
+        </Alert>
       )}
 
       {/* Node detail panel — rendered outside the graph canvas so it isn't
@@ -861,7 +866,7 @@ export const ClusterGraph = ({ data, loading, groupBy, onGroupByChange, fileId, 
         <div className="intel-graph-container">
           {loading && (
             <div className="intel-graph-layouting">
-              <span className="spinner-border spinner-border-sm" />
+              <Spinner animation="border" size="sm" />
               Loading…
             </div>
           )}
@@ -890,7 +895,7 @@ export const ClusterGraph = ({ data, loading, groupBy, onGroupByChange, fileId, 
         <div className="intel-graph-container">
           {(loading || layoutLoading) && (
             <div className="intel-graph-layouting">
-              <span className="spinner-border spinner-border-sm" />
+              <Spinner animation="border" size="sm" />
               Computing layout…
             </div>
           )}

--- a/frontend/src/components/intelligence/ClusterGraph/CountryMapView.tsx
+++ b/frontend/src/components/intelligence/ClusterGraph/CountryMapView.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useMemo, useEffect } from 'react';
 import {
   ComposableMap,
@@ -6,6 +7,7 @@ import {
   Marker,
   ZoomableGroup,
 } from 'react-simple-maps';
+import { Button } from '@govtechsg/sgds-react';
 import type { ClusterGraphResponse, ClusterNode } from '@/features/intelligence/services/intelligenceService';
 import { intelligenceService } from '@/features/intelligence/services/intelligenceService';
 import { formatBytes } from '@/utils/formatters';
@@ -143,31 +145,33 @@ export function CountryMapView({
       {/* Breadcrumb */}
       {isDrilled && (
         <div style={{ position: 'absolute', top: 10, left: 10, zIndex: 20, display: 'flex', alignItems: 'center', gap: 8 }}>
-          <button
-            className="btn btn-sm btn-light border d-flex align-items-center gap-1"
+          <Button
+            size="sm"
+            variant="light"
+            className="border d-flex align-items-center gap-1"
             style={{ fontSize: 12 }}
             onClick={exitDrillDown}
           >
             <i className="bi bi-arrow-left" />
             World
-          </button>
+          </Button>
           <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--tp-text, #212529)' }}>
             <i className="bi bi-geo-alt me-1" />
             {clusterById.get(drilledCountryId!)?.label ?? drilledCC}
           </span>
-          {cityLoading && <span className="spinner-border spinner-border-sm text-primary" style={{ width: 14, height: 14, borderWidth: 2 }} />}
+          {cityLoading && <Spinner animation="border" size="sm" className="text-primary" style={{ width: 14, height: 14, borderWidth: 2 }} />}
           {noCityData && <span style={{ fontSize: 11, color: 'var(--tp-text-muted, #6c757d)' }}>No city-level data available</span>}
         </div>
       )}
 
       {/* Zoom controls */}
       <div style={{ position: 'absolute', bottom: 12, left: 12, zIndex: 10, display: 'flex', flexDirection: 'column', gap: 4 }}>
-        <button className="btn btn-sm btn-light border" style={{ width: 28, height: 28, padding: 0, lineHeight: 1 }}
-          onClick={() => setZoom(z => Math.min(z * 1.5, 1200))} title="Zoom in">+</button>
-        <button className="btn btn-sm btn-light border" style={{ width: 28, height: 28, padding: 0, lineHeight: 1 }}
-          onClick={() => setZoom(z => Math.max(z / 1.5, 1))} title="Zoom out">−</button>
-        <button className="btn btn-sm btn-light border" style={{ width: 28, height: 28, padding: 0, fontSize: 10 }}
-          onClick={exitDrillDown} title="Reset view">⌂</button>
+        <Button size="sm" variant="light" className="border" style={{ width: 28, height: 28, padding: 0, lineHeight: 1 }}
+          onClick={() => setZoom(z => Math.min(z * 1.5, 1200))} title="Zoom in">+</Button>
+        <Button size="sm" variant="light" className="border" style={{ width: 28, height: 28, padding: 0, lineHeight: 1 }}
+          onClick={() => setZoom(z => Math.max(z / 1.5, 1))} title="Zoom out">−</Button>
+        <Button size="sm" variant="light" className="border" style={{ width: 28, height: 28, padding: 0, fontSize: 10 }}
+          onClick={exitDrillDown} title="Reset view">⌂</Button>
       </div>
 
       <ComposableMap

--- a/frontend/src/components/intelligence/SummaryStatsBar/SummaryStatsBar.tsx
+++ b/frontend/src/components/intelligence/SummaryStatsBar/SummaryStatsBar.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@govtechsg/sgds-react';
 import type { AnalysisData } from '@/types';
 import { formatBytes } from '@/utils/formatters';
 
@@ -42,18 +43,18 @@ export const SummaryStatsBar = ({ data }: SummaryStatsBarProps) => {
     <div className="row g-3 mb-4">
       {stats.map(s => (
         <div key={s.label} className="col-6 col-md-3">
-          <div
-            className="card h-100"
+          <Card
+            className="h-100"
             style={{ borderLeft: `4px solid ${s.color}` }}
           >
-            <div className="card-body py-3">
+            <Card.Body className="py-3">
               <div className="d-flex align-items-center gap-2 mb-1">
                 <i className={`bi ${s.icon}`} style={{ color: s.color, fontSize: '1.1rem' }} />
                 <small className="text-muted">{s.label}</small>
               </div>
               <div className="fw-bold fs-5">{s.value}</div>
-            </div>
-          </div>
+            </Card.Body>
+          </Card>
         </div>
       ))}
     </div>

--- a/frontend/src/components/intelligence/TopHostsTable/TopHostsTable.tsx
+++ b/frontend/src/components/intelligence/TopHostsTable/TopHostsTable.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState } from 'react';
+import { Badge, Button } from '@govtechsg/sgds-react';
 import { formatBytes } from '@/utils/formatters';
 import type { HostSummary, SortBy } from '@/features/intelligence/services/intelligenceService';
 
@@ -64,17 +66,18 @@ export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHos
         <h6 className="mb-0">Top Hosts</h6>
         <div className="d-flex gap-1">
           {SORT_OPTIONS.map(o => (
-            <button
+            <Button
               key={o.value}
-              className={`btn btn-sm ${sortBy === o.value ? 'btn-primary' : 'btn-outline-secondary'}`}
+              size="sm"
+              variant={sortBy === o.value ? 'primary' : 'outline-secondary'}
               onClick={() => { onSortByChange(o.value); setPage(0); }}
               disabled={loading}
             >
               {o.label}
-            </button>
+            </Button>
           ))}
         </div>
-        {loading && <span className="spinner-border spinner-border-sm text-primary" role="status" />}
+        {loading && <Spinner animation="border" size="sm" className="text-primary" role="status" />}
       </div>
 
       <div style={{ overflowX: 'auto' }}>
@@ -109,14 +112,13 @@ export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHos
                 <td>{host.conversationCount.toLocaleString()}</td>
                 <td>
                   {host.riskCount > 0 ? (
-                    <span className="badge bg-danger">{host.riskCount}</span>
+                    <Badge bg="danger">{host.riskCount}</Badge>
                   ) : (
                     <span className="text-muted">—</span>
                   )}
                 </td>
                 <td>
-                  <span
-                    className="badge"
+                  <Badge
                     style={{
                       background: host.role === 'server' ? '#107c10'
                         : host.role === 'client' ? '#0072c6'
@@ -125,7 +127,7 @@ export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHos
                     }}
                   >
                     {host.role}
-                  </span>
+                  </Badge>
                 </td>
                 <td>
                   {host.deviceType ? (
@@ -160,21 +162,23 @@ export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHos
 
       {totalPages > 1 && (
         <div className="d-flex align-items-center gap-2 mt-2">
-          <button
-            className="btn btn-sm btn-outline-secondary"
+          <Button
+            size="sm"
+            variant="outline-secondary"
             onClick={() => setPage(p => p - 1)}
             disabled={page === 0}
           >
             ‹ Prev
-          </button>
+          </Button>
           <small className="text-muted">Page {page + 1} / {totalPages}</small>
-          <button
-            className="btn btn-sm btn-outline-secondary"
+          <Button
+            size="sm"
+            variant="outline-secondary"
             onClick={() => setPage(p => p + 1)}
             disabled={page >= totalPages - 1}
           >
             Next ›
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
+++ b/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
@@ -1,5 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useEffect, useRef, useState } from 'react';
-import { Modal } from '@govtechsg/sgds-react';
+import { Alert, Button, Modal } from '@govtechsg/sgds-react';
 import { useDropzone } from 'react-dropzone';
 import { apiClient } from '@/services/api/client';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
@@ -148,10 +149,10 @@ export const AddSnapshotModal = ({
                 </>
               )}
             </div>
-            {uploadError && <div className="alert alert-danger py-2">{uploadError}</div>}
-            <button
-              type="button"
-              className="btn btn-primary w-100"
+            {uploadError && <Alert variant="danger" className="py-2">{uploadError}</Alert>}
+            <Button
+              variant="primary"
+              className="w-100"
               disabled={uploadFiles.length === 0}
               onClick={handleUploadAndAdd}
             >
@@ -159,7 +160,7 @@ export const AddSnapshotModal = ({
               {uploadFiles.length > 1
                 ? `Upload ${uploadFiles.length} files & add to network`
                 : 'Upload & add to network'}
-            </button>
+            </Button>
           </>
         ) : (
           <div className="text-center py-4">
@@ -169,7 +170,7 @@ export const AddSnapshotModal = ({
               </div>
             ) : (
               <>
-                <div className="spinner-border text-primary mb-3" role="status" />
+                <Spinner animation="border" className="text-primary mb-3" role="status" />
                 <div className="fw-semibold">
                   {totalFiles > 1 && `File ${uploadCurrent} of ${totalFiles} — `}
                   {phaseLabel[uploadPhase]}

--- a/frontend/src/components/monitor/BaselineDefinitionPanel/BaselineDefinitionPanel.tsx
+++ b/frontend/src/components/monitor/BaselineDefinitionPanel/BaselineDefinitionPanel.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState } from 'react';
+import { Alert, Badge, Button, Form } from '@govtechsg/sgds-react';
 import type {
   BaselineDefinition,
   BaselineEntryType,
@@ -137,9 +139,9 @@ export const BaselineDefinitionPanel = ({
               {definitions.map(def => (
                 <tr key={def.id}>
                   <td>
-                    <span className="badge bg-light text-dark border">
+                    <Badge bg="light" text="dark" className="border">
                       {ENTRY_TYPE_LABELS[def.entryType] ?? def.entryType}
-                    </span>
+                    </Badge>
                   </td>
                   <td>
                     <code>{def.entityKey}</code>
@@ -153,18 +155,18 @@ export const BaselineDefinitionPanel = ({
                     <small className="text-muted">{def.notes ?? '—'}</small>
                   </td>
                   <td>
-                    <button
-                      type="button"
-                      className="btn btn-sm btn-outline-danger"
+                    <Button
+                      size="sm"
+                      variant="outline-danger"
                       onClick={() => handleDelete(def.id)}
                       disabled={deletingId === def.id}
                     >
                       {deletingId === def.id ? (
-                        <span className="spinner-border spinner-border-sm" />
+                        <Spinner animation="border" size="sm" />
                       ) : (
                         <i className="bi bi-trash"></i>
                       )}
-                    </button>
+                    </Button>
                   </td>
                 </tr>
               ))}
@@ -175,12 +177,12 @@ export const BaselineDefinitionPanel = ({
 
       {showForm ? (
         <form onSubmit={handleAdd} className="border rounded p-3 bg-light">
-          {error && <div className="alert alert-danger py-2 small">{error}</div>}
+          {error && <Alert variant="danger" className="py-2 small">{error}</Alert>}
           <div className="row g-2">
             <div className="col-sm-3">
-              <label className="form-label small fw-semibold">Type</label>
-              <select
-                className="form-select form-select-sm"
+              <Form.Label className="small fw-semibold">Type</Form.Label>
+              <Form.Select
+                size="sm"
                 value={entryType}
                 onChange={e => {
                   setEntryType(e.target.value as BaselineEntryType);
@@ -191,15 +193,15 @@ export const BaselineDefinitionPanel = ({
                 {ENTRY_TYPES.map(t => (
                   <option key={t} value={t}>{ENTRY_TYPE_LABELS[t]}</option>
                 ))}
-              </select>
+              </Form.Select>
             </div>
             <div className={FIELD_CONFIG[entryType].valueLabel ? 'col-sm-3' : 'col-sm-5'}>
-              <label className="form-label small fw-semibold">
+              <Form.Label className="small fw-semibold">
                 {FIELD_CONFIG[entryType].keyLabel} <span className="text-danger">*</span>
-              </label>
-              <input
+              </Form.Label>
+              <Form.Control
+                size="sm"
                 type="text"
-                className="form-control form-control-sm"
                 placeholder={FIELD_CONFIG[entryType].keyPlaceholder}
                 value={entityKey}
                 onChange={e => setEntityKey(e.target.value)}
@@ -208,12 +210,12 @@ export const BaselineDefinitionPanel = ({
             </div>
             {FIELD_CONFIG[entryType].valueLabel && (
               <div className="col-sm-3">
-                <label className="form-label small fw-semibold">
+                <Form.Label className="small fw-semibold">
                   {FIELD_CONFIG[entryType].valueLabel}
-                </label>
-                <input
+                </Form.Label>
+                <Form.Control
+                  size="sm"
                   type="text"
-                  className="form-control form-control-sm"
                   placeholder={FIELD_CONFIG[entryType].valuePlaceholder}
                   value={entityValue}
                   onChange={e => setEntityValue(e.target.value)}
@@ -221,10 +223,10 @@ export const BaselineDefinitionPanel = ({
               </div>
             )}
             <div className={FIELD_CONFIG[entryType].valueLabel ? 'col-sm-3' : 'col-sm-4'}>
-              <label className="form-label small fw-semibold">Notes</label>
-              <input
+              <Form.Label className="small fw-semibold">Notes</Form.Label>
+              <Form.Control
+                size="sm"
                 type="text"
-                className="form-control form-control-sm"
                 placeholder="Optional"
                 value={notes}
                 onChange={e => setNotes(e.target.value)}
@@ -232,28 +234,28 @@ export const BaselineDefinitionPanel = ({
             </div>
           </div>
           <div className="d-flex gap-2 mt-3">
-            <button type="submit" className="btn btn-sm btn-primary" disabled={saving || !entityKey.trim()}>
-              {saving ? <span className="spinner-border spinner-border-sm me-1" /> : null}
+            <Button size="sm" type="submit" variant="primary" disabled={saving || !entityKey.trim()}>
+              {saving ? <Spinner animation="border" size="sm" className="me-1" /> : null}
               Add Entry
-            </button>
-            <button
-              type="button"
-              className="btn btn-sm btn-secondary"
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
               onClick={() => setShowForm(false)}
               disabled={saving}
             >
               Cancel
-            </button>
+            </Button>
           </div>
         </form>
       ) : (
-        <button
-          type="button"
-          className="btn btn-sm btn-outline-primary"
+        <Button
+          size="sm"
+          variant="outline-primary"
           onClick={() => setShowForm(true)}
         >
           <i className="bi bi-plus-lg me-1"></i>Add Entry
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
+++ b/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect } from 'react';
+import { Button, Form } from '@govtechsg/sgds-react';
 import type { ChangeEvent, NetworkSnapshot } from '@/features/monitor/types/monitor.types';
 import { parseDateTime } from '@/utils/dateUtils';
 
@@ -120,8 +122,9 @@ export const ChangeEventBadge = ({ event, snapshots, onPatch }: ChangeEventBadge
         )}
         {showNotes && (
           <div className="mt-2">
-            <textarea
-              className="form-control form-control-sm"
+            <Form.Control
+              as="textarea"
+              size="sm"
               rows={2}
               placeholder="Add notes…"
               value={draftNotes}
@@ -129,23 +132,23 @@ export const ChangeEventBadge = ({ event, snapshots, onPatch }: ChangeEventBadge
               autoFocus
             />
             <div className="d-flex gap-1 mt-1">
-              <button
-                type="button"
-                className="btn btn-sm btn-primary"
+              <Button
+                size="sm"
+                variant="primary"
                 onClick={handleSaveNotes}
                 disabled={saving}
               >
-                {saving ? <span className="spinner-border spinner-border-sm me-1" /> : null}
+                {saving ? <Spinner animation="border" size="sm" className="me-1" /> : null}
                 Save
-              </button>
-              <button
-                type="button"
-                className="btn btn-sm btn-outline-secondary"
+              </Button>
+              <Button
+                size="sm"
+                variant="outline-secondary"
                 onClick={() => { setShowNotes(false); setDraftNotes(localNotes); }}
                 disabled={saving}
               >
                 Cancel
-              </button>
+              </Button>
             </div>
           </div>
         )}
@@ -153,23 +156,25 @@ export const ChangeEventBadge = ({ event, snapshots, onPatch }: ChangeEventBadge
 
       <div className="d-flex align-items-center gap-2 flex-shrink-0">
         <small className="text-muted text-nowrap">{formattedTime}</small>
-        <button
-          type="button"
-          className="btn btn-sm btn-link p-0 text-muted"
+        <Button
+          size="sm"
+          variant="link"
+          className="p-0 text-muted"
           title={showNotes ? 'Hide notes' : (localNotes ? 'Edit notes' : 'Add notes')}
           onClick={() => { setShowNotes(v => !v); setDraftNotes(localNotes); }}
         >
           <i className={`bi bi-chat-left-text${localNotes ? '-fill' : ''}`}></i>
-        </button>
-        <button
-          type="button"
-          className={`btn btn-sm btn-link p-0 ${localReviewed ? 'text-success' : 'text-muted'}`}
+        </Button>
+        <Button
+          size="sm"
+          variant="link"
+          className={`p-0 ${localReviewed ? 'text-success' : 'text-muted'}`}
           title={localReviewed ? 'Mark as unreviewed' : 'Mark as reviewed'}
           onClick={handleReviewToggle}
           disabled={saving}
         >
           <i className={`bi bi-check-circle${localReviewed ? '-fill' : ''}`}></i>
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/components/monitor/CreateNetworkModal/CreateNetworkModal.tsx
+++ b/frontend/src/components/monitor/CreateNetworkModal/CreateNetworkModal.tsx
@@ -1,5 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState } from 'react';
-import { Modal } from '@govtechsg/sgds-react';
+import { Alert, Button, Form, Modal } from '@govtechsg/sgds-react';
 
 interface CreateNetworkModalProps {
   show: boolean;
@@ -45,15 +46,14 @@ export const CreateNetworkModal = ({ show, onHide, onCreate }: CreateNetworkModa
       </Modal.Header>
       <form onSubmit={handleSubmit}>
         <Modal.Body>
-          {error && <div className="alert alert-danger py-2">{error}</div>}
-          <div className="mb-3">
-            <label className="form-label fw-semibold" htmlFor="network-name">
+          {error && <Alert variant="danger" className="py-2">{error}</Alert>}
+          <Form.Group className="mb-3">
+            <Form.Label className="fw-semibold" htmlFor="network-name">
               Name <span className="text-danger">*</span>
-            </label>
-            <input
+            </Form.Label>
+            <Form.Control
               id="network-name"
               type="text"
-              className="form-control"
               placeholder="e.g. Office LAN, OT Segment A"
               value={name}
               onChange={e => setName(e.target.value)}
@@ -61,35 +61,35 @@ export const CreateNetworkModal = ({ show, onHide, onCreate }: CreateNetworkModa
               required
               autoFocus
             />
-          </div>
-          <div className="mb-3">
-            <label className="form-label fw-semibold" htmlFor="network-desc">
+          </Form.Group>
+          <Form.Group className="mb-3">
+            <Form.Label className="fw-semibold" htmlFor="network-desc">
               Description
-            </label>
-            <textarea
+            </Form.Label>
+            <Form.Control
               id="network-desc"
-              className="form-control"
+              as="textarea"
               rows={3}
               placeholder="Optional description of this network segment"
               value={description}
               onChange={e => setDescription(e.target.value)}
             />
-          </div>
+          </Form.Group>
         </Modal.Body>
         <Modal.Footer>
-          <button type="button" className="btn btn-secondary" onClick={handleHide} disabled={saving}>
+          <Button variant="secondary" onClick={handleHide} disabled={saving}>
             Cancel
-          </button>
-          <button type="submit" className="btn btn-primary" disabled={saving || !name.trim()}>
+          </Button>
+          <Button type="submit" variant="primary" disabled={saving || !name.trim()}>
             {saving ? (
               <>
-                <span className="spinner-border spinner-border-sm me-2" />
+                <Spinner animation="border" size="sm" className="me-2" />
                 Creating…
               </>
             ) : (
               'Create Network'
             )}
-          </button>
+          </Button>
         </Modal.Footer>
       </form>
     </Modal>

--- a/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
+++ b/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
@@ -1,5 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, type CSSProperties } from 'react';
-import { Modal } from '@govtechsg/sgds-react';
+import { Badge, Button, Modal } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
 import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
 import { parseDateTime } from '@/utils/dateUtils';
@@ -153,7 +154,7 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
   }
 
   if (loading) {
-    return <div className="text-muted small text-center py-3"><span className="spinner-border spinner-border-sm me-2" />Loading…</div>;
+    return <div className="text-muted small text-center py-3"><Spinner animation="border" size="sm" className="me-2" />Loading…</div>;
   }
 
   const total = active.length + absent.length;
@@ -168,28 +169,29 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
     <>
       <div className="d-flex flex-wrap gap-2">
         {active.map(mac => (
-          <button
+          <Badge
             key={mac}
+            as="button"
             type="button"
-            className="badge"
             style={{ cursor: 'pointer', ...hashBadgeStyle(mac) }}
             onClick={() => openModal(mac)}
             title="View device history"
           >
             {mac}
-          </button>
+          </Badge>
         ))}
         {absent.map(mac => (
-          <button
+          <Badge
             key={mac}
+            as="button"
             type="button"
-            className="badge text-decoration-line-through"
+            className="text-decoration-line-through"
             style={{ cursor: 'pointer', opacity: 0.5, ...hashBadgeStyle(mac) }}
             onClick={() => openModal(mac)}
             title="View device history"
           >
             {mac}
-          </button>
+          </Badge>
         ))}
       </div>
       {absent.length > 0 && (
@@ -205,9 +207,9 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
             <i className="bi bi-device-hdd me-2"></i>
             {selectedMac}
             {' '}
-            <span className={`badge ms-2 ${isActive ? 'bg-success' : 'bg-secondary'}`}>
+            <Badge bg={isActive ? 'success' : 'secondary'} className="ms-2">
               {isActive ? 'Active' : 'Gone'}
-            </span>
+            </Badge>
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
@@ -268,7 +270,7 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
               <h6 className="text-muted fw-semibold mb-2">Snapshot History</h6>
               {modalLoading ? (
                 <div className="text-muted small text-center py-2">
-                  <span className="spinner-border spinner-border-sm me-2" />Loading protocols & apps…
+                  <Spinner animation="border" size="sm" className="me-2" />Loading protocols & apps…
                 </div>
               ) : (() => {
                 const totalPages = Math.ceil(selectedHistory.length / HISTORY_PAGE_SIZE);
@@ -301,7 +303,7 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
                               <td>
                                 <code>{host.ip ?? '—'}</code>
                                 {globalIdx > 0 && host.ip !== selectedHistory[globalIdx - 1].host.ip && (
-                                  <span className="badge bg-warning text-dark ms-1" style={{ fontSize: '0.65rem' }}>changed</span>
+                                  <Badge bg="warning" text="dark" className="ms-1" style={{ fontSize: '0.65rem' }}>changed</Badge>
                                 )}
                               </td>
                               <td><small className="text-muted">{host.deviceType ?? '—'}</small></td>
@@ -311,10 +313,10 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
                                 ) : (
                                   <div className="d-flex flex-wrap gap-1">
                                     {protocols.map(p => (
-                                      <span key={p} className="badge" style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(p) }}>{p}</span>
+                                      <Badge key={p} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(p) }}>{p}</Badge>
                                     ))}
                                     {apps.map(a => (
-                                      <span key={a} className="badge" style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(a) }}>{a}</span>
+                                      <Badge key={a} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(a) }}>{a}</Badge>
                                     ))}
                                   </div>
                                 )}
@@ -330,22 +332,22 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
                           {historyPage * HISTORY_PAGE_SIZE + 1}–{Math.min((historyPage + 1) * HISTORY_PAGE_SIZE, selectedHistory.length)} of {selectedHistory.length}
                         </small>
                         <div className="d-flex gap-1">
-                          <button
-                            type="button"
-                            className="btn btn-sm btn-outline-secondary"
+                          <Button
+                            size="sm"
+                            variant="outline-secondary"
                             disabled={historyPage === 0}
                             onClick={() => setHistoryPage(p => p - 1)}
                           >
                             <i className="bi bi-chevron-left" />
-                          </button>
-                          <button
-                            type="button"
-                            className="btn btn-sm btn-outline-secondary"
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline-secondary"
                             disabled={historyPage >= totalPages - 1}
                             onClick={() => setHistoryPage(p => p + 1)}
                           >
                             <i className="bi bi-chevron-right" />
-                          </button>
+                          </Button>
                         </div>
                       </div>
                     )}

--- a/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
+++ b/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
@@ -169,29 +169,32 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
     <>
       <div className="d-flex flex-wrap gap-2">
         {active.map(mac => (
-          <Badge
+          <Button
             key={mac}
-            as="button"
             type="button"
-            style={{ cursor: 'pointer', ...hashBadgeStyle(mac) }}
+            variant="secondary"
+            size="sm"
+            className="border-0 py-0 px-1"
+            style={{ fontSize: '0.75em', ...hashBadgeStyle(mac) }}
             onClick={() => openModal(mac)}
             title="View device history"
           >
             {mac}
-          </Badge>
+          </Button>
         ))}
         {absent.map(mac => (
-          <Badge
+          <Button
             key={mac}
-            as="button"
             type="button"
-            className="text-decoration-line-through"
-            style={{ cursor: 'pointer', opacity: 0.5, ...hashBadgeStyle(mac) }}
+            variant="secondary"
+            size="sm"
+            className="text-decoration-line-through border-0 py-0 px-1"
+            style={{ fontSize: '0.75em', opacity: 0.5, ...hashBadgeStyle(mac) }}
             onClick={() => openModal(mac)}
             title="View device history"
           >
             {mac}
-          </Badge>
+          </Button>
         ))}
       </div>
       {absent.length > 0 && (

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, type CSSProperties } from 'react';
-import { Badge } from '@govtechsg/sgds-react';
+import { Badge, Button } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
 import type { NetworkSnapshot, AbsentEntity } from '@/features/monitor/types/monitor.types';
 import { LastSeenModal } from '../LastSeenModal/LastSeenModal';
@@ -60,17 +60,18 @@ function IpBadgeGroup({
         </Badge>
       ))}
       {absentItems.map(entity => (
-        <Badge
+        <Button
           key={entity.key}
-          as="button"
           type="button"
-          className="text-decoration-line-through"
-          style={{ cursor: 'pointer', opacity: 0.5, ...hashBadgeStyle(entity.key) }}
+          variant="secondary"
+          size="sm"
+          className="text-decoration-line-through border-0 py-0 px-1"
+          style={{ fontSize: '0.75em', opacity: 0.5, ...hashBadgeStyle(entity.key) }}
           onClick={() => onAbsentClick(entity)}
           title={`Last seen in ${entity.lastSeenFileName}`}
         >
           {entity.key}
-        </Badge>
+        </Button>
       ))}
     </div>
   );

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, type CSSProperties } from 'react';
+import { Badge } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
 import type { NetworkSnapshot, AbsentEntity } from '@/features/monitor/types/monitor.types';
 import { LastSeenModal } from '../LastSeenModal/LastSeenModal';
@@ -53,21 +55,22 @@ function IpBadgeGroup({
   return (
     <div className="d-flex flex-wrap gap-2">
       {items.map(ip => (
-        <span key={ip} className="badge" style={hashBadgeStyle(ip)}>
+        <Badge key={ip} style={hashBadgeStyle(ip)}>
           {ip}
-        </span>
+        </Badge>
       ))}
       {absentItems.map(entity => (
-        <button
+        <Badge
           key={entity.key}
+          as="button"
           type="button"
-          className="badge text-decoration-line-through"
+          className="text-decoration-line-through"
           style={{ cursor: 'pointer', opacity: 0.5, ...hashBadgeStyle(entity.key) }}
           onClick={() => onAbsentClick(entity)}
           title={`Last seen in ${entity.lastSeenFileName}`}
         >
           {entity.key}
-        </button>
+        </Badge>
       ))}
     </div>
   );
@@ -131,7 +134,7 @@ export const IpDriftPanel = ({ snapshots }: IpDriftPanelProps) => {
   }, [snapshots.map(s => s.id).join(',')]);
 
   if (loading) {
-    return <div className="text-muted small text-center py-3"><span className="spinner-border spinner-border-sm me-2" />Loading…</div>;
+    return <div className="text-muted small text-center py-3"><Spinner animation="border" size="sm" className="me-2" />Loading…</div>;
   }
 
   const hasData =

--- a/frontend/src/components/monitor/LastSeenModal/LastSeenModal.tsx
+++ b/frontend/src/components/monitor/LastSeenModal/LastSeenModal.tsx
@@ -1,4 +1,4 @@
-import { Modal } from '@govtechsg/sgds-react';
+import { Button, Modal } from '@govtechsg/sgds-react';
 import { useNavigate } from 'react-router-dom';
 import type { AbsentEntity } from '@/features/monitor/types/monitor.types';
 import { parseDateTime } from '@/utils/dateUtils';
@@ -46,20 +46,21 @@ export const LastSeenModal = ({ show, onHide, entity }: LastSeenModalProps) => {
       </Modal.Body>
       <Modal.Footer>
         {entity.lastSeenFileId && (
-          <button
+          <Button
             type="button"
-            className="btn btn-sm btn-outline-primary"
+            size="sm"
+            variant="outline-primary"
             onClick={() => {
               onHide();
               navigate(`/analysis/${entity.lastSeenFileId}`);
             }}
           >
             <i className="bi bi-box-arrow-up-right me-1"></i>Open in Analysis
-          </button>
+          </Button>
         )}
-        <button type="button" className="btn btn-sm btn-secondary" onClick={onHide}>
+        <Button type="button" size="sm" variant="secondary" onClick={onHide}>
           Close
-        </button>
+        </Button>
       </Modal.Footer>
     </Modal>
   );

--- a/frontend/src/components/monitor/MonitorNetworkDiagram/MonitorNetworkDiagram.tsx
+++ b/frontend/src/components/monitor/MonitorNetworkDiagram/MonitorNetworkDiagram.tsx
@@ -1,5 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useMemo, useState, useEffect } from 'react';
-import { Modal } from '@govtechsg/sgds-react';
+import { Button, Form, Modal } from '@govtechsg/sgds-react';
 import type { NetworkSnapshot, ChangeEvent } from '@/features/monitor/types/monitor.types';
 import type { NodeHighlight } from '@/components/network/NetworkGraph/NetworkGraph';
 import { NetworkGraph } from '@/components/network/NetworkGraph';
@@ -178,17 +179,17 @@ export const MonitorNetworkDiagram = ({
         {/* Snapshot selector + comparison info */}
         <div className="d-flex align-items-center gap-3 mb-3 flex-wrap">
           <div className="d-flex align-items-center gap-2">
-            <button
-              type="button"
-              className="btn btn-sm btn-outline-secondary"
+            <Button
+              size="sm"
+              variant="outline-secondary"
               disabled={selectedIndex <= 0}
               onClick={() => sorted[selectedIndex - 1] && setSelectedId(sorted[selectedIndex - 1].id)}
               title="Previous snapshot"
             >
               <i className="bi bi-chevron-left" />
-            </button>
-            <select
-              className="form-select form-select-sm"
+            </Button>
+            <Form.Select
+              size="sm"
               style={{ width: 'auto', minWidth: 220 }}
               value={selectedSnap?.id ?? ''}
               onChange={e => setSelectedId(e.target.value)}
@@ -198,16 +199,16 @@ export const MonitorNetworkDiagram = ({
                   {i + 1}. {formatSnapLabel(snap)} — {snap.fileName}
                 </option>
               ))}
-            </select>
-            <button
-              type="button"
-              className="btn btn-sm btn-outline-secondary"
+            </Form.Select>
+            <Button
+              size="sm"
+              variant="outline-secondary"
               disabled={selectedIndex >= sorted.length - 1}
               onClick={() => sorted[selectedIndex + 1] && setSelectedId(sorted[selectedIndex + 1].id)}
               title="Next snapshot"
             >
               <i className="bi bi-chevron-right" />
-            </button>
+            </Button>
           </div>
 
           {prevSnap ? (
@@ -238,7 +239,7 @@ export const MonitorNetworkDiagram = ({
         <div className="monitor-diagram-graph" style={{ height: 480 }}>
           {loading ? (
             <div className="d-flex align-items-center justify-content-center h-100 text-muted">
-              <span className="spinner-border spinner-border-sm me-2" />
+              <Spinner animation="border" size="sm" className="me-2" />
               Loading graph…
             </div>
           ) : (

--- a/frontend/src/components/monitor/NetworkCard/NetworkCard.tsx
+++ b/frontend/src/components/monitor/NetworkCard/NetworkCard.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@govtechsg/sgds-react';
+import { Button, Card } from '@govtechsg/sgds-react';
 import type { Network } from '@/features/monitor/types/monitor.types';
 
 interface NetworkCardProps {
@@ -13,9 +13,11 @@ export const NetworkCard = ({ network, onClick, onDelete }: NetworkCardProps) =>
       <Card.Body>
         <div className="d-flex justify-content-between align-items-start mb-2">
           <h5 className="mb-0 text-break">{network.name}</h5>
-          <button
+          <Button
             type="button"
-            className="btn btn-sm btn-outline-danger ms-2 flex-shrink-0"
+            size="sm"
+            variant="outline-danger"
+            className="ms-2 flex-shrink-0"
             onClick={e => {
               e.stopPropagation();
               onDelete();
@@ -24,7 +26,7 @@ export const NetworkCard = ({ network, onClick, onDelete }: NetworkCardProps) =>
             aria-label="Delete network"
           >
             <i className="bi bi-trash"></i>
-          </button>
+          </Button>
         </div>
 
         {network.description && (

--- a/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
+++ b/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, type CSSProperties } from 'react';
-import { Badge } from '@govtechsg/sgds-react';
+import { Badge, Button } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
 import type {
   NetworkSnapshot,
@@ -59,17 +59,18 @@ function BadgeGroup({
         </Badge>
       ))}
       {absentItems.map(entity => (
-        <Badge
+        <Button
           key={entity.key}
-          as="button"
           type="button"
-          className="text-decoration-line-through"
-          style={{ cursor: 'pointer', opacity: 0.5, ...hashBadgeStyle(entity.key) }}
+          variant="secondary"
+          size="sm"
+          className="text-decoration-line-through border-0 py-0 px-1"
+          style={{ fontSize: '0.75em', opacity: 0.5, ...hashBadgeStyle(entity.key) }}
           onClick={() => onAbsentClick(entity)}
           title={`Last seen in ${entity.lastSeenFileName}`}
         >
           {entity.key}
-        </Badge>
+        </Button>
       ))}
     </div>
   );

--- a/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
+++ b/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, type CSSProperties } from 'react';
+import { Badge } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
 import type {
   NetworkSnapshot,
@@ -52,25 +54,22 @@ function BadgeGroup({
   return (
     <div className="d-flex flex-wrap gap-2">
       {items.map(name => (
-        <span
-          key={name}
-          className="badge"
-          style={hashBadgeStyle(name)}
-        >
+        <Badge key={name} style={hashBadgeStyle(name)}>
           {name}
-        </span>
+        </Badge>
       ))}
       {absentItems.map(entity => (
-        <button
+        <Badge
           key={entity.key}
+          as="button"
           type="button"
-          className="badge text-decoration-line-through"
+          className="text-decoration-line-through"
           style={{ cursor: 'pointer', opacity: 0.5, ...hashBadgeStyle(entity.key) }}
           onClick={() => onAbsentClick(entity)}
           title={`Last seen in ${entity.lastSeenFileName}`}
         >
           {entity.key}
-        </button>
+        </Badge>
       ))}
     </div>
   );
@@ -140,7 +139,7 @@ export const ProtocolDriftPanel = ({ snapshots }: ProtocolDriftPanelProps) => {
   }, [snapshots.map(s => s.id).join(',')]);
 
   if (loading) {
-    return <div className="text-muted small text-center py-3"><span className="spinner-border spinner-border-sm me-2" />Loading…</div>;
+    return <div className="text-muted small text-center py-3"><Spinner animation="border" size="sm" className="me-2" />Loading…</div>;
   }
 
   const hasData =

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -1,5 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState } from 'react';
-import { Modal } from '@govtechsg/sgds-react';
+import { Badge, Button, Card, Modal } from '@govtechsg/sgds-react';
 import type { NetworkSnapshot, ChangeEvent } from '@/features/monitor/types/monitor.types';
 import { Pagination } from '@/components/common/Pagination';
 import { ScrollableTable } from '@/components/common/ScrollableTable';
@@ -84,9 +85,9 @@ export const SnapshotTimeline = ({
         <h6 className="mb-0 text-muted fw-normal">
           {snapshots.length} snapshot{snapshots.length !== 1 ? 's' : ''}
         </h6>
-        <button type="button" className="btn btn-sm btn-outline-secondary" onClick={onAddSnapshot}>
+        <Button size="sm" variant="outline-secondary" onClick={onAddSnapshot}>
           <i className="bi bi-plus-lg me-1"></i>Add PCAP
-        </button>
+        </Button>
       </div>
 
       {snapshots.length === 0 ? (
@@ -118,14 +119,15 @@ export const SnapshotTimeline = ({
                         <small className="text-muted">{formatCaptureDate(snap.startTime)}</small>
                       </td>
                       <td>
-                        <button
-                          type="button"
-                          className="btn btn-link btn-sm p-0 text-start text-break"
+                        <Button
+                          size="sm"
+                          variant="link"
+                          className="p-0 text-start text-break"
                           onClick={() => onSelectSnapshot(snap.id)}
                           title="View network diagram"
                         >
                           {snap.fileName}
-                        </button>
+                        </Button>
                       </td>
                       <td>
                         <small className="text-muted">{formatDuration(snap.startTime, snap.endTime)}</small>
@@ -135,39 +137,44 @@ export const SnapshotTimeline = ({
                       </td>
                       <td>
                         {snap.changeCount === 0 ? (
-                          <span className="badge bg-light text-muted border">No changes</span>
+                          <Badge bg="light" text="muted" className="border">No changes</Badge>
                         ) : snap.criticalCount > 0 ? (
-                          <button
+                          <Badge
+                            as="button"
                             type="button"
-                            className="badge bg-danger border-0"
+                            bg="danger"
+                            className="border-0"
                             style={{ cursor: 'pointer' }}
                             onClick={() => setChangesSnap(snap)}
                           >
                             {snap.criticalCount} critical
                             {snap.changeCount > snap.criticalCount &&
                               `, ${snap.changeCount - snap.criticalCount} more`}
-                          </button>
+                          </Badge>
                         ) : (
-                          <button
+                          <Badge
+                            as="button"
                             type="button"
-                            className="badge bg-warning text-dark border-0"
+                            bg="warning"
+                            text="dark"
+                            className="border-0"
                             style={{ cursor: 'pointer' }}
                             onClick={() => setChangesSnap(snap)}
                           >
                             {snap.changeCount} change{snap.changeCount !== 1 ? 's' : ''}
-                          </button>
+                          </Badge>
                         )}
                       </td>
                       <td>
-                        <button
-                          type="button"
-                          className="btn btn-sm btn-outline-danger"
+                        <Button
+                          size="sm"
+                          variant="outline-danger"
                           onClick={() => setConfirmRemove(snap.id)}
                           disabled={removing !== null}
                           title="Remove snapshot"
                         >
                           <i className="bi bi-trash"></i>
-                        </button>
+                        </Button>
                       </td>
                     </tr>
                   );
@@ -176,7 +183,7 @@ export const SnapshotTimeline = ({
             </table>
           </ScrollableTable>
 
-          <div className="card-footer border-top pt-2 mt-2">
+          <Card.Footer className="border-top pt-2 mt-2">
             <Pagination
               currentPage={page}
               totalPages={totalPages}
@@ -186,7 +193,7 @@ export const SnapshotTimeline = ({
               showPageSizeSelector
               onPageSizeChange={size => { setPageSize(size); setPage(1); }}
             />
-          </div>
+          </Card.Footer>
         </>
       )}
 
@@ -228,23 +235,21 @@ export const SnapshotTimeline = ({
           </p>
         </Modal.Body>
         <Modal.Footer>
-          <button
-            type="button"
-            className="btn btn-outline-secondary"
+          <Button
+            variant="outline-secondary"
             onClick={() => setConfirmRemove(null)}
             disabled={removing !== null}
           >
             Cancel
-          </button>
-          <button
-            type="button"
-            className="btn btn-outline-danger"
+          </Button>
+          <Button
+            variant="outline-danger"
             onClick={() => confirmRemove && handleRemove(confirmRemove)}
             disabled={removing !== null}
           >
-            {removing ? <span className="spinner-border spinner-border-sm me-1" /> : null}
+            {removing ? <Spinner animation="border" size="sm" className="me-1" /> : null}
             Remove
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
     </div>

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -139,30 +139,29 @@ export const SnapshotTimeline = ({
                         {snap.changeCount === 0 ? (
                           <Badge bg="light" text="muted" className="border">No changes</Badge>
                         ) : snap.criticalCount > 0 ? (
-                          <Badge
-                            as="button"
+                          <Button
                             type="button"
-                            bg="danger"
-                            className="border-0"
-                            style={{ cursor: 'pointer' }}
+                            variant="danger"
+                            size="sm"
+                            className="border-0 py-0 px-1"
+                            style={{ fontSize: '0.75em' }}
                             onClick={() => setChangesSnap(snap)}
                           >
                             {snap.criticalCount} critical
                             {snap.changeCount > snap.criticalCount &&
                               `, ${snap.changeCount - snap.criticalCount} more`}
-                          </Badge>
+                          </Button>
                         ) : (
-                          <Badge
-                            as="button"
+                          <Button
                             type="button"
-                            bg="warning"
-                            text="dark"
-                            className="border-0"
-                            style={{ cursor: 'pointer' }}
+                            variant="warning"
+                            size="sm"
+                            className="border-0 py-0 px-1"
+                            style={{ fontSize: '0.75em' }}
                             onClick={() => setChangesSnap(snap)}
                           >
                             {snap.changeCount} change{snap.changeCount !== 1 ? 's' : ''}
-                          </Badge>
+                          </Button>
                         )}
                       </td>
                       <td>

--- a/frontend/src/components/monitor/SnapshotTrafficChart/SnapshotTrafficChart.tsx
+++ b/frontend/src/components/monitor/SnapshotTrafficChart/SnapshotTrafficChart.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useEffect, useState, useMemo } from 'react';
+import { Button, ButtonGroup, Card, Form } from '@govtechsg/sgds-react';
 import {
   BarChart,
   Bar,
@@ -83,8 +85,8 @@ function CustomTooltip({ active, payload, label, viewMode }: TooltipProps) {
   const total = payload.reduce((s, e) => s + (e.value ?? 0), 0);
   const snapLabel = payload[0]?.payload?.snapLabel;
   return (
-    <div className="card shadow-sm" style={{ minWidth: 200 }}>
-      <div className="card-body p-2 small">
+    <Card className="shadow-sm" style={{ minWidth: 200 }}>
+      <Card.Body className="p-2 small">
         {snapLabel && <p className="mb-0 text-muted" style={{ fontSize: '0.7rem' }}>{snapLabel}</p>}
         <p className="mb-1 fw-semibold">{label}</p>
         <div className="mb-1">
@@ -101,8 +103,8 @@ function CustomTooltip({ active, payload, label, viewMode }: TooltipProps) {
             ))}
           </ul>
         )}
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   );
 }
 
@@ -201,8 +203,8 @@ export const SnapshotTrafficChart = ({ snapshots }: Props) => {
         <div className="d-flex align-items-center gap-2 flex-wrap">
           <div className="d-flex align-items-center gap-1">
             <label className="text-muted small mb-0">Granularity:</label>
-            <select
-              className="form-select form-select-sm"
+            <Form.Select
+              size="sm"
               style={{ width: 'auto' }}
               value={granularity === 'auto' ? 'auto' : String(granularity)}
               onChange={e => {
@@ -214,30 +216,28 @@ export const SnapshotTrafficChart = ({ snapshots }: Props) => {
               {GRANULARITY_OPTIONS.map(({ label, seconds }) => (
                 <option key={seconds} value={String(seconds)}>{label}</option>
               ))}
-            </select>
+            </Form.Select>
           </div>
-          <div className="btn-group btn-group-sm">
-            <button
-              type="button"
-              className={`btn ${viewMode === 'packets' ? 'btn-primary' : 'btn-outline-primary'}`}
+          <ButtonGroup size="sm">
+            <Button
+              variant={viewMode === 'packets' ? 'primary' : 'outline-primary'}
               onClick={() => setViewMode('packets')}
             >
               Packets
-            </button>
-            <button
-              type="button"
-              className={`btn ${viewMode === 'bytes' ? 'btn-primary' : 'btn-outline-primary'}`}
+            </Button>
+            <Button
+              variant={viewMode === 'bytes' ? 'primary' : 'outline-primary'}
               onClick={() => setViewMode('bytes')}
             >
               Bytes
-            </button>
-          </div>
+            </Button>
+          </ButtonGroup>
         </div>
       </div>
 
       {loading ? (
         <div className="d-flex align-items-center justify-content-center py-5 text-muted">
-          <span className="spinner-border spinner-border-sm me-2" />
+          <Spinner animation="border" size="sm" className="me-2" />
           Loading traffic data…
         </div>
       ) : (

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -15,7 +15,7 @@ import {
   RISK_BADGE,
 } from '@/utils/appColors';
 import { PillSectionHeader } from '@components/common/PillSectionHeader/PillSectionHeader';
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Badge, Button, Card, Form, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import './NetworkControls.css';
 
 function InfoPopover({ id, title, body }: { id: string; title: string; body: ReactNode }) {
@@ -27,14 +27,15 @@ function InfoPopover({ id, title, body }: { id: string; title: string; body: Rea
   );
   return (
     <OverlayTrigger trigger="click" placement="right" overlay={popover} rootClose>
-      <button
+      <Button
         type="button"
-        className="btn btn-link p-0 text-muted ms-1"
+        variant="link"
+        className="p-0 text-muted ms-1"
         style={{ lineHeight: 1 }}
         aria-label={`About ${title}`}
       >
         <i className="bi bi-info-circle" style={{ fontSize: '0.8rem' }}></i>
-      </button>
+      </Button>
     </OverlayTrigger>
   );
 }
@@ -215,31 +216,33 @@ export function NetworkControls({
       <div className="nc-filter-panel">
         {/* Toggle button */}
         <div className="d-flex align-items-center gap-2">
-          <button
-            type="button"
-            className="btn btn-outline-secondary btn-sm"
+          <Button
+            size="sm"
+            variant="outline-secondary"
             onClick={() => setIsOpen(o => !o)}
           >
             <i className="bi bi-funnel me-1"></i>
             Filters
             {activeFilterCount > 0 && (
-              <span className="badge bg-primary ms-2">{activeFilterCount}</span>
+              <Badge bg="primary" className="ms-2">{activeFilterCount}</Badge>
             )}
             <i className={`bi ms-2 ${isOpen ? 'bi-chevron-up' : 'bi-chevron-down'}`}></i>
-          </button>
-          <button
-            className="btn btn-link btn-sm p-0 text-muted"
+          </Button>
+          <Button
+            size="sm"
+            variant="link"
+            className="p-0 text-muted"
             onClick={() => setShowColorInfo(true)}
             title="How are node colours determined?"
           >
             <i className="bi bi-info-circle me-1"></i>Node colours
-          </button>
+          </Button>
         </div>
 
         {/* Collapsible panel */}
         {isOpen && (
           <div className="card mt-2">
-            <div className="card-body p-3">
+            <Card.Body className="p-3">
               <div className="row g-3">
                 {/* IP / Hostname */}
                 <div className="col-md-3">
@@ -248,21 +251,19 @@ export function NetworkControls({
                     <span className="input-group-text">
                       <i className="bi bi-search" />
                     </span>
-                    <input
+                    <Form.Control
                       type="text"
-                      className="form-control"
                       placeholder="e.g. 192.168.1.1"
                       value={ipInput}
                       onChange={e => handleIpChange(e.target.value)}
                     />
                     {ipInput && (
-                      <button
-                        type="button"
-                        className="btn btn-outline-secondary"
+                      <Button
+                        variant="outline-secondary"
                         onClick={() => handleIpChange('')}
                       >
                         ×
-                      </button>
+                      </Button>
                     )}
                   </div>
                 </div>
@@ -271,40 +272,34 @@ export function NetworkControls({
                 <div className="col-md-2">
                   <label className="filter-section-label d-block mb-2">Port</label>
                   <div className="input-group input-group-sm">
-                    <input
+                    <Form.Control
                       type="text"
                       inputMode="numeric"
-                      className="form-control"
                       placeholder="e.g. 443"
                       value={portInput}
                       onChange={e => handlePortChange(e.target.value)}
                     />
                     {portInput && (
-                      <button
-                        type="button"
-                        className="btn btn-outline-secondary"
+                      <Button
+                        variant="outline-secondary"
                         onClick={() => handlePortChange('')}
                       >
                         ×
-                      </button>
+                      </Button>
                     )}
                   </div>
                 </div>
 
                 {/* Has risks */}
                 <div className="col-md-2 d-flex align-items-end">
-                  <div className="form-check mb-0">
-                    <input
-                      type="checkbox"
-                      className="form-check-input"
-                      id="ncHasRisks"
-                      checked={hasRisksOnly}
-                      onChange={e => onHasRisksOnlyChange(e.target.checked)}
-                    />
-                    <label className="form-check-label small" htmlFor="ncHasRisks">
-                      Security risks only
-                    </label>
-                  </div>
+                  <Form.Check
+                    className="mb-0"
+                    type="checkbox"
+                    id="ncHasRisks"
+                    label="Security risks only"
+                    checked={hasRisksOnly}
+                    onChange={e => onHasRisksOnlyChange(e.target.checked)}
+                  />
                 </div>
 
                 {/* Node Types */}
@@ -782,17 +777,17 @@ export function NetworkControls({
 
               {activeFilterCount > 0 && (
                 <div className="mt-3 pt-2 border-top">
-                  <button
-                    type="button"
-                    className="btn btn-sm btn-outline-secondary"
+                  <Button
+                    size="sm"
+                    variant="outline-secondary"
                     onClick={onClearAllFilters}
                   >
                     <i className="bi bi-x-circle me-1" />
                     Clear filters
-                  </button>
+                  </Button>
                 </div>
               )}
-            </div>
+            </Card.Body>
           </div>
         )}
       </div>
@@ -826,24 +821,24 @@ export function NetworkControls({
                 </p>
                 <ol className="ps-3" style={{ lineHeight: '2' }}>
                   <li>
-                    <span className="badge me-2" style={{ backgroundColor: NODE_TYPE_COLORS['dns-server'], color: '#fff' }}>DNS</span>
-                    <span className="badge me-2" style={{ backgroundColor: NODE_TYPE_COLORS['web-server'], color: '#fff' }}>Web</span>
-                    <span className="badge me-2" style={{ backgroundColor: NODE_TYPE_COLORS['router'], color: '#fff' }}>Router</span>
+                    <Badge className="me-2" style={{ backgroundColor: NODE_TYPE_COLORS['dns-server'], color: '#fff' }}>DNS</Badge>
+                    <Badge className="me-2" style={{ backgroundColor: NODE_TYPE_COLORS['web-server'], color: '#fff' }}>Web</Badge>
+                    <Badge className="me-2" style={{ backgroundColor: NODE_TYPE_COLORS['router'], color: '#fff' }}>Router</Badge>
                     <strong>Specific server role</strong> — the node's dominant inbound port identifies it as a known server type (DNS, web, SSH, FTP, mail, DHCP, NTP, database, router). Each type has a fixed colour.
                   </li>
                   <li>
-                    <span className="badge me-2" style={{ backgroundColor: deviceTypeColor('MOBILE'), color: '#fff' }}>Mobile</span>
-                    <span className="badge me-2" style={{ backgroundColor: deviceTypeColor('IOT'), color: '#fff' }}>IoT</span>
+                    <Badge className="me-2" style={{ backgroundColor: deviceTypeColor('MOBILE'), color: '#fff' }}>Mobile</Badge>
+                    <Badge className="me-2" style={{ backgroundColor: deviceTypeColor('IOT'), color: '#fff' }}>IoT</Badge>
                     <strong>Device classification</strong> — inferred from MAC OUI vendor lookup, TTL fingerprinting, and observed nDPI application profiles. Overrides generic node type when a non-unknown device type is detected.
                   </li>
                   <li>
-                    <span className="badge me-2" style={{ backgroundColor: NODE_TYPE_COLORS['client'], color: '#fff' }}>Client</span>
+                    <Badge className="me-2" style={{ backgroundColor: NODE_TYPE_COLORS['client'], color: '#fff' }}>Client</Badge>
                     <strong>Generic node type</strong> — nodes that only initiate outbound connections with no dominant inbound port are classified as clients and shown in blue.
                   </li>
                   <li>
-                    <span className="badge me-2" style={{ backgroundColor: '#2ecc71', color: '#fff' }}>Server</span>
-                    <span className="badge me-2" style={{ backgroundColor: '#9b59b6', color: '#fff' }}>Both</span>
-                    <span className="badge bg-secondary me-2">Other</span>
+                    <Badge className="me-2" style={{ backgroundColor: '#2ecc71', color: '#fff' }}>Server</Badge>
+                    <Badge className="me-2" style={{ backgroundColor: '#9b59b6', color: '#fff' }}>Both</Badge>
+                    <Badge bg="secondary" className="me-2">Other</Badge>
                     <strong>Traffic role fallback</strong> — if no type can be determined, nodes are coloured by their observed role: green if they only receive connections (server), purple if they both send and receive (both), grey otherwise.
                   </li>
                 </ol>

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useEffect, useRef, useState, useCallback, useMemo, memo } from 'react';
 import ELK from 'elkjs';
 const ELK_WORKER_URL = `${import.meta.env.BASE_URL}elk-worker.min.js`;
@@ -666,7 +667,7 @@ export const NetworkGraph = memo(function NetworkGraph({
       {/* ── Layout spinner ───────────────────────────────────────────────── */}
       {layouting && (
         <div className="ng-layouting">
-          <div className="spinner-border spinner-border-sm text-secondary me-2" role="status" />
+          <Spinner animation="border" size="sm" className="text-secondary me-2" />
           Computing layout…
         </div>
       )}

--- a/frontend/src/components/network/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/components/network/NodeDetails/NodeDetails.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Badge } from '@govtechsg/sgds-react';
 import { useNavigate } from 'react-router-dom';
 import type { GraphNode, GraphEdge } from '@/features/network/types';
 import { NODE_TYPE_CONFIG, getProtocolColor } from '@/features/network/constants';
@@ -272,9 +273,9 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                         </td>
                         <td>
                           {Array.from(info.apps).map(app => (
-                            <span key={app} className="badge bg-light text-dark me-1 border">
+                            <Badge key={app} bg="light" text="dark" className="me-1 border">
                               {app}
-                            </span>
+                            </Badge>
                           ))}
                         </td>
                         <td className="text-end small">{formatNumber(info.packets)}</td>

--- a/frontend/src/components/signatures/SignaturesModal.tsx
+++ b/frontend/src/components/signatures/SignaturesModal.tsx
@@ -1,5 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect } from 'react';
-import { Modal } from '@govtechsg/sgds-react';
+import { Alert, Button, ButtonGroup, Form, Modal } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
 import { ipOrgRuleService, type IpOrgRule } from '@/features/intelligence/services/ipOrgRuleService';
 
@@ -113,24 +114,22 @@ export function SignaturesModal({ show, onHide }: SignaturesModalProps) {
 
       <Modal.Body>
         {/* Tabs */}
-        <div className="btn-group mb-3" role="group">
-          <button
-            type="button"
-            className={`btn btn-sm ${activeTab === 'rules' ? 'btn-primary' : 'btn-outline-primary'}`}
+        <ButtonGroup size="sm" className="mb-3">
+          <Button
+            variant={activeTab === 'rules' ? 'primary' : 'outline-primary'}
             onClick={() => setActiveTab('rules')}
           >
             <i className="bi bi-code-square me-1" />
             Detection Rules
-          </button>
-          <button
-            type="button"
-            className={`btn btn-sm ${activeTab === 'labels' ? 'btn-primary' : 'btn-outline-primary'}`}
+          </Button>
+          <Button
+            variant={activeTab === 'labels' ? 'primary' : 'outline-primary'}
             onClick={() => setActiveTab('labels')}
           >
             <i className="bi bi-tag me-1" />
             Network Labels
-          </button>
-        </div>
+          </Button>
+        </ButtonGroup>
 
         {/* ── Detection Rules tab ─────────────────────────────────────── */}
         {activeTab === 'rules' && (
@@ -143,12 +142,13 @@ export function SignaturesModal({ show, onHide }: SignaturesModalProps) {
 
             {loading ? (
               <div className="text-center py-4 text-muted">
-                <div className="spinner-border spinner-border-sm me-2" role="status" />
+                <Spinner animation="border" size="sm" className="me-2" role="status" />
                 Loading…
               </div>
             ) : (
-              <textarea
-                className="form-control font-monospace"
+              <Form.Control
+                as="textarea"
+                className="font-monospace"
                 rows={20}
                 value={content}
                 onChange={e => { setContent(e.target.value); setSaved(false); }}
@@ -157,11 +157,11 @@ export function SignaturesModal({ show, onHide }: SignaturesModalProps) {
               />
             )}
 
-            {error && <div className="alert alert-danger mt-2 py-2 small mb-0">{error}</div>}
+            {error && <Alert variant="danger" className="mt-2 py-2 small mb-0">{error}</Alert>}
             {saved && (
-              <div className="alert alert-success mt-2 py-2 small mb-0">
+              <Alert variant="success" className="mt-2 py-2 small mb-0">
                 <i className="bi bi-check-circle me-1"></i>Saved — rules will apply on the next analysis.
-              </div>
+              </Alert>
             )}
           </>
         )}
@@ -179,7 +179,7 @@ export function SignaturesModal({ show, onHide }: SignaturesModalProps) {
             {/* Existing rules */}
             {rulesLoading ? (
               <div className="text-center py-4 text-muted">
-                <div className="spinner-border spinner-border-sm me-2" role="status" />
+                <Spinner animation="border" size="sm" className="me-2" role="status" />
                 Loading…
               </div>
             ) : rules.length === 0 ? (
@@ -201,16 +201,18 @@ export function SignaturesModal({ show, onHide }: SignaturesModalProps) {
                       <td>{r.label}</td>
                       <td><code>{r.cidr}</code></td>
                       <td>
-                        <button
-                          className="btn btn-link btn-sm text-danger p-0"
+                        <Button
+                          size="sm"
+                          variant="link"
+                          className="text-danger p-0"
                           onClick={() => handleDelete(r.id)}
                           disabled={deletingId === r.id}
                           title="Delete"
                         >
                           {deletingId === r.id
-                            ? <span className="spinner-border spinner-border-sm" style={{ width: 12, height: 12 }} />
+                            ? <Spinner animation="border" size="sm" style={{ width: 12, height: 12 }} />
                             : <i className="bi bi-trash" />}
-                        </button>
+                        </Button>
                       </td>
                     </tr>
                   ))}
@@ -222,10 +224,10 @@ export function SignaturesModal({ show, onHide }: SignaturesModalProps) {
             <div className="border rounded p-3" style={{ background: 'var(--tp-bg-subtle, #f8f9fa)' }}>
               <div className="row g-2 align-items-end">
                 <div className="col">
-                  <label className="form-label small mb-1">Label</label>
-                  <input
+                  <Form.Label className="small mb-1">Label</Form.Label>
+                  <Form.Control
+                    size="sm"
                     type="text"
-                    className="form-control form-control-sm"
                     placeholder="e.g. Engineering Team"
                     value={newLabel}
                     onChange={e => { setNewLabel(e.target.value); setAddError(null); }}
@@ -233,10 +235,10 @@ export function SignaturesModal({ show, onHide }: SignaturesModalProps) {
                   />
                 </div>
                 <div className="col">
-                  <label className="form-label small mb-1">CIDR Range</label>
-                  <input
+                  <Form.Label className="small mb-1">CIDR Range</Form.Label>
+                  <Form.Control
+                    size="sm"
                     type="text"
-                    className="form-control form-control-sm"
                     placeholder="e.g. 10.0.1.0/24 or 10.0.1.5"
                     value={newCidr}
                     onChange={e => { setNewCidr(e.target.value); setAddError(null); }}
@@ -244,15 +246,16 @@ export function SignaturesModal({ show, onHide }: SignaturesModalProps) {
                   />
                 </div>
                 <div className="col-auto">
-                  <button
-                    className="btn btn-primary btn-sm"
+                  <Button
+                    size="sm"
+                    variant="primary"
                     onClick={handleAdd}
                     disabled={adding}
                   >
                     {adding
-                      ? <span className="spinner-border spinner-border-sm" />
+                      ? <Spinner animation="border" size="sm" />
                       : <><i className="bi bi-plus-lg me-1" />Add</>}
-                  </button>
+                  </Button>
                 </div>
               </div>
               {addError && <div className="text-danger small mt-2">{addError}</div>}
@@ -262,22 +265,21 @@ export function SignaturesModal({ show, onHide }: SignaturesModalProps) {
       </Modal.Body>
 
       <Modal.Footer>
-        <button type="button" className="btn btn-outline-secondary" onClick={handleHide}>
+        <Button variant="outline-secondary" onClick={handleHide}>
           Close
-        </button>
+        </Button>
         {activeTab === 'rules' && (
-          <button
-            type="button"
-            className="btn btn-primary"
+          <Button
+            variant="primary"
             onClick={handleSave}
             disabled={loading || saving}
           >
             {saving ? (
-              <><span className="spinner-border spinner-border-sm me-1" role="status" />Saving…</>
+              <><Spinner animation="border" size="sm" className="me-1" role="status" />Saving…</>
             ) : (
               <><i className="bi bi-floppy me-1"></i>Save</>
             )}
-          </button>
+          </Button>
         )}
       </Modal.Footer>
     </Modal>

--- a/frontend/src/components/story/AggregatesPanel/AggregatesPanel.tsx
+++ b/frontend/src/components/story/AggregatesPanel/AggregatesPanel.tsx
@@ -1,4 +1,4 @@
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Badge, Button, Card, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import type { StoryAggregates, AsnEntry, ProtocolRiskEntry, BeaconCandidate } from '@/types';
 
 function InfoPopover() {
@@ -31,14 +31,15 @@ function InfoPopover() {
   );
   return (
     <OverlayTrigger trigger="click" placement="left" overlay={popover} rootClose>
-      <button
+      <Button
         type="button"
-        className="btn btn-link p-0 text-muted ms-1"
+        variant="link"
+        className="p-0 text-muted ms-1"
         style={{ lineHeight: 1 }}
         aria-label="About Traffic Intelligence"
       >
         <i className="bi bi-info-circle" style={{ fontSize: '0.9rem' }}></i>
-      </button>
+      </Button>
     </OverlayTrigger>
   );
 }
@@ -129,9 +130,9 @@ function TopAsnsTable({ entries }: { entries: AsnEntry[] }) {
           <tr key={i}>
             <td>
               {e.country && (
-                <span className="badge bg-secondary me-1 fw-normal" style={{ fontSize: '0.7em' }}>
+                <Badge bg="secondary" className="me-1 fw-normal" style={{ fontSize: '0.7em' }}>
                   {e.country}
-                </span>
+                </Badge>
               )}
               {e.org ?? 'Unknown'}
               {e.asn && (
@@ -199,10 +200,10 @@ function TlsBadges({ aggregates }: { aggregates: StoryAggregates }) {
   const anomalies = tls.selfSigned + tls.expired + tls.unknownCa;
   if (anomalies === 0) {
     return (
-      <span className="badge bg-success">
+      <Badge bg="success">
         <i className="bi bi-shield-check me-1" />
         All {tls.total} TLS flows OK
-      </span>
+      </Badge>
     );
   }
 
@@ -210,11 +211,11 @@ function TlsBadges({ aggregates }: { aggregates: StoryAggregates }) {
     <div className="d-flex flex-wrap gap-2 align-items-center">
       <span className="text-muted small">{tls.total} TLS flows —</span>
       {tls.selfSigned > 0 && (
-        <span className="badge bg-warning text-dark">{tls.selfSigned} self-signed</span>
+        <Badge bg="warning" text="dark">{tls.selfSigned} self-signed</Badge>
       )}
-      {tls.expired > 0 && <span className="badge bg-danger">{tls.expired} expired</span>}
+      {tls.expired > 0 && <Badge bg="danger">{tls.expired} expired</Badge>}
       {tls.unknownCa > 0 && (
-        <span className="badge bg-secondary">{tls.unknownCa} unknown issuer</span>
+        <Badge bg="secondary">{tls.unknownCa} unknown issuer</Badge>
       )}
     </div>
   );
@@ -228,17 +229,18 @@ function BeaconList({ candidates }: { candidates: BeaconCandidate[] }) {
     <div className="d-flex flex-column gap-2">
       {candidates.map((b, i) => (
         <div key={i} className="d-flex align-items-start gap-2 small">
-          <span
-            className="badge bg-danger mt-1"
+          <Badge
+            bg="danger"
+            className="mt-1"
             style={{ minWidth: '1.5rem', textAlign: 'center' }}
           >
             {i + 1}
-          </span>
+          </Badge>
           <div>
             <span className="fw-medium font-monospace">
               {b.srcIp} → {b.dstIp ?? '?'}:{b.dstPort ?? '*'}
             </span>
-            {b.appName && <span className="badge bg-light text-dark ms-1 border">{b.appName}</span>}
+            {b.appName && <Badge bg="light" text="dark" className="ms-1 border">{b.appName}</Badge>}
             <div className="text-muted">
               {b.protocol} &middot; {b.flowCount} flows &middot; avg&nbsp;
               <span className="fw-medium">{fmtInterval(b.avgIntervalMs)}</span>
@@ -263,18 +265,18 @@ export const AggregatesPanel = ({ aggregates }: Props) => {
     0;
 
   return (
-    <div className="card mb-4">
-      <div className="card-header d-flex align-items-center gap-2">
+    <Card className="mb-4">
+      <Card.Header className="d-flex align-items-center gap-2">
         <i className="bi bi-bar-chart-line text-primary" />
         <h6 className="mb-0 d-flex align-items-center">
           Traffic Intelligence — Full Dataset
           <InfoPopover />
         </h6>
         {(hasBeacons || hasTlsAnomalies) && (
-          <span className="badge bg-danger ms-auto">Findings</span>
+          <Badge bg="danger" className="ms-auto">Findings</Badge>
         )}
-      </div>
-      <div className="card-body">
+      </Card.Header>
+      <Card.Body>
         {/* Coverage banner */}
         <CoverageBanner aggregates={aggregates} />
 
@@ -310,15 +312,15 @@ export const AggregatesPanel = ({ aggregates }: Props) => {
             <h6 className="text-muted text-uppercase small fw-semibold mb-2 d-flex align-items-center gap-2">
               Beacon Candidates
               {hasBeacons && (
-                <span className="badge bg-danger fw-normal">
+                <Badge bg="danger" className="fw-normal">
                   {aggregates.beaconCandidates.length}
-                </span>
+                </Badge>
               )}
             </h6>
             <BeaconList candidates={aggregates.beaconCandidates} />
           </div>
         </div>
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   );
 };

--- a/frontend/src/components/story/AnomalyHighlight/AnomalyHighlight.tsx
+++ b/frontend/src/components/story/AnomalyHighlight/AnomalyHighlight.tsx
@@ -1,4 +1,4 @@
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Alert, Button, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import type { Highlight } from '@/types';
 import { formatTimestamp } from '@/utils/formatters';
 
@@ -32,14 +32,15 @@ function InfoPopover() {
   );
   return (
     <OverlayTrigger trigger="click" placement="right" overlay={popover} rootClose>
-      <button
+      <Button
         type="button"
-        className="btn btn-link p-0 text-muted ms-2"
+        variant="link"
+        className="p-0 text-muted ms-2"
         style={{ lineHeight: 1 }}
         aria-label="About Key Highlights"
       >
         <i className="bi bi-info-circle" style={{ fontSize: '0.9rem' }}></i>
-      </button>
+      </Button>
     </OverlayTrigger>
   );
 }
@@ -49,14 +50,14 @@ interface AnomalyHighlightProps {
 }
 
 export const AnomalyHighlight = ({ highlights }: AnomalyHighlightProps) => {
-  const getHighlightClass = (type: string) => {
-    const classes: Record<string, string> = {
-      anomaly: 'alert-danger',
-      warning: 'alert-warning',
-      insight: 'alert-info',
-      info: 'alert-primary',
+  const getHighlightVariant = (type: string) => {
+    const variants: Record<string, string> = {
+      anomaly: 'danger',
+      warning: 'warning',
+      insight: 'info',
+      info: 'primary',
     };
-    return classes[type] || 'alert-secondary';
+    return variants[type] || 'secondary';
   };
 
   const getHighlightIcon = (type: string) => {
@@ -88,10 +89,10 @@ export const AnomalyHighlight = ({ highlights }: AnomalyHighlightProps) => {
       </h5>
 
       {sortedHighlights.map(highlight => (
-        <div
+        <Alert
           key={highlight.id}
-          className={`alert ${getHighlightClass(highlight.type)} d-flex`}
-          role="alert"
+          variant={getHighlightVariant(highlight.type)}
+          className="d-flex"
         >
           <div className="flex-shrink-0 me-3">
             <i className={`bi ${getHighlightIcon(highlight.type)} fs-4`}></i>
@@ -106,13 +107,13 @@ export const AnomalyHighlight = ({ highlights }: AnomalyHighlightProps) => {
               </small>
             )}
           </div>
-        </div>
+        </Alert>
       ))}
 
       {highlights.length === 0 && (
-        <div className="alert alert-secondary">
+        <Alert variant="secondary">
           <p className="mb-0">No highlights to display</p>
-        </div>
+        </Alert>
       )}
     </div>
   );

--- a/frontend/src/components/story/FindingsPanel/FindingsPanel.tsx
+++ b/frontend/src/components/story/FindingsPanel/FindingsPanel.tsx
@@ -1,4 +1,4 @@
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Badge, Button, Card, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import type { Finding, FindingSeverity } from '@/types';
 
 function FindingsInfoPopover() {
@@ -26,30 +26,35 @@ function FindingsInfoPopover() {
   );
   return (
     <OverlayTrigger trigger="click" placement="left" overlay={popover} rootClose>
-      <button
+      <Button
         type="button"
-        className="btn btn-link p-0 text-muted ms-1"
+        variant="link"
+        className="p-0 text-muted ms-1"
         style={{ lineHeight: 1 }}
         aria-label="About Deterministic Findings"
       >
         <i className="bi bi-info-circle" style={{ fontSize: '0.9rem' }}></i>
-      </button>
+      </Button>
     </OverlayTrigger>
   );
 }
 
 const SEVERITY_ORDER: FindingSeverity[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'];
 
-function severityBadgeClass(severity: FindingSeverity): string {
+function severityBadgeBg(severity: FindingSeverity): string {
   switch (severity) {
-    case 'CRITICAL':
-      return 'badge bg-danger';
+    case 'CRITICAL': return 'danger';
+    case 'HIGH': return 'warning';
+    case 'MEDIUM': return 'info';
+    case 'LOW': return 'secondary';
+  }
+}
+
+function severityBadgeText(severity: FindingSeverity): 'dark' | undefined {
+  switch (severity) {
     case 'HIGH':
-      return 'badge bg-warning text-dark';
-    case 'MEDIUM':
-      return 'badge bg-info text-dark';
-    case 'LOW':
-      return 'badge bg-secondary';
+    case 'MEDIUM': return 'dark';
+    default: return undefined;
   }
 }
 
@@ -76,15 +81,16 @@ function FindingCard({ finding }: FindingCardProps) {
     : [];
 
   return (
-    <div className="card mb-2">
-      <div className="card-body py-2 px-3">
+    <Card className="mb-2">
+      <Card.Body className="py-2 px-3">
         <div className="d-flex align-items-start gap-2 mb-1">
-          <span
-            className={severityBadgeClass(finding.severity)}
+          <Badge
+            bg={severityBadgeBg(finding.severity)}
+            text={severityBadgeText(finding.severity)}
             style={{ whiteSpace: 'nowrap', fontSize: '0.7rem' }}
           >
             {finding.severity}
-          </span>
+          </Badge>
           <h6 className="mb-0 small fw-semibold" style={{ lineHeight: '1.4' }}>
             {finding.title}
           </h6>
@@ -108,18 +114,20 @@ function FindingCard({ finding }: FindingCardProps) {
         {finding.affectedIps && finding.affectedIps.length > 0 && (
           <div className="d-flex flex-wrap gap-1">
             {finding.affectedIps.map(ip => (
-              <span
+              <Badge
                 key={ip}
-                className="badge bg-light text-dark border"
+                bg="light"
+                text="dark"
+                className="border"
                 style={{ fontSize: '0.7rem', fontFamily: 'monospace' }}
               >
                 {ip}
-              </span>
+              </Badge>
             ))}
           </div>
         )}
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   );
 }
 
@@ -141,8 +149,8 @@ export function FindingsPanel({ findings }: Props) {
   const highCount = grouped.HIGH.length;
 
   return (
-    <div className="card">
-      <div className="card-header d-flex align-items-center justify-content-between">
+    <Card>
+      <Card.Header className="d-flex align-items-center justify-content-between">
         <div className="d-flex align-items-center gap-2">
           <h6 className="mb-0">
             <i className="bi bi-shield-exclamation me-2"></i>
@@ -154,11 +162,11 @@ export function FindingsPanel({ findings }: Props) {
           <span className="text-muted small">
             {total} finding{total !== 1 ? 's' : ''}
           </span>
-          {criticalCount > 0 && <span className="badge bg-danger">{criticalCount} CRITICAL</span>}
-          {highCount > 0 && <span className="badge bg-warning text-dark">{highCount} HIGH</span>}
+          {criticalCount > 0 && <Badge bg="danger">{criticalCount} CRITICAL</Badge>}
+          {highCount > 0 && <Badge bg="warning" text="dark">{highCount} HIGH</Badge>}
         </div>
-      </div>
-      <div className="card-body">
+      </Card.Header>
+      <Card.Body>
         {SEVERITY_ORDER.map(sev => {
           const group = grouped[sev];
           if (group.length === 0) return null;
@@ -173,7 +181,7 @@ export function FindingsPanel({ findings }: Props) {
             </div>
           );
         })}
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   );
 }

--- a/frontend/src/components/story/InvestigationPanel/InvestigationPanel.tsx
+++ b/frontend/src/components/story/InvestigationPanel/InvestigationPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Badge, Button, Card, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import type { InvestigationStep } from '@/types';
 
 interface InvestigationPanelProps {
@@ -29,14 +29,15 @@ function InfoPopover() {
   );
   return (
     <OverlayTrigger trigger="click" placement="right" overlay={popover} rootClose>
-      <button
+      <Button
         type="button"
-        className="btn btn-link p-0 text-muted ms-2"
+        variant="link"
+        className="p-0 text-muted ms-2"
         style={{ lineHeight: 1 }}
         aria-label="About Investigation"
       >
         <i className="bi bi-info-circle" style={{ fontSize: '0.9rem' }}></i>
-      </button>
+      </Button>
     </OverlayTrigger>
   );
 }
@@ -60,13 +61,14 @@ function QueryResultTable({ step }: { step: InvestigationStep }) {
 
   return (
     <div className="border rounded mb-2">
-      <button
-        className="btn btn-link w-100 text-start text-decoration-none p-3 d-flex align-items-center justify-content-between"
+      <Button
+        variant="link"
+        className="w-100 text-start text-decoration-none p-3 d-flex align-items-center justify-content-between"
         onClick={() => setExpanded(e => !e)}
         type="button"
       >
         <div className="d-flex align-items-center gap-2 flex-wrap">
-          <span className="badge bg-secondary font-monospace">{step.query.id}</span>
+          <Badge bg="secondary" className="font-monospace">{step.query.id}</Badge>
           <span className="fw-semibold small">{step.query.label}</span>
           {step.hypothesis && (
             <span
@@ -82,7 +84,7 @@ function QueryResultTable({ step }: { step: InvestigationStep }) {
           </span>
           <i className={`bi bi-chevron-${expanded ? 'up' : 'down'}`}></i>
         </div>
-      </button>
+      </Button>
 
       {expanded && (
         <div className="px-3 pb-3">
@@ -126,13 +128,14 @@ function QueryResultTable({ step }: { step: InvestigationStep }) {
                         <td>
                           {conv.flowRisks && conv.flowRisks.length > 0 ? (
                             conv.flowRisks.map(r => (
-                              <span
+                              <Badge
                                 key={r}
-                                className="badge bg-danger me-1"
+                                bg="danger"
+                                className="me-1"
                                 style={{ fontSize: '0.65rem' }}
                               >
                                 {r}
-                              </span>
+                              </Badge>
                             ))
                           ) : (
                             <span className="text-muted">-</span>
@@ -162,24 +165,24 @@ export const InvestigationPanel = ({ steps }: InvestigationPanelProps) => {
   const withEvidenceCount = steps.filter(s => s.conversationCount > 0).length;
 
   return (
-    <div className="card">
-      <div className="card-header d-flex align-items-center justify-content-between">
+    <Card>
+      <Card.Header className="d-flex align-items-center justify-content-between">
         <h6 className="mb-0 d-flex align-items-center">
           <i className="bi bi-search me-2"></i>
           LLM Investigation
           <InfoPopover />
         </h6>
         <div className="d-flex gap-2">
-          <span className="badge bg-primary">
+          <Badge bg="primary">
             {steps.length} quer{steps.length !== 1 ? 'ies' : 'y'}
-          </span>
-          <span className="badge bg-secondary">
+          </Badge>
+          <Badge bg="secondary">
             {hypothesisCount} hypothesis{hypothesisCount !== 1 ? 'es' : ''}
-          </span>
-          <span className="badge bg-success">{withEvidenceCount} with evidence</span>
+          </Badge>
+          <Badge bg="success">{withEvidenceCount} with evidence</Badge>
         </div>
-      </div>
-      <div className="card-body">
+      </Card.Header>
+      <Card.Body>
         <p className="text-muted small mb-3">
           The LLM analysed the findings and timeline, then issued {steps.length} targeted quer
           {steps.length !== 1 ? 'ies' : 'y'} to retrieve real conversation evidence before writing
@@ -188,7 +191,7 @@ export const InvestigationPanel = ({ steps }: InvestigationPanelProps) => {
         {steps.map(step => (
           <QueryResultTable key={step.query.id} step={step} />
         ))}
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   );
 };

--- a/frontend/src/components/story/NarrativeView/NarrativeView.tsx
+++ b/frontend/src/components/story/NarrativeView/NarrativeView.tsx
@@ -1,4 +1,5 @@
 import type { NarrativeSection } from '@/types';
+import { Card } from '@govtechsg/sgds-react';
 
 interface NarrativeViewProps {
   sections: NarrativeSection[];
@@ -28,14 +29,14 @@ export const NarrativeView = ({ sections }: NarrativeViewProps) => {
   return (
     <div className="narrative-view">
       {sections.map((section, index) => (
-        <div key={index} className={`card mb-3 overflow-hidden ${getSectionClass(section.type)}`}>
-          <div className="card-header bg-white rounded-top">
+        <Card key={index} className={`mb-3 overflow-hidden ${getSectionClass(section.type)}`}>
+          <Card.Header className="bg-white rounded-top">
             <h5 className="mb-0 d-flex align-items-center">
               <i className={`bi ${getSectionIcon(section.type)} me-2`}></i>
               {section.title}
             </h5>
-          </div>
-          <div className="card-body">
+          </Card.Header>
+          <Card.Body>
             <div className="narrative-content" style={{ whiteSpace: 'pre-line' }}>
               {section.content}
             </div>
@@ -58,8 +59,8 @@ export const NarrativeView = ({ sections }: NarrativeViewProps) => {
                 </small>
               </div>
             )}
-          </div>
-        </div>
+          </Card.Body>
+        </Card>
       ))}
     </div>
   );

--- a/frontend/src/components/story/StoryChat/StoryChat.tsx
+++ b/frontend/src/components/story/StoryChat/StoryChat.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useRef, useEffect } from 'react';
+import { Alert, Button, Card, Form } from '@govtechsg/sgds-react';
 import { storyService } from '@/features/story/services/storyService';
 
 interface Message {
@@ -62,14 +64,14 @@ export const StoryChat = ({ storyId, suggestedQuestions }: StoryChatProps) => {
   };
 
   return (
-    <div className="card mb-4">
-      <div className="card-header">
+    <Card className="mb-4">
+      <Card.Header>
         <h6 className="mb-0">
           <i className="bi bi-chat-dots me-2"></i>
           Ask the LLM
         </h6>
-      </div>
-      <div className="card-body p-0">
+      </Card.Header>
+      <Card.Body className="p-0">
         {messages.length > 0 && (
           <div
             ref={messagesContainerRef}
@@ -108,10 +110,7 @@ export const StoryChat = ({ storyId, suggestedQuestions }: StoryChatProps) => {
                   <i className="bi bi-cpu text-white" style={{ fontSize: '0.7rem' }}></i>
                 </div>
                 <div className="px-3 py-2 rounded-3 small bg-light border text-muted">
-                  <span
-                    className="spinner-border spinner-border-sm me-2"
-                    style={{ width: '0.7rem', height: '0.7rem' }}
-                  ></span>
+                  <Spinner animation="border" size="sm" className="me-2" style={{ width: '0.7rem', height: '0.7rem' }} />
                   Thinking...
                 </div>
               </div>
@@ -119,14 +118,16 @@ export const StoryChat = ({ storyId, suggestedQuestions }: StoryChatProps) => {
           </div>
         )}
 
-        {error && <div className="mx-3 mt-3 alert alert-danger small py-2 mb-0">{error}</div>}
+        {error && <Alert variant="danger" className="mx-3 mt-3 small py-2 mb-0">{error}</Alert>}
 
         {currentSuggestions.length > 0 && !loading && (
           <div className="px-3 pb-2 pt-3 d-flex flex-wrap gap-2">
             {currentSuggestions.map((q, i) => (
-              <button
+              <Button
                 key={i}
-                className="btn btn-outline-secondary btn-sm text-start"
+                variant="outline-secondary"
+                size="sm"
+                className="text-start"
                 style={{ fontSize: '0.78rem', maxWidth: '100%' }}
                 onClick={() => {
                   setInput(q);
@@ -136,15 +137,16 @@ export const StoryChat = ({ storyId, suggestedQuestions }: StoryChatProps) => {
               >
                 <i className="bi bi-lightbulb me-1 text-warning"></i>
                 {q}
-              </button>
+              </Button>
             ))}
           </div>
         )}
 
         <div className="p-3 d-flex gap-2 align-items-end">
-          <textarea
+          <Form.Control
             ref={inputRef}
-            className="form-control form-control-sm"
+            as="textarea"
+            size="sm"
             rows={2}
             placeholder="Ask a question about this story… (Enter to send, Shift+Enter for new line)"
             value={input}
@@ -153,20 +155,22 @@ export const StoryChat = ({ storyId, suggestedQuestions }: StoryChatProps) => {
             disabled={loading}
             style={{ resize: 'none' }}
           />
-          <button
-            className="btn btn-primary btn-sm flex-shrink-0"
+          <Button
+            variant="primary"
+            size="sm"
+            className="flex-shrink-0"
             onClick={handleSubmit}
             disabled={loading || !input.trim()}
             style={{ height: '58px', width: '42px' }}
           >
             {loading ? (
-              <span className="spinner-border spinner-border-sm"></span>
+              <Spinner animation="border" size="sm" />
             ) : (
               <i className="bi bi-send-fill"></i>
             )}
-          </button>
+          </Button>
         </div>
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   );
 };

--- a/frontend/src/components/story/StoryInfoCard/StoryInfoCard.tsx
+++ b/frontend/src/components/story/StoryInfoCard/StoryInfoCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Button, Card, Form } from '@govtechsg/sgds-react';
 
 interface StoryInfoCardProps {
   additionalContext?: string;
@@ -40,37 +41,40 @@ function CapControl({
     <div className="d-flex align-items-center gap-2 flex-wrap">
       <span className="text-muted small fw-semibold" style={{ minWidth: 140 }}>{label}:</span>
       {presets.map(p => (
-        <button
+        <Button
           key={p}
           type="button"
-          className={`btn btn-sm ${value === p ? 'btn-info' : 'btn-outline-secondary'}`}
+          size="sm"
+          variant={value === p ? 'info' : 'outline-secondary'}
           style={{ minWidth: 44 }}
           onClick={() => onChange(p)}
         >
           {p}
-        </button>
+        </Button>
       ))}
-      <button
+      <Button
         type="button"
-        className={`btn btn-sm ${total !== undefined && value >= total ? 'btn-info' : 'btn-outline-secondary'}`}
+        size="sm"
+        variant={total !== undefined && value >= total ? 'info' : 'outline-secondary'}
         style={{ minWidth: 44 }}
         onClick={() => onChange(total ?? 999999)}
       >
         {total !== undefined ? `All ${total}` : 'All'}
-      </button>
+      </Button>
       {value !== defaultValue && !presets.includes(value) && (total === undefined || value < total) && (
-        <button
+        <Button
           type="button"
-          className="btn btn-sm btn-info"
+          size="sm"
+          variant="info"
           style={{ minWidth: 44 }}
         >
           {value}
-        </button>
+        </Button>
       )}
       <div className="input-group input-group-sm" style={{ width: 110 }}>
-        <input
+        <Form.Control
           type="number"
-          className="form-control form-control-sm"
+          size="sm"
           placeholder="Custom…"
           min={1}
           value={customInput}
@@ -96,9 +100,9 @@ export const StoryInfoCard = ({
   const [collapsed, setCollapsed] = useState(true);
 
   return (
-    <div className="card" style={{ overflow: 'hidden' }}>
-      <div
-        className="card-header d-flex align-items-center justify-content-between"
+    <Card style={{ overflow: 'hidden' }}>
+      <Card.Header
+        className="d-flex align-items-center justify-content-between"
         style={{
           cursor: 'pointer',
           userSelect: 'none',
@@ -111,9 +115,9 @@ export const StoryInfoCard = ({
           How Stories Are Generated &amp; Limitations
         </h6>
         <i className={`bi bi-chevron-${collapsed ? 'down' : 'up'} text-muted`}></i>
-      </div>
+      </Card.Header>
       {!collapsed && (
-        <div className="card-body">
+        <Card.Body>
           <p className="text-muted small mb-2">
             The following data is sent to the configured LLM to generate the narrative:
           </p>
@@ -141,12 +145,12 @@ export const StoryInfoCard = ({
 
           {(onMaxFindingsChange || onMaxRiskMatrixChange) && (
             <div className="mt-3 pt-3 border-top">
-              <label className="form-label small fw-semibold mb-2">
+              <Form.Label className="small fw-semibold mb-2">
                 Prompt limits{' '}
                 <span className="text-muted fw-normal">
                   (reduce if generation fails due to context length)
                 </span>
-              </label>
+              </Form.Label>
               <div className="d-flex flex-column gap-2">
                 {onMaxFindingsChange && (
                   <CapControl
@@ -174,11 +178,12 @@ export const StoryInfoCard = ({
 
           {onAdditionalContextChange !== undefined && (
             <div className="mt-3 pt-3 border-top">
-              <label className="form-label small fw-semibold mb-1">
+              <Form.Label className="small fw-semibold mb-1">
                 Additional context <span className="text-muted fw-normal">(optional)</span>
-              </label>
-              <textarea
-                className="form-control form-control-sm"
+              </Form.Label>
+              <Form.Control
+                as="textarea"
+                size="sm"
                 rows={3}
                 placeholder={
                   'Help the LLM produce a more relevant story by providing context it cannot see, e.g.:\n' +
@@ -192,8 +197,8 @@ export const StoryInfoCard = ({
               />
             </div>
           )}
-        </div>
+        </Card.Body>
       )}
-    </div>
+    </Card>
   );
 };

--- a/frontend/src/components/story/StoryTimeline/StoryTimeline.tsx
+++ b/frontend/src/components/story/StoryTimeline/StoryTimeline.tsx
@@ -1,4 +1,4 @@
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Alert, Button, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import type { StoryTimelineEvent } from '@/types';
 import { formatTimestamp } from '@/utils/formatters';
 
@@ -33,14 +33,15 @@ function InfoPopover() {
   );
   return (
     <OverlayTrigger trigger="click" placement="right" overlay={popover} rootClose>
-      <button
+      <Button
         type="button"
-        className="btn btn-link p-0 text-muted ms-2"
+        variant="link"
+        className="p-0 text-muted ms-2"
         style={{ lineHeight: 1 }}
         aria-label="About Event Timeline"
       >
         <i className="bi bi-info-circle" style={{ fontSize: '0.9rem' }}></i>
-      </button>
+      </Button>
     </OverlayTrigger>
   );
 }
@@ -125,9 +126,9 @@ export const StoryTimeline = ({ events }: StoryTimelineProps) => {
       </div>
 
       {events.length === 0 && (
-        <div className="alert alert-secondary">
+        <Alert variant="secondary">
           <p className="mb-0">No timeline events to display</p>
-        </div>
+        </Alert>
       )}
     </div>
   );

--- a/frontend/src/components/timeline/TrafficTimeline/TrafficTimeline.tsx
+++ b/frontend/src/components/timeline/TrafficTimeline/TrafficTimeline.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { Button, ButtonGroup, Card, Form } from '@govtechsg/sgds-react';
 import {
   BarChart,
   Bar,
@@ -76,8 +77,8 @@ function CustomTooltip({ active, payload, label, viewMode }: CustomTooltipProps)
   if (!active || !payload || payload.length === 0 || typeof label !== 'number') return null;
   const total = payload.reduce((s, e) => s + (e.value ?? 0), 0);
   return (
-    <div className="card shadow-sm" style={{ minWidth: '220px' }}>
-      <div className="card-body p-2">
+    <Card className="shadow-sm" style={{ minWidth: '220px' }}>
+      <Card.Body className="p-2">
         <p className="mb-2 fw-semibold small">{formatTimestamp(label)}</p>
         <div className="mb-1 small">
           <strong>Total {viewMode === 'packets' ? 'Packets' : 'Bytes'}:</strong>{' '}
@@ -93,8 +94,8 @@ function CustomTooltip({ active, payload, label, viewMode }: CustomTooltipProps)
             ))}
           </ul>
         )}
-      </div>
-    </div>
+      </Card.Body>
+    </Card>
   );
 }
 
@@ -169,9 +170,9 @@ export const TrafficTimeline = ({
             <label htmlFor="granularity-select" className="text-muted small mb-0">
               Granularity:
             </label>
-            <select
+            <Form.Select
               id="granularity-select"
-              className="form-select form-select-sm"
+              size="sm"
               style={{ width: 'auto' }}
               value={granularity === 'auto' ? 'auto' : String(granularity)}
               onChange={e => {
@@ -185,24 +186,24 @@ export const TrafficTimeline = ({
                   {label}
                 </option>
               ))}
-            </select>
+            </Form.Select>
           </div>
-          <div className="btn-group btn-group-sm" role="group" aria-label="View mode">
-            <button
+          <ButtonGroup size="sm" aria-label="View mode">
+            <Button
               type="button"
-              className={`btn ${viewMode === 'packets' ? 'btn-primary' : 'btn-outline-primary'}`}
+              variant={viewMode === 'packets' ? 'primary' : 'outline-primary'}
               onClick={() => setViewMode('packets')}
             >
               Packets
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
-              className={`btn ${viewMode === 'bytes' ? 'btn-primary' : 'btn-outline-primary'}`}
+              variant={viewMode === 'bytes' ? 'primary' : 'outline-primary'}
               onClick={() => setViewMode('bytes')}
             >
               Bytes
-            </button>
-          </div>
+            </Button>
+          </ButtonGroup>
         </div>
       </div>
 

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -1,7 +1,8 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState, useRef } from 'react';
 import { isAxiosError } from 'axios';
-import { Card, Modal } from '@govtechsg/sgds-react';
+import { Alert, Badge, Button, Card, Form, Modal } from '@govtechsg/sgds-react';
 import { AlertCircle } from 'lucide-react';
 import { apiClient } from '@/services/api/client';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
@@ -161,15 +162,16 @@ export const FileList = () => {
               All Uploads
             </h5>
             <div ref={infoRef} style={{ position: 'relative' }}>
-              <button
+              <Button
                 type="button"
-                className="btn btn-link p-0 text-muted"
+                variant="link"
+                className="p-0 text-muted"
                 style={{ lineHeight: 1 }}
                 onClick={() => setShowInfo(v => !v)}
                 aria-label="About file actions"
               >
                 <i className="bi bi-info-circle" style={{ fontSize: '0.85rem' }}></i>
-              </button>
+              </Button>
               {showInfo && (
                 <div
                   className="card shadow"
@@ -182,7 +184,7 @@ export const FileList = () => {
                     fontSize: '0.82rem',
                   }}
                 >
-                  <div className="card-body py-2 px-3">
+                  <Card.Body className="py-2 px-3">
                     <p className="mb-1">
                       <i className="bi bi-graph-up me-1 text-primary"></i>
                       Click <strong>Analyze</strong> on any file to open its individual analysis.
@@ -192,7 +194,7 @@ export const FileList = () => {
                       Select <strong>two or more</strong> files using the checkboxes, then click{' '}
                       <strong>Multi-Analysis</strong> for cross-PCAP topology analysis.
                     </p>
-                  </div>
+                  </Card.Body>
                 </div>
               )}
             </div>
@@ -200,9 +202,10 @@ export const FileList = () => {
           {files.length > 0 && (
             <div className="d-flex gap-2">
               {selectedForCompare.size >= 2 && (
-                <button
+                <Button
                   type="button"
-                  className="btn btn-outline-primary btn-sm"
+                  variant="outline-primary"
+                  size="sm"
                   onClick={() => {
                     setMergedFileName(buildAutoMergeName(selectedForCompare));
                     setShowMultiSelectModal(true);
@@ -210,27 +213,24 @@ export const FileList = () => {
                 >
                   <i className="bi bi-diagram-3 me-1"></i>
                   Multi-Analysis ({selectedForCompare.size})
-                </button>
+                </Button>
               )}
-              <button
+              <Button
                 type="button"
-                className="btn btn-outline-danger btn-sm"
+                variant="outline-danger"
+                size="sm"
                 onClick={() => setConfirmDeleteAll(true)}
               >
                 <i className="bi bi-trash me-1"></i>
                 Delete all
-              </button>
+              </Button>
             </div>
           )}
         </Card.Header>
         <Card.Body className="p-0">
           {loading ? (
             <div className="text-center text-muted py-4">
-              <div
-                className="spinner-border spinner-border-sm me-2"
-                role="status"
-                aria-hidden="true"
-              />
+              <Spinner animation="border" size="sm" className="me-2" />
               Loading files…
             </div>
           ) : files.length === 0 ? (
@@ -253,9 +253,9 @@ export const FileList = () => {
                 >
                   <div className="flex-grow-1">
                     <div className="d-flex align-items-center gap-2">
-                      <input
+                      <Form.Check.Input
                         type="checkbox"
-                        className="form-check-input mt-0 flex-shrink-0"
+                        className="mt-0 flex-shrink-0"
                         checked={selectedForCompare.has(file.fileId)}
                         disabled={file.status.toLowerCase() !== 'completed'}
                         title={
@@ -276,12 +276,13 @@ export const FileList = () => {
                           {formatFileSize(file.fileSize)} •{' '}
                           {formatDate(parseDateTime(file.uploadedAt))}
                           {file.status.toLowerCase() !== 'completed' && (
-                            <span
-                              className="ms-2 badge bg-secondary"
+                            <Badge
+                              bg="secondary"
+                              className="ms-2"
                               style={{ fontSize: '0.7rem' }}
                             >
                               {file.status.toLowerCase()}
-                            </span>
+                            </Badge>
                           )}
                         </small>
                       </div>
@@ -291,29 +292,32 @@ export const FileList = () => {
                     className="d-flex gap-2 align-items-center"
                     onClick={e => e.stopPropagation()}
                   >
-                    <button
-                      className="btn btn-outline-primary btn-sm"
+                    <Button
+                      variant="outline-primary"
+                      size="sm"
                       onClick={() => navigate(`/analysis/${file.fileId}`)}
                     >
                       <i className="bi bi-graph-up me-1"></i>
                       Analyze
-                    </button>
-                    <button
-                      className="btn btn-link btn-sm p-0 text-danger"
+                    </Button>
+                    <Button
+                      variant="link"
+                      size="sm"
+                      className="p-0 text-danger"
                       onClick={() => setPendingDeleteFile(file)}
                       title="Delete this file"
                     >
                       <i className="bi bi-trash"></i>
-                    </button>
+                    </Button>
                   </div>
                 </div>
               ))}
             </div>
           )}
-          <div className="card-footer text-muted small">
+          <Card.Footer className="text-muted small">
             <AlertCircle size={14} className="me-1" />
             Files are automatically deleted after 12 hours
-          </div>
+          </Card.Footer>
         </Card.Body>
       </Card>
 
@@ -328,23 +332,23 @@ export const FileList = () => {
           </p>
         </Modal.Body>
         <Modal.Footer>
-          <button
+          <Button
             type="button"
-            className="btn btn-outline-secondary"
+            variant="outline-secondary"
             onClick={() => setPendingDeleteFile(null)}
           >
             Cancel
-          </button>
-          <button type="button" className="btn btn-outline-danger" onClick={handleConfirmDelete}>
+          </Button>
+          <Button type="button" variant="outline-danger" onClick={handleConfirmDelete}>
             Delete
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
 
       {/* Merge in-progress overlay */}
       <Modal show={merging} onHide={() => {}} centered backdrop="static" keyboard={false}>
         <Modal.Body className="text-center py-4">
-          <div className="spinner-border text-primary mb-3" role="status" aria-hidden="true" />
+          <Spinner animation="border" className="text-primary mb-3" />
           <p className="mb-0 fw-semibold">Merging files…</p>
           <small className="text-muted">This may take a moment.</small>
         </Modal.Body>
@@ -364,16 +368,17 @@ export const FileList = () => {
         </Modal.Header>
         <Modal.Body>
           {mergeError && (
-            <div className="alert alert-danger py-2 mb-3" role="alert">
+            <Alert variant="danger" className="py-2 mb-3">
               <i className="bi bi-exclamation-triangle me-2"></i>
               {mergeError}
-            </div>
+            </Alert>
           )}
           <p className="mb-3">How would you like to process the selected files?</p>
           <div className="d-flex flex-column gap-3">
-            <button
+            <Button
               type="button"
-              className="btn btn-outline-primary text-start p-3 multiselect-action-btn"
+              variant="outline-primary"
+              className="text-start p-3 multiselect-action-btn"
               onClick={() => handleMultiSelectAction('analyze')}
             >
               <div className="fw-semibold mb-1">
@@ -384,7 +389,7 @@ export const FileList = () => {
                 View a joint topology diagram overlaying all selected files. The original files
                 remain separate.
               </small>
-            </button>
+            </Button>
             <div className="border rounded p-3" style={{ borderColor: '#6c757d' }}>
               <div className="fw-semibold mb-1">
                 <i className="bi bi-layers me-2"></i>
@@ -394,9 +399,8 @@ export const FileList = () => {
                 Combine all selected files into a single new PCAP file for unified analysis.
               </small>
               <div className="input-group input-group-sm mb-2" onClick={e => e.stopPropagation()}>
-                <input
+                <Form.Control
                   type="text"
-                  className="form-control"
                   value={mergedFileName}
                   onChange={e => setMergedFileName(e.target.value)}
                   placeholder="merged file name"
@@ -404,28 +408,30 @@ export const FileList = () => {
                 />
                 <span className="input-group-text">.pcap</span>
               </div>
-              <button
+              <Button
                 type="button"
-                className="btn btn-secondary btn-sm w-100"
+                variant="secondary"
+                size="sm"
+                className="w-100"
                 onClick={() => handleMultiSelectAction('merge')}
                 disabled={!mergedFileName.trim()}
               >
                 Merge &amp; Analyze
-              </button>
+              </Button>
             </div>
           </div>
         </Modal.Body>
         <Modal.Footer>
-          <button
+          <Button
             type="button"
-            className="btn btn-outline-secondary"
+            variant="outline-secondary"
             onClick={() => {
               setShowMultiSelectModal(false);
               setMergeError(null);
             }}
           >
             Cancel
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
 
@@ -440,16 +446,16 @@ export const FileList = () => {
           </p>
         </Modal.Body>
         <Modal.Footer>
-          <button
+          <Button
             type="button"
-            className="btn btn-outline-secondary"
+            variant="outline-secondary"
             onClick={() => setConfirmDeleteAll(false)}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
-            className="btn btn-danger"
+            variant="danger"
             onClick={async () => {
               const results = await Promise.allSettled(
                 files.map(f => apiClient.delete(API_ENDPOINTS.FILE_DELETE(f.fileId)))
@@ -464,7 +470,7 @@ export const FileList = () => {
             }}
           >
             Delete all
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
     </>

--- a/frontend/src/components/upload/FileUploadZone/FileUploadZone.tsx
+++ b/frontend/src/components/upload/FileUploadZone/FileUploadZone.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { Card } from '@govtechsg/sgds-react';
+import { Alert, Card } from '@govtechsg/sgds-react';
 import { CloudUpload } from 'lucide-react';
 import { formatBytes } from '@/utils/formatters';
 import './FileUploadZone.css';
@@ -73,7 +73,7 @@ export const FileUploadZone = ({
         {fileRejections.length > 0 && (
           <div className="mt-3">
             {fileRejections.map(({ file, errors }) => (
-              <div key={file.name} className="alert alert-danger text-start">
+              <Alert key={file.name} variant="danger" className="text-start">
                 <strong>{file.name}</strong>
                 <ul className="mb-0 mt-2">
                   {errors.map(e => (
@@ -86,7 +86,7 @@ export const FileUploadZone = ({
                     </li>
                   ))}
                 </ul>
-              </div>
+              </Alert>
             ))}
           </div>
         )}

--- a/frontend/src/components/upload/UploadProgress/UploadProgress.tsx
+++ b/frontend/src/components/upload/UploadProgress/UploadProgress.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@govtechsg/sgds-react';
 import './UploadProgress.css';
 
 interface UploadProgressProps {
@@ -76,16 +77,16 @@ export const UploadProgress = ({
       {/* Action */}
       <div className="usc-action">
         {isDone && isDuplicate && onOpenExisting && (
-          <button className="btn btn-sm btn-outline-warning me-1" onClick={onOpenExisting}>
+          <Button size="sm" variant="outline-warning" className="me-1" onClick={onOpenExisting}>
             <i className="bi bi-folder2-open me-1"></i>
             Open existing
-          </button>
+          </Button>
         )}
         {isDone && onAnalyze && (
-          <button className="btn btn-sm btn-primary" onClick={onAnalyze}>
+          <Button size="sm" variant="primary" onClick={onAnalyze}>
             <i className="bi bi-graph-up me-1"></i>
             Analyze
-          </button>
+          </Button>
         )}
         {isDone && !onAnalyze && (
           <i className="bi bi-check-circle-fill text-success usc-icon-lg"></i>

--- a/frontend/src/pages/Analysis/AnalysisOverview.tsx
+++ b/frontend/src/pages/Analysis/AnalysisOverview.tsx
@@ -11,7 +11,7 @@ import {
   getSeverityColor,
   RISK_BADGE,
 } from '@/utils/appColors';
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Button, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import { conversationService } from '@/features/conversation/services/conversationService';
 import { getExtractedFiles } from '@features/extractedFiles/services/extractedFilesService';
 
@@ -151,14 +151,15 @@ export const AnalysisOverview = () => {
               </span>
             )}
             <OverlayTrigger trigger="click" placement="right" overlay={ndpiPopover} rootClose>
-              <button
+              <Button
                 type="button"
-                className="btn btn-link p-0 text-muted"
+                variant="link"
+                className="p-0 text-muted"
                 style={{ lineHeight: 1 }}
                 aria-label="About application detection accuracy"
               >
                 <i className="bi bi-info-circle fs-6"></i>
-              </button>
+              </Button>
             </OverlayTrigger>
           </h5>
           <div className="d-flex flex-wrap gap-2">
@@ -194,14 +195,15 @@ export const AnalysisOverview = () => {
             <i className="bi bi-layers me-2"></i>
             Dissected Protocols
             <OverlayTrigger trigger="click" placement="right" overlay={l7Popover} rootClose>
-              <button
+              <Button
                 type="button"
-                className="btn btn-link p-0 text-muted"
+                variant="link"
+                className="p-0 text-muted"
                 style={{ lineHeight: 1 }}
                 aria-label="About L7 protocol detection"
               >
                 <i className="bi bi-info-circle fs-6"></i>
-              </button>
+              </Button>
             </OverlayTrigger>
           </h5>
           <div className="d-flex flex-wrap gap-2">
@@ -233,14 +235,15 @@ export const AnalysisOverview = () => {
             <i className="bi bi-shield-exclamation me-2 text-warning"></i>
             Risk Alerts
             <OverlayTrigger trigger="click" placement="right" overlay={riskPopover} rootClose>
-              <button
+              <Button
                 type="button"
-                className="btn btn-link p-0 text-muted"
+                variant="link"
+                className="p-0 text-muted"
                 style={{ lineHeight: 1 }}
                 aria-label="About nDPI risk flags"
               >
                 <i className="bi bi-info-circle fs-6"></i>
-              </button>
+              </Button>
             </OverlayTrigger>
           </h5>
           <div className="d-flex flex-wrap gap-2">
@@ -278,14 +281,15 @@ export const AnalysisOverview = () => {
               overlay={customRulesPopover}
               rootClose
             >
-              <button
+              <Button
                 type="button"
-                className="btn btn-link p-0 text-muted"
+                variant="link"
+                className="p-0 text-muted"
                 style={{ lineHeight: 1 }}
                 aria-label="About custom security alerts"
               >
                 <i className="bi bi-info-circle fs-6"></i>
-              </button>
+              </Button>
             </OverlayTrigger>
           </h5>
           <div className="d-flex flex-wrap gap-2">

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -405,7 +405,7 @@ export const AnalysisPage = () => {
       {/* Navigation Tabs */}
       <ul
         className="nav nav-tabs"
-        style={{ display: 'flex', flexWrap: 'nowrap', overflowX: 'auto', borderBottom: 'none', paddingTop: '1px' }}
+        style={{ borderBottom: 'none', paddingTop: '1px' }}
       >
         <li className="nav-item">
           <button

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, useRef, useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
+import { Button, Card } from '@govtechsg/sgds-react';
 import { useParams, Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { useAnalysisData } from '@features/analysis/hooks/useAnalysisData';
 import { ErrorMessage } from '@components/common/ErrorMessage';
@@ -367,12 +369,12 @@ export const AnalysisPage = () => {
             justifyContent: 'center',
           }}
         >
-          <div className="card shadow-lg p-4 text-center" style={{ minWidth: 320 }}>
-            <div className="spinner-border text-primary mb-3" role="status" />
+          <Card className="shadow-lg p-4 text-center" style={{ minWidth: 320 }}>
+            <Spinner animation="border" className="text-primary mb-3" />
             <h6 className="mb-1">Generating Report</h6>
             <p className="text-muted small mb-0">{reportStep}</p>
             <p className="text-muted small mt-1">This may take up to 60 seconds.</p>
-          </div>
+          </Card>
         </div>
       )}
       <div className="analysis-header mb-4 d-flex justify-content-between align-items-start">
@@ -381,14 +383,15 @@ export const AnalysisPage = () => {
           <p className="text-muted">File ID: {fileId}</p>
         </div>
         <div className="d-flex flex-column align-items-end gap-1">
-          <button
-            className="btn btn-outline-primary btn-sm"
+          <Button
+            variant="outline-primary"
+            size="sm"
             onClick={handleDownloadReport}
             disabled={reportLoading}
           >
             {reportLoading ? (
               <>
-                <span className="spinner-border spinner-border-sm me-2" role="status" />
+                <Spinner animation="border" size="sm" className="me-2" />
                 Generating report…
               </>
             ) : (
@@ -397,7 +400,7 @@ export const AnalysisPage = () => {
                 Download Report
               </>
             )}
-          </button>
+          </Button>
           {reportError && <small className="text-danger">{reportError}</small>}
         </div>
       </div>
@@ -432,7 +435,7 @@ export const AnalysisPage = () => {
             onClick={() => handleTabChange('story')}
           >
             <i className="bi bi-journal-text me-2"></i>Story
-            {storyGenerating && <span className="spinner-border spinner-border-sm ms-2" style={{ width: 10, height: 10, borderWidth: 2 }} role="status" />}
+            {storyGenerating && <Spinner animation="border" size="sm" className="ms-2" style={{ width: 10, height: 10, borderWidth: 2 }} />}
           </button>
         </li>
         <li className="nav-item">
@@ -474,11 +477,11 @@ export const AnalysisPage = () => {
       </ul>
 
       {/* Tab Content */}
-      <div className="card">
-        <div className="card-body">
+      <Card>
+        <Card.Body>
           <Outlet context={{ data, fileId: fileId!, networkGraphStateRef, networkDiagramFilters, storyState } satisfies AnalysisOutletContext} />
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
     </div>
   );
 };

--- a/frontend/src/pages/Compare/ComparePage.tsx
+++ b/frontend/src/pages/Compare/ComparePage.tsx
@@ -1,4 +1,6 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useMemo, useRef, useEffect } from 'react';
+import { Alert, Badge, Button, Card, Form } from '@govtechsg/sgds-react';
 import { MAX_DIAGRAM_NODES } from '@/features/network/hooks/useNetworkData';
 import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import type { GraphNode } from '@/features/network/types';
@@ -362,18 +364,18 @@ export const ComparePage = () => {
             justifyContent: 'center',
           }}
         >
-          <div className="card shadow-lg p-4 text-center" style={{ minWidth: 320 }}>
-            <div className="spinner-border text-primary mb-3" role="status" />
+          <Card className="shadow-lg p-4 text-center" style={{ minWidth: 320 }}>
+            <Spinner animation="border" className="text-primary mb-3" />
             <h6 className="mb-1">Generating Report</h6>
             <p className="text-muted small mb-0">{reportStep}</p>
             <p className="text-muted small mt-1">This may take up to 60 seconds.</p>
-          </div>
+          </Card>
         </div>
       )}
 
       {/* Back link + header */}
       <div className="d-flex align-items-center gap-3 mb-3">
-        <Link to="/" className="btn btn-link btn-sm p-0 text-muted text-decoration-none">
+        <Link to="/" className="text-muted text-decoration-none small">
           <i className="bi bi-arrow-left me-1" />
           Back
         </Link>
@@ -382,14 +384,15 @@ export const ComparePage = () => {
           Compare Topology
         </h4>
         <div className="d-flex flex-column align-items-end gap-1">
-          <button
-            className="btn btn-outline-primary btn-sm"
+          <Button
+            variant="outline-primary"
+            size="sm"
             onClick={handleDownloadReport}
             disabled={reportLoading}
           >
             {reportLoading ? (
               <>
-                <span className="spinner-border spinner-border-sm me-2" role="status" />
+                <Spinner animation="border" size="sm" className="me-2" />
                 Generating report…
               </>
             ) : (
@@ -398,7 +401,7 @@ export const ComparePage = () => {
                 Download Report
               </>
             )}
-          </button>
+          </Button>
           {reportError && <small className="text-danger">{reportError}</small>}
         </div>
       </div>
@@ -407,8 +410,7 @@ export const ComparePage = () => {
       <div className="d-flex align-items-center gap-2 mb-3 flex-wrap">
         {labels.map((label, i) => (
           <span key={label}>
-            <span
-              className="badge"
+            <Badge
               style={{
                 fontSize: '0.8rem',
                 backgroundColor: SOURCE_COLORS[i % SOURCE_COLORS.length],
@@ -416,31 +418,30 @@ export const ComparePage = () => {
             >
               <i className="bi bi-file-earmark-binary me-1" />
               {label}
-            </span>
+            </Badge>
             {i < labels.length - 1 && <span className="text-muted small ms-2">vs</span>}
           </span>
         ))}
       </div>
 
       {/* Per-file stats — one column per file, wraps naturally */}
-      <div className="card mb-3">
-        <div className="card-header">
+      <Card className="mb-3">
+        <Card.Header>
           <strong>Comparison Overview</strong>
-        </div>
-        <div className="card-body py-2 px-3">
+        </Card.Header>
+        <Card.Body className="py-2 px-3">
           <div className="d-flex flex-wrap gap-3">
             {perFileStats.map(({ label, stats }, i) => (
               <div key={label} style={{ minWidth: 200 }}>
                 <div className="mb-2">
-                  <span
-                    className="badge"
+                  <Badge
                     style={{
                       fontSize: '0.7rem',
                       backgroundColor: SOURCE_COLORS[i % SOURCE_COLORS.length],
                     }}
                   >
                     {label}
-                  </span>
+                  </Badge>
                 </div>
                 <div className="d-flex gap-2 flex-wrap">
                   {[
@@ -469,8 +470,8 @@ export const ComparePage = () => {
           <div className="mt-2 text-muted small">
             {filteredNodes.length} nodes · {filteredEdges.length} connections shown
           </div>
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
 
       {totalNodes > MAX_DIAGRAM_NODES &&
         (() => {
@@ -481,7 +482,7 @@ export const ComparePage = () => {
             setCustomInput('');
           };
           return (
-            <div className="alert alert-info mb-3">
+            <Alert variant="info" className="mb-3">
               <div className="d-flex align-items-start gap-2 flex-wrap">
                 <div className="flex-grow-1">
                   <div>
@@ -501,27 +502,29 @@ export const ComparePage = () => {
                   <div className="d-flex align-items-center gap-2 mt-2 flex-wrap">
                     <span className="text-muted small fw-semibold me-1">Show:</span>
                     {presets.map(p => (
-                      <button
+                      <Button
                         key={p}
-                        className={`btn btn-sm ${nodeLimit === p ? 'btn-info' : 'btn-outline-secondary'}`}
+                        size="sm"
+                        variant={nodeLimit === p ? 'info' : 'outline-secondary'}
                         style={{ minWidth: 52 }}
                         onClick={() => setNodeLimit(p)}
                       >
                         Top {p}
-                      </button>
+                      </Button>
                     ))}
-                    <button
-                      className={`btn btn-sm ${nodeLimit >= totalNodes ? 'btn-info' : 'btn-outline-secondary'}`}
+                    <Button
+                      size="sm"
+                      variant={nodeLimit >= totalNodes ? 'info' : 'outline-secondary'}
                       style={{ minWidth: 52 }}
                       onClick={() => setNodeLimit(totalNodes)}
                     >
                       All {totalNodes}
-                    </button>
+                    </Button>
                     <span className="text-muted small ms-2 me-1">or</span>
                     <div className="input-group input-group-sm" style={{ width: 120 }}>
-                      <input
+                      <Form.Control
                         type="number"
-                        className="form-control form-control-sm"
+                        size="sm"
                         placeholder="Custom…"
                         min={1}
                         max={totalNodes}
@@ -534,7 +537,7 @@ export const ComparePage = () => {
                   </div>
                 </div>
               </div>
-            </div>
+            </Alert>
           );
         })()}
 
@@ -597,9 +600,9 @@ export const ComparePage = () => {
           const color = SOURCE_COLORS[i % SOURCE_COLORS.length];
           const hidden = hiddenSources.has(label);
           return (
-            <button
+            <Button
               key={label}
-              className="btn btn-sm"
+              size="sm"
               style={{
                 backgroundColor: hidden ? 'transparent' : color,
                 borderColor: color,
@@ -610,7 +613,7 @@ export const ComparePage = () => {
             >
               <i className={`bi ${hidden ? 'bi-eye-slash' : 'bi-eye'} me-1`} />
               {label}
-            </button>
+            </Button>
           );
         })}
         <span className="small text-muted ms-3">
@@ -622,18 +625,20 @@ export const ComparePage = () => {
       {/* Graph */}
       <div className="row">
         <div className="col-12">
-          <div className="card" ref={graphCardRef}>
-            <div className="card-header d-flex justify-content-between align-items-center">
+          <Card ref={graphCardRef}>
+            <Card.Header className="d-flex justify-content-between align-items-center">
               <strong>Topology Diagram</strong>
-              <button
-                className="btn btn-link btn-sm p-0 text-muted"
+              <Button
+                variant="link"
+                size="sm"
+                className="p-0 text-muted"
                 onClick={toggleFullscreen}
                 title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
               >
                 <i className={`bi ${isFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'}`} />
-              </button>
-            </div>
-            <div className="card-body p-0 network-diagram-graph-body">
+              </Button>
+            </Card.Header>
+            <Card.Body className="p-0 network-diagram-graph-body">
               <NetworkGraph
                 key={layoutType}
                 nodes={filteredNodes}
@@ -643,8 +648,8 @@ export const ComparePage = () => {
                 onLayoutChange={setLayoutType}
                 primarySource={primaryLabel}
               />
-            </div>
-          </div>
+            </Card.Body>
+          </Card>
         </div>
       </div>
 

--- a/frontend/src/pages/Conversation/ConversationPage.tsx
+++ b/frontend/src/pages/Conversation/ConversationPage.tsx
@@ -420,7 +420,7 @@ export const ConversationPage = () => {
             if (e.target === e.currentTarget) closeModal();
           }}
         >
-          <div className="modal-dialog modal-xl modal-dialog-scrollable">
+          <div className="modal-dialog modal-xl modal-dialog-centered">
             <div className="modal-content">
               <div className="modal-header">
                 <div className="d-flex align-items-center gap-3 flex-grow-1 min-w-0">

--- a/frontend/src/pages/Conversation/ConversationPage.tsx
+++ b/frontend/src/pages/Conversation/ConversationPage.tsx
@@ -420,7 +420,7 @@ export const ConversationPage = () => {
             if (e.target === e.currentTarget) closeModal();
           }}
         >
-          <div className="modal-dialog modal-xl modal-dialog-centered">
+          <div className="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
             <div className="modal-content">
               <div className="modal-header">
                 <div className="d-flex align-items-center gap-3 flex-grow-1 min-w-0">

--- a/frontend/src/pages/Conversation/ConversationPage.tsx
+++ b/frontend/src/pages/Conversation/ConversationPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { Button, Card, Modal } from '@govtechsg/sgds-react';
 import { useOutletContext, useSearchParams } from 'react-router-dom';
 import type { AnalysisData, Conversation, HostClassification } from '@/types';
 import type { SortField } from '@/features/conversation/types';
@@ -320,6 +321,7 @@ export const ConversationPage = () => {
                 href={exportUrl}
                 download={exportFilename}
                 className="btn btn-sm btn-outline-secondary"
+                role="button"
                 title="Export current filtered results as CSV"
               >
                 <i className="bi bi-download me-1"></i>
@@ -329,6 +331,7 @@ export const ConversationPage = () => {
                 href={pcapExportUrl}
                 download={pcapExportFilename}
                 className="btn btn-sm btn-outline-secondary"
+                role="button"
                 title="Export current filtered results as PCAP"
               >
                 <i className="bi bi-download me-1"></i>
@@ -360,12 +363,12 @@ export const ConversationPage = () => {
 
       <div className="row">
         <div className="col-12">
-          <div className="card">
-            <div className="card-header d-flex justify-content-between align-items-center">
+          <Card>
+            <Card.Header className="d-flex justify-content-between align-items-center">
               <h6 className="mb-0">Conversations</h6>
               <small className="text-muted">Click a row to view details</small>
-            </div>
-            <div className="card-body p-0" style={{ position: 'relative' }}>
+            </Card.Header>
+            <Card.Body className="p-0" style={{ position: 'relative' }}>
               {loading && conversations.length === 0 && (
                 <LoadingSpinner size="medium" message="Loading conversations..." />
               )}
@@ -393,9 +396,9 @@ export const ConversationPage = () => {
                   />
                 </div>
               )}
-            </div>
+            </Card.Body>
             {totalPages > 1 && (
-              <div className="card-footer">
+              <Card.Footer>
                 <Pagination
                   currentPage={filters.page}
                   totalPages={totalPages}
@@ -405,99 +408,91 @@ export const ConversationPage = () => {
                   showPageSizeSelector
                   onPageSizeChange={pageSize => setFilters({ pageSize, page: 1 })}
                 />
-              </div>
+              </Card.Footer>
             )}
-          </div>
+          </Card>
         </div>
       </div>
 
       {/* Conversation detail modal */}
-      {selectedConversation && (
-        <div
-          className="modal fade show d-block"
-          style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
-          onClick={e => {
-            if (e.target === e.currentTarget) closeModal();
-          }}
-        >
-          <div className="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
-            <div className="modal-content">
-              <div className="modal-header">
-                <div className="d-flex align-items-center gap-3 flex-grow-1 min-w-0">
-                  <button
-                    className="btn btn-sm btn-outline-secondary"
-                    onClick={handlePrev}
-                    disabled={selectedIndex <= 0}
-                    title="Previous conversation"
-                  >
-                    ‹ Prev
-                  </button>
-                  <h5 className="modal-title text-truncate mb-0 font-monospace small">
-                    {modalTitle}
-                  </h5>
-                  <button
-                    className="btn btn-sm btn-outline-secondary"
-                    onClick={handleNext}
-                    disabled={selectedIndex >= conversations.length - 1}
-                    title="Next conversation"
-                  >
-                    Next ›
-                  </button>
-                  <span className="text-muted small text-nowrap">
-                    {selectedIndex + 1} / {conversations.length}
-                  </span>
-                </div>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-outline-info ms-2"
-                  onClick={() => setTracerConversationId(selectedConversation.id)}
-                  title="Step through packets with AI explanations"
-                >
-                  <i className="bi bi-play-circle me-1"></i>Trace
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-outline-secondary ms-2"
-                  onClick={() => exportConversationCsv(selectedConversation)}
-                  title="Export this conversation as CSV"
-                >
-                  <i className="bi bi-download me-1"></i>CSV
-                </button>
-                <a
-                  href={conversationService.getConversationPcapExportUrl(selectedConversation.id)}
-                  download={makeExportFilename(
-                    exportBase,
-                    'pcap',
-                    `${selectedConversation.endpoints[0].ip.replace(/[^a-zA-Z0-9.]/g, '_')}-${selectedConversation.endpoints[1].ip.replace(/[^a-zA-Z0-9.]/g, '_')}`
-                  )}
-                  className="btn btn-sm btn-outline-secondary ms-2"
-                  title="Export this conversation as PCAP"
-                >
-                  <i className="bi bi-download me-1"></i>PCAP
-                </a>
-                <button
-                  type="button"
-                  className="btn-close ms-2"
-                  onClick={closeModal}
-                  title="Close (Esc)"
-                />
-              </div>
-              <div className="modal-body">
-                {detailLoading ? (
-                  <LoadingSpinner size="medium" message="Loading conversation..." />
-                ) : (
-                  <ConversationDetail
-                    conversation={selectedConversation}
-                    signatureSeverities={signatureSeverities}
-                    hostClassMap={hostClassMap}
-                    fileId={fileId}
-                  />
-                )}
-              </div>
-            </div>
+      <Modal show={!!selectedConversation} onHide={closeModal} size="xl" centered scrollable>
+        <Modal.Header closeButton>
+          <div className="d-flex align-items-center gap-3 flex-grow-1 min-w-0">
+            <Button
+              size="sm"
+              variant="outline-secondary"
+              onClick={handlePrev}
+              disabled={selectedIndex <= 0}
+              title="Previous conversation"
+            >
+              ‹ Prev
+            </Button>
+            <Modal.Title className="text-truncate mb-0 font-monospace small" as="h5">
+              {modalTitle}
+            </Modal.Title>
+            <Button
+              size="sm"
+              variant="outline-secondary"
+              onClick={handleNext}
+              disabled={selectedIndex >= conversations.length - 1}
+              title="Next conversation"
+            >
+              Next ›
+            </Button>
+            <span className="text-muted small text-nowrap">
+              {selectedIndex + 1} / {conversations.length}
+            </span>
           </div>
-        </div>
-      )}
+          <Button
+            type="button"
+            size="sm"
+            variant="outline-info"
+            className="ms-2"
+            onClick={() => selectedConversation && setTracerConversationId(selectedConversation.id)}
+            title="Step through packets with AI explanations"
+          >
+            <i className="bi bi-play-circle me-1"></i>Trace
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline-secondary"
+            className="ms-2"
+            onClick={() => selectedConversation && exportConversationCsv(selectedConversation)}
+            title="Export this conversation as CSV"
+          >
+            <i className="bi bi-download me-1"></i>CSV
+          </Button>
+          {selectedConversation && (
+            <a
+              href={conversationService.getConversationPcapExportUrl(selectedConversation.id)}
+              download={makeExportFilename(
+                exportBase,
+                'pcap',
+                `${selectedConversation.endpoints[0].ip.replace(/[^a-zA-Z0-9.]/g, '_')}-${selectedConversation.endpoints[1].ip.replace(/[^a-zA-Z0-9.]/g, '_')}`
+              )}
+              className="btn btn-sm btn-outline-secondary ms-2"
+              title="Export this conversation as PCAP"
+            >
+              <i className="bi bi-download me-1"></i>PCAP
+            </a>
+          )}
+        </Modal.Header>
+        <Modal.Body>
+          {detailLoading ? (
+            <LoadingSpinner size="medium" message="Loading conversation..." />
+          ) : (
+            selectedConversation && (
+              <ConversationDetail
+                conversation={selectedConversation}
+                signatureSeverities={signatureSeverities}
+                hostClassMap={hostClassMap}
+                fileId={fileId}
+              />
+            )
+          )}
+        </Modal.Body>
+      </Modal>
 
       {/* Conversation Tracer modal */}
       {tracerConversationId && (

--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -11,7 +11,7 @@ import { LoadingSpinner } from '@components/common/LoadingSpinner';
 import { ErrorMessage } from '@components/common/ErrorMessage';
 import { ScrollableTable } from '@components/common/ScrollableTable';
 import { PillSectionHeader } from '@components/common/PillSectionHeader/PillSectionHeader';
-import { Modal } from '@govtechsg/sgds-react';
+import { Alert, Badge, Button, Card, Modal } from '@govtechsg/sgds-react';
 import { formatBytes } from '@/utils/formatters';
 import '@components/conversation/ConversationFilterPanel/ConversationFilterPanel.css';
 
@@ -26,9 +26,9 @@ type SortDir = 'asc' | 'desc';
 const ExtractionInfoCard = () => {
   const [collapsed, setCollapsed] = useState(true);
   return (
-    <div className="card mb-3" style={{ overflow: 'hidden' }}>
-      <div
-        className="card-header d-flex align-items-center justify-content-between"
+    <Card className="mb-3" style={{ overflow: 'hidden' }}>
+      <Card.Header
+        className="d-flex align-items-center justify-content-between"
         style={{
           cursor: 'pointer',
           userSelect: 'none',
@@ -41,9 +41,9 @@ const ExtractionInfoCard = () => {
           What's listed here &amp; how files are extracted
         </h6>
         <i className={`bi bi-chevron-${collapsed ? 'down' : 'up'} text-muted`}></i>
-      </div>
+      </Card.Header>
       {!collapsed && (
-        <div className="card-body small text-muted">
+        <Card.Body className="small text-muted">
           <p className="mb-2">Files are extracted using two methods:</p>
           <ul className="mb-3">
             <li>
@@ -66,12 +66,12 @@ const ExtractionInfoCard = () => {
             All extracted files are stored as raw bytes only — no execution or active-content
             rendering occurs. A safety disclaimer is shown before each download. Individual files
             larger than 50 MB are not stored; they appear in this list with a{' '}
-            <span className="badge bg-warning text-dark" style={{ fontSize: '0.85em' }}>Too large</span>{' '}
+            <Badge bg="warning" text="dark" style={{ fontSize: '0.85em' }}>Too large</Badge>{' '}
             badge so you can see they were detected but skipped.
           </p>
-        </div>
+        </Card.Body>
       )}
-    </div>
+    </Card>
   );
 };
 
@@ -105,9 +105,9 @@ function nativePreviewMode(mimeType: string | null): 'audio' | 'video' | 'image'
 }
 
 function methodBadge(method: string | null) {
-  if (method === 'tshark_http') return <span className="badge bg-primary">HTTP</span>;
-  if (method === 'magic_bytes') return <span className="badge bg-secondary">Raw stream</span>;
-  return <span className="badge bg-light text-dark">{method ?? '—'}</span>;
+  if (method === 'tshark_http') return <Badge bg="primary">HTTP</Badge>;
+  if (method === 'magic_bytes') return <Badge bg="secondary">Raw stream</Badge>;
+  return <Badge bg="light" text="dark">{method ?? '—'}</Badge>;
 }
 
 function sortFiles(files: ExtractedFile[], by: SortField | '', dir: SortDir): ExtractedFile[] {
@@ -136,14 +136,16 @@ const CopyHash = ({ hash }: { hash: string }) => {
       <span className="font-monospace text-muted" style={{ fontSize: '0.75em' }} title={hash}>
         {hash.substring(0, 8)}…{hash.substring(hash.length - 8)}
       </span>
-      <button
-        className="btn btn-link btn-sm p-0 text-muted"
+      <Button
+        variant="link"
+        size="sm"
+        className="p-0 text-muted"
         style={{ fontSize: '0.75em', lineHeight: 1 }}
         onClick={copy}
         title={copied ? 'Copied!' : 'Copy full hash'}
       >
         <i className={`bi ${copied ? 'bi-check text-success' : 'bi-clipboard'}`}></i>
-      </button>
+      </Button>
     </span>
   );
 };
@@ -236,12 +238,12 @@ export const ExtractedFilesPage = () => {
             Files detected and extracted from HTTP transfers and raw packet streams.
           </small>
         </div>
-        <span className="badge bg-secondary fs-6">
+        <Badge bg="secondary" className="fs-6">
           {mimeTypeFilter.length > 0
             ? `${sorted.length} / ${files.length}`
             : files.length}{' '}
           file{files.length !== 1 ? 's' : ''}
-        </span>
+        </Badge>
       </div>
 
       <ExtractionInfoCard />
@@ -250,22 +252,23 @@ export const ExtractedFilesPage = () => {
       {allMimeTypes.length > 0 && (
         <div className="conversation-filter-panel mb-3">
           <div className="d-flex align-items-center gap-2">
-            <button
+            <Button
               type="button"
-              className="btn btn-outline-secondary btn-sm"
+              variant="outline-secondary"
+              size="sm"
               onClick={() => setFilterOpen(o => !o)}
             >
               <i className="bi bi-funnel me-1"></i>
               Filters
               {mimeTypeFilter.length > 0 && (
-                <span className="badge bg-primary ms-2">{mimeTypeFilter.length}</span>
+                <Badge bg="primary" className="ms-2">{mimeTypeFilter.length}</Badge>
               )}
               <i className={`bi ms-2 ${filterOpen ? 'bi-chevron-up' : 'bi-chevron-down'}`}></i>
-            </button>
+            </Button>
           </div>
           {filterOpen && (
-            <div className="card mt-2 filter-panel-body">
-              <div className="card-body p-3">
+            <Card className="mt-2 filter-panel-body">
+              <Card.Body className="p-3">
                 <PillSectionHeader
                   label="MIME Type"
                   onSelectAll={() => setMimeTypeFilter(allMimeTypes)}
@@ -293,27 +296,28 @@ export const ExtractedFilesPage = () => {
                 </div>
                 {mimeTypeFilter.length > 0 && (
                   <div className="mt-3 pt-2 border-top">
-                    <button
+                    <Button
                       type="button"
-                      className="btn btn-sm btn-outline-secondary"
+                      size="sm"
+                      variant="outline-secondary"
                       onClick={() => setMimeTypeFilter([])}
                     >
                       <i className="bi bi-x-circle me-1"></i>Clear filters
-                    </button>
+                    </Button>
                   </div>
                 )}
-              </div>
-            </div>
+              </Card.Body>
+            </Card>
           )}
         </div>
       )}
 
-      <div className="card">
-        <div className="card-header d-flex justify-content-between align-items-center">
+      <Card>
+        <Card.Header className="d-flex justify-content-between align-items-center">
           <h6 className="mb-0">Files</h6>
           <small className="text-muted">Click a column header to sort</small>
-        </div>
-        <div className="card-body p-0" style={{ position: 'relative' }}>
+        </Card.Header>
+        <Card.Body className="p-0" style={{ position: 'relative' }}>
           {sorted.length === 0 ? (
             <div className="text-center py-5 text-muted">
               <i className="bi bi-inbox fs-1 d-block mb-2"></i>
@@ -363,8 +367,10 @@ export const ExtractedFilesPage = () => {
                       </td>
                       <td>
                         {file.conversationId ? (
-                          <button
-                            className="btn btn-link btn-sm p-0"
+                          <Button
+                            variant="link"
+                            size="sm"
+                            className="p-0"
                             style={{ fontSize: '0.8em' }}
                             onClick={() =>
                               navigate(
@@ -373,7 +379,7 @@ export const ExtractedFilesPage = () => {
                             }
                           >
                             View conversation
-                          </button>
+                          </Button>
                         ) : (
                           <span
                             className="text-muted"
@@ -387,32 +393,37 @@ export const ExtractedFilesPage = () => {
                       <td>{methodBadge(file.extractionMethod)}</td>
                       <td>
                         {isSkipped ? (
-                          <span
-                            className="badge bg-warning text-dark"
+                          <Badge
+                            bg="warning"
+                            text="dark"
                             title="File exceeds the 50 MB size limit and was not stored"
                           >
                             <i className="bi bi-slash-circle me-1"></i>
                             Too large
-                          </span>
+                          </Badge>
                         ) : (
                           <div className="d-flex gap-1">
                             {nativePreviewMode(file.mimeType) && (
-                              <button
-                                className="btn btn-outline-secondary btn-sm text-nowrap"
+                              <Button
+                                variant="outline-secondary"
+                                size="sm"
+                                className="text-nowrap"
                                 onClick={() => setPreviewFile(file)}
                                 title="Preview in browser"
                               >
                                 <i className="bi bi-play-circle me-1"></i>
                                 Preview
-                              </button>
+                              </Button>
                             )}
-                            <button
-                              className="btn btn-outline-primary btn-sm text-nowrap"
+                            <Button
+                              variant="outline-primary"
+                              size="sm"
+                              className="text-nowrap"
                               onClick={() => handleDownloadRequest(file)}
                             >
                               <i className="bi bi-download me-1"></i>
                               Download
-                            </button>
+                            </Button>
                           </div>
                         )}
                       </td>
@@ -423,8 +434,8 @@ export const ExtractedFilesPage = () => {
               </table>
             </ScrollableTable>
           )}
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
 
       {/* Inline media preview modal */}
       <Modal show={previewFile !== null} onHide={() => setPreviewFile(null)} size="lg">
@@ -463,23 +474,23 @@ export const ExtractedFilesPage = () => {
             }
             return null;
           })()}
-          <div className="alert alert-warning mt-3 mb-0 text-start" style={{ fontSize: '0.8rem' }}>
+          <Alert variant="warning" className="mt-3 mb-0 text-start" style={{ fontSize: '0.8rem' }}>
             <i className="bi bi-exclamation-triangle-fill me-1"></i>
             Content rendered from a packet capture. Do not interact with active content on a
             production system.
-          </div>
+          </Alert>
         </Modal.Body>
         <Modal.Footer>
-          <button className="btn btn-secondary" onClick={() => setPreviewFile(null)}>
+          <Button variant="secondary" onClick={() => setPreviewFile(null)}>
             Close
-          </button>
-          <button
-            className="btn btn-outline-primary"
+          </Button>
+          <Button
+            variant="outline-primary"
             onClick={() => { setPreviewFile(null); handleDownloadRequest(previewFile!); }}
           >
             <i className="bi bi-download me-1"></i>
             Download
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
 
@@ -493,26 +504,26 @@ export const ExtractedFilesPage = () => {
         </Modal.Header>
         <Modal.Body>
           <p>You are about to download a file that was extracted from a packet capture:</p>
-          <div className="alert alert-secondary font-monospace" style={{ fontSize: '0.85em' }}>
+          <Alert variant="secondary" className="font-monospace" style={{ fontSize: '0.85em' }}>
             {pendingDownload?.filename ?? '(unnamed)'}{' '}
             {pendingDownload?.fileSize != null && (
               <span className="text-muted">({formatBytes(pendingDownload.fileSize)})</span>
             )}
-          </div>
-          <div className="alert alert-warning mb-0">
+          </Alert>
+          <Alert variant="warning" className="mb-0">
             <strong>Safety disclaimer:</strong> This file was transferred over the network and may
             contain malware, scripts, or other active content. Do <strong>not</strong> open or
             execute it on a production system. Use an isolated, sandboxed environment for analysis.
-          </div>
+          </Alert>
         </Modal.Body>
         <Modal.Footer>
-          <button className="btn btn-secondary" onClick={() => setPendingDownload(null)}>
+          <Button variant="secondary" onClick={() => setPendingDownload(null)}>
             Cancel
-          </button>
-          <button className="btn btn-primary" onClick={confirmDownload}>
+          </Button>
+          <Button variant="primary" onClick={confirmDownload}>
             <i className="bi bi-download me-1"></i>
             Download anyway
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
     </div>

--- a/frontend/src/pages/FilterGenerator/FilterGeneratorPage.tsx
+++ b/frontend/src/pages/FilterGenerator/FilterGeneratorPage.tsx
@@ -1,5 +1,7 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect } from 'react';
 import { useOutletContext } from 'react-router-dom';
+import { Alert, Badge, Button, Card, Form, Modal } from '@govtechsg/sgds-react';
 import type { AnalysisData, Packet } from '@/types';
 import { apiClient } from '@/services/api/client';
 import { filterService } from '@/features/filter/services/filterService';
@@ -198,19 +200,19 @@ export const FilterGeneratorPage = () => {
       {/* Natural Language Input */}
       <div className="row mb-4">
         <div className="col-12">
-          <div className="card">
-            <div className="card-body">
+          <Card>
+            <Card.Body>
               <h5 className="card-title mb-3">
                 <i className="bi bi-chat-dots me-2"></i>
                 Ask in Natural Language
               </h5>
               <div className="mb-3">
-                <label htmlFor="query" className="form-label">
+                <Form.Label htmlFor="query">
                   Describe what you want to filter
-                </label>
-                <textarea
+                </Form.Label>
+                <Form.Control
+                  as="textarea"
                   id="query"
-                  className="form-control"
                   rows={3}
                   placeholder="Examples:&#10;- Show me all HTTP traffic&#10;- Find DNS queries&#10;- Traffic from 192.168.1.1&#10;- SSH connections"
                   value={query}
@@ -220,14 +222,14 @@ export const FilterGeneratorPage = () => {
                 />
                 <small className="text-muted">Press Ctrl+Enter to generate filter</small>
               </div>
-              <button
-                className="btn btn-primary"
+              <Button
+                variant="primary"
                 onClick={handleGenerateFilter}
                 disabled={generating || !query.trim()}
               >
                 {generating ? (
                   <>
-                    <span className="spinner-border spinner-border-sm me-2" />
+                    <Spinner animation="border" size="sm" className="me-2" />
                     Generating...
                   </>
                 ) : (
@@ -236,9 +238,9 @@ export const FilterGeneratorPage = () => {
                     Generate Filter
                   </>
                 )}
-              </button>
-            </div>
-          </div>
+              </Button>
+            </Card.Body>
+          </Card>
         </div>
       </div>
 
@@ -246,37 +248,38 @@ export const FilterGeneratorPage = () => {
       {generatedFilter && (
         <div className="row mb-4">
           <div className="col-12">
-            <div className="card">
-              <div className="card-body">
+            <Card>
+              <Card.Body>
                 <h5 className="card-title mb-3">
                   <i className="bi bi-funnel me-2"></i>
                   Generated Filter
                   {confidence !== null && (
-                    <span
-                      className={`badge ms-2 ${confidence > 0.8 ? 'bg-success' : confidence > 0.6 ? 'bg-warning' : 'bg-secondary'}`}
+                    <Badge
+                      bg={confidence > 0.8 ? 'success' : confidence > 0.6 ? 'warning' : 'secondary'}
+                      className="ms-2"
                     >
                       {(confidence * 100).toFixed(0)}% confidence
-                    </span>
+                    </Badge>
                   )}
                 </h5>
 
                 {/* Explanation */}
                 {explanation && (
-                  <div className="alert alert-info mb-3">
+                  <Alert variant="info" className="mb-3">
                     <i className="bi bi-info-circle me-2"></i>
                     {explanation}
-                  </div>
+                  </Alert>
                 )}
 
                 {/* Editable Filter */}
                 <div className="mb-3">
-                  <label htmlFor="filter" className="form-label">
+                  <Form.Label htmlFor="filter">
                     Filter Expression (editable)
-                  </label>
-                  <input
+                  </Form.Label>
+                  <Form.Control
                     type="text"
                     id="filter"
-                    className="form-control font-monospace"
+                    className="font-monospace"
                     value={editableFilter}
                     onChange={e => setEditableFilter(e.target.value)}
                     disabled={executing}
@@ -286,7 +289,7 @@ export const FilterGeneratorPage = () => {
                 {/* Suggestions */}
                 {suggestions.length > 0 && (
                   <div className="mb-3">
-                    <label className="form-label">Suggestions:</label>
+                    <Form.Label>Suggestions:</Form.Label>
                     <ul className="list-unstyled mb-0">
                       {suggestions.map((suggestion, index) => (
                         <li key={index} className="text-muted small">
@@ -300,14 +303,14 @@ export const FilterGeneratorPage = () => {
 
                 {/* Action Buttons */}
                 <div className="d-flex gap-2">
-                  <button
-                    className="btn btn-success"
+                  <Button
+                    variant="success"
                     onClick={() => handleExecuteFilter(1)}
                     disabled={executing || !editableFilter.trim()}
                   >
                     {executing ? (
                       <>
-                        <span className="spinner-border spinner-border-sm me-2" />
+                        <Spinner animation="border" size="sm" className="me-2" />
                         Executing...
                       </>
                     ) : (
@@ -316,14 +319,14 @@ export const FilterGeneratorPage = () => {
                         Execute Filter
                       </>
                     )}
-                  </button>
-                  <button className="btn btn-outline-info" onClick={() => setShowCheatSheet(true)}>
+                  </Button>
+                  <Button variant="outline-info" onClick={() => setShowCheatSheet(true)}>
                     <i className="bi bi-file-earmark-text me-2"></i>
                     BPF Cheat Sheet
-                  </button>
+                  </Button>
                 </div>
-              </div>
-            </div>
+              </Card.Body>
+            </Card>
           </div>
         </div>
       )}
@@ -332,16 +335,10 @@ export const FilterGeneratorPage = () => {
       {error && (
         <div className="row mb-4">
           <div className="col-12">
-            <div className="alert alert-danger alert-dismissible fade show" role="alert">
+            <Alert variant="danger" dismissible onClose={() => setError(null)}>
               <i className="bi bi-exclamation-triangle me-2"></i>
               {error}
-              <button
-                type="button"
-                className="btn-close"
-                onClick={() => setError(null)}
-                aria-label="Close"
-              ></button>
-            </div>
+            </Alert>
           </div>
         </div>
       )}
@@ -350,7 +347,7 @@ export const FilterGeneratorPage = () => {
       {!error && executionTime !== null && packets.length === 0 && (
         <div className="row mb-4">
           <div className="col-12">
-            <div className="alert alert-info" role="alert">
+            <Alert variant="info">
               <h5 className="alert-heading">
                 <i className="bi bi-info-circle me-2"></i>
                 No Matching Packets Found
@@ -377,7 +374,7 @@ export const FilterGeneratorPage = () => {
                   <small className="text-muted">Execution time: {executionTime}ms</small>
                 </div>
               )}
-            </div>
+            </Alert>
           </div>
         </div>
       )}
@@ -386,17 +383,17 @@ export const FilterGeneratorPage = () => {
       {packets.length > 0 && (
         <div className="row mb-4">
           <div className="col-12">
-            <div className="card">
-              <div className="card-body">
+            <Card>
+              <Card.Body>
                 <div className="d-flex justify-content-between align-items-center mb-3">
                   <h5 className="card-title mb-0">
                     <i className="bi bi-list-check me-2"></i>
                     Matching Packets
                   </h5>
                   <div>
-                    <span className="badge bg-primary me-2">{totalMatches} matches</span>
+                    <Badge bg="primary" className="me-2">{totalMatches} matches</Badge>
                     {executionTime !== null && (
-                      <span className="badge bg-secondary">{executionTime}ms</span>
+                      <Badge bg="secondary">{executionTime}ms</Badge>
                     )}
                   </div>
                 </div>
@@ -431,23 +428,24 @@ export const FilterGeneratorPage = () => {
                             {packet.destination.ip}:{packet.destination.port}
                           </td>
                           <td>
-                            <span className="badge bg-info">{packet.protocol.name}</span>
+                            <Badge bg="info">{packet.protocol.name}</Badge>
                           </td>
                           <td>{formatBytes(packet.size)}</td>
                           <td>
                             {packet.flags?.map((flag, idx) => (
-                              <span key={idx} className="badge bg-secondary me-1">
+                              <Badge key={idx} bg="secondary" className="me-1">
                                 {flag}
-                              </span>
+                              </Badge>
                             ))}
                           </td>
                           <td>
-                            <button
-                              className="btn btn-sm btn-outline-primary"
+                            <Button
+                              size="sm"
+                              variant="outline-primary"
                               onClick={() => setSelectedPacket(packet)}
                             >
                               Details
-                            </button>
+                            </Button>
                           </td>
                         </tr>
                       ))}
@@ -467,163 +465,135 @@ export const FilterGeneratorPage = () => {
                     />
                   </div>
                 )}
-              </div>
-            </div>
+              </Card.Body>
+            </Card>
           </div>
         </div>
       )}
 
       {/* Packet Details Modal */}
-      {selectedPacket && (
-        <div
-          className="modal show d-block"
-          tabIndex={-1}
-          style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
-        >
-          <div className="modal-dialog modal-lg">
-            <div className="modal-content">
-              <div className="modal-header">
-                <h5 className="modal-title">Packet Details</h5>
-                <button
-                  type="button"
-                  className="btn-close"
-                  onClick={() => setSelectedPacket(null)}
-                ></button>
+      <Modal show={!!selectedPacket} onHide={() => setSelectedPacket(null)} size="lg" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>Packet Details</Modal.Title>
+        </Modal.Header>
+        {selectedPacket && (
+          <Modal.Body>
+            <div className="row mb-3">
+              <div className="col-md-6">
+                <strong>Timestamp:</strong>
+                <p className="font-monospace">{formatTimestamp(selectedPacket.timestamp)}</p>
               </div>
-              <div className="modal-body">
-                <div className="row mb-3">
-                  <div className="col-md-6">
-                    <strong>Timestamp:</strong>
-                    <p className="font-monospace">{formatTimestamp(selectedPacket.timestamp)}</p>
-                  </div>
-                  <div className="col-md-6">
-                    <strong>Protocol:</strong>
-                    <p>
-                      {selectedPacket.protocol.name} ({selectedPacket.protocol.layer})
-                    </p>
-                  </div>
-                </div>
-                <div className="row mb-3">
-                  <div className="col-md-6">
-                    <strong>Source:</strong>
-                    <p className="font-monospace">
-                      {selectedPacket.source.ip}:{selectedPacket.source.port}
-                      {selectedPacket.source.hostname && (
-                        <>
-                          <br />
-                          <small className="text-muted">{selectedPacket.source.hostname}</small>
-                        </>
-                      )}
-                    </p>
-                  </div>
-                  <div className="col-md-6">
-                    <strong>Destination:</strong>
-                    <p className="font-monospace">
-                      {selectedPacket.destination.ip}:{selectedPacket.destination.port}
-                      {selectedPacket.destination.hostname && (
-                        <>
-                          <br />
-                          <small className="text-muted">
-                            {selectedPacket.destination.hostname}
-                          </small>
-                        </>
-                      )}
-                    </p>
-                  </div>
-                </div>
-                <div className="row mb-3">
-                  <div className="col-md-6">
-                    <strong>Size:</strong>
-                    <p>{formatBytes(selectedPacket.size)}</p>
-                  </div>
-                  <div className="col-md-6">
-                    <strong>Flags:</strong>
-                    <p>
-                      {selectedPacket.flags?.map((flag, idx) => (
-                        <span key={idx} className="badge bg-secondary me-1">
-                          {flag}
-                        </span>
-                      )) || 'None'}
-                    </p>
-                  </div>
-                </div>
-                <div className="row">
-                  <div className="col-12">
-                    <strong>Payload:</strong>
-                    <pre
-                      className="tp-payload-pre p-3 rounded mt-2 font-monospace small"
-                      style={{ maxHeight: '300px', overflow: 'auto' }}
-                    >
-                      {selectedPacket.payload || 'No payload data'}
-                    </pre>
-                  </div>
-                </div>
-              </div>
-              <div className="modal-footer">
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  onClick={() => setSelectedPacket(null)}
-                >
-                  Close
-                </button>
+              <div className="col-md-6">
+                <strong>Protocol:</strong>
+                <p>
+                  {selectedPacket.protocol.name} ({selectedPacket.protocol.layer})
+                </p>
               </div>
             </div>
-          </div>
-        </div>
-      )}
+            <div className="row mb-3">
+              <div className="col-md-6">
+                <strong>Source:</strong>
+                <p className="font-monospace">
+                  {selectedPacket.source.ip}:{selectedPacket.source.port}
+                  {selectedPacket.source.hostname && (
+                    <>
+                      <br />
+                      <small className="text-muted">{selectedPacket.source.hostname}</small>
+                    </>
+                  )}
+                </p>
+              </div>
+              <div className="col-md-6">
+                <strong>Destination:</strong>
+                <p className="font-monospace">
+                  {selectedPacket.destination.ip}:{selectedPacket.destination.port}
+                  {selectedPacket.destination.hostname && (
+                    <>
+                      <br />
+                      <small className="text-muted">
+                        {selectedPacket.destination.hostname}
+                      </small>
+                    </>
+                  )}
+                </p>
+              </div>
+            </div>
+            <div className="row mb-3">
+              <div className="col-md-6">
+                <strong>Size:</strong>
+                <p>{formatBytes(selectedPacket.size)}</p>
+              </div>
+              <div className="col-md-6">
+                <strong>Flags:</strong>
+                <p>
+                  {selectedPacket.flags?.map((flag, idx) => (
+                    <Badge key={idx} bg="secondary" className="me-1">
+                      {flag}
+                    </Badge>
+                  )) || 'None'}
+                </p>
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-12">
+                <strong>Payload:</strong>
+                <pre
+                  className="tp-payload-pre p-3 rounded mt-2 font-monospace small"
+                  style={{ maxHeight: '300px', overflow: 'auto' }}
+                >
+                  {selectedPacket.payload || 'No payload data'}
+                </pre>
+              </div>
+            </div>
+          </Modal.Body>
+        )}
+        <Modal.Footer>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => setSelectedPacket(null)}
+          >
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
 
       {/* Cheat Sheet Modal */}
-      {showCheatSheet && (
-        <div
-          className="modal show d-block"
-          tabIndex={-1}
-          style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
-        >
-          <div className="modal-dialog modal-xl">
-            <div className="modal-content">
-              <div className="modal-header">
-                <h5 className="modal-title">
-                  <i className="bi bi-file-earmark-text me-2"></i>
-                  BPF Filter Cheat Sheet
-                </h5>
-                <button
-                  type="button"
-                  className="btn-close"
-                  onClick={() => setShowCheatSheet(false)}
-                ></button>
-              </div>
-              <div className="modal-body">
-                <div className="text-center">
-                  <img
-                    src="/assets/Wireshark-Cheat-Sheet.jpg"
-                    alt="Wireshark BPF Filter Cheat Sheet"
-                    className="img-fluid"
-                    style={{ maxHeight: '80vh', objectFit: 'contain' }}
-                  />
-                </div>
-              </div>
-              <div className="modal-footer">
-                <a
-                  href="/assets/Wireshark-Cheat-Sheet.jpg"
-                  download="Wireshark-Cheat-Sheet.jpg"
-                  className="btn btn-outline-primary"
-                >
-                  <i className="bi bi-download me-2"></i>
-                  Download
-                </a>
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  onClick={() => setShowCheatSheet(false)}
-                >
-                  Close
-                </button>
-              </div>
-            </div>
+      <Modal show={showCheatSheet} onHide={() => setShowCheatSheet(false)} size="xl" centered>
+        <Modal.Header closeButton>
+          <Modal.Title>
+            <i className="bi bi-file-earmark-text me-2"></i>
+            BPF Filter Cheat Sheet
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="text-center">
+            <img
+              src="/assets/Wireshark-Cheat-Sheet.jpg"
+              alt="Wireshark BPF Filter Cheat Sheet"
+              className="img-fluid"
+              style={{ maxHeight: '80vh', objectFit: 'contain' }}
+            />
           </div>
-        </div>
-      )}
+        </Modal.Body>
+        <Modal.Footer>
+          <a
+            href="/assets/Wireshark-Cheat-Sheet.jpg"
+            download="Wireshark-Cheat-Sheet.jpg"
+            className="btn btn-outline-primary"
+          >
+            <i className="bi bi-download me-2"></i>
+            Download
+          </a>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => setShowCheatSheet(false)}
+          >
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </div>
   );
 };

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { Row, Col } from '@govtechsg/sgds-react';
+import { Button, Row, Col } from '@govtechsg/sgds-react';
 import { FileList } from '@components/upload/FileList';
 
 export const HomePage = () => {
@@ -12,10 +12,10 @@ export const HomePage = () => {
           <div className="text-center mb-4">
             <h2 className="mb-2">TracePcap</h2>
             <p className="text-muted mb-3">PCAP File Analysis &amp; Network Traffic Storytelling</p>
-            <button className="btn btn-primary" onClick={() => navigate('/upload')}>
+            <Button variant="primary" onClick={() => navigate('/upload')}>
               <i className="bi bi-upload me-2"></i>
               Upload PCAP
-            </button>
+            </Button>
           </div>
 
           <FileList />

--- a/frontend/src/pages/Monitor/MonitorPage.tsx
+++ b/frontend/src/pages/Monitor/MonitorPage.tsx
@@ -1,6 +1,7 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Container, Row, Col, Modal } from '@govtechsg/sgds-react';
+import { Alert, Button, Container, Form, Modal, Row, Col } from '@govtechsg/sgds-react';
 import { monitorService } from '@/features/monitor/services/monitorService';
 import type { Network } from '@/features/monitor/types/monitor.types';
 import { NetworkCard } from '@/components/monitor/NetworkCard/NetworkCard';
@@ -68,16 +69,17 @@ export const MonitorPage = () => {
               Updated {lastUpdated.toLocaleTimeString()}
             </small>
           )}
-          <button
+          <Button
             type="button"
-            className="btn btn-sm btn-outline-secondary"
+            size="sm"
+            variant="outline-secondary"
             onClick={() => loadNetworks(false)}
             title="Refresh now"
           >
             <i className="bi bi-arrow-clockwise"></i>
-          </button>
-          <select
-            className="form-select form-select-sm"
+          </Button>
+          <Form.Select
+            size="sm"
             style={{ width: 'auto' }}
             value={pollInterval}
             onChange={e => setPollInterval(Number(e.target.value))}
@@ -88,40 +90,39 @@ export const MonitorPage = () => {
             <option value={60}>Every 1m</option>
             <option value={300}>Every 5m</option>
             <option value={0}>Manual only</option>
-          </select>
-          <button
+          </Form.Select>
+          <Button
             type="button"
-            className="btn btn-primary"
+            variant="primary"
             onClick={() => setShowCreate(true)}
           >
             <i className="bi bi-plus-lg me-1"></i>Create Network
-          </button>
+          </Button>
         </div>
       </div>
 
       {error && (
-        <div className="alert alert-danger alert-dismissible">
+        <Alert variant="danger" dismissible onClose={() => setError(null)}>
           {error}
-          <button type="button" className="btn-close" onClick={() => setError(null)} />
-        </div>
+        </Alert>
       )}
 
       {loading ? (
         <div className="text-center py-5">
-          <div className="spinner-border text-primary" role="status" />
+          <Spinner animation="border" className="text-primary" />
         </div>
       ) : networks.length === 0 ? (
         <div className="text-center py-5 text-muted">
           <i className="bi bi-diagram-3 display-4 d-block mb-3"></i>
           <h5>No networks yet</h5>
           <p>Create a network group to start monitoring changes across PCAPs.</p>
-          <button
+          <Button
             type="button"
-            className="btn btn-primary"
+            variant="primary"
             onClick={() => setShowCreate(true)}
           >
             <i className="bi bi-plus-lg me-1"></i>Create your first network
-          </button>
+          </Button>
         </div>
       ) : (
         <Row>
@@ -155,23 +156,23 @@ export const MonitorPage = () => {
           </p>
         </Modal.Body>
         <Modal.Footer>
-          <button
+          <Button
             type="button"
-            className="btn btn-outline-secondary"
+            variant="outline-secondary"
             onClick={() => setConfirmDeleteId(null)}
             disabled={deleting}
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
-            className="btn btn-outline-danger"
+            variant="outline-danger"
             onClick={() => confirmDeleteId && handleDelete(confirmDeleteId)}
             disabled={deleting}
           >
-            {deleting ? <span className="spinner-border spinner-border-sm me-1" /> : null}
+            {deleting ? <Spinner animation="border" size="sm" className="me-1" /> : null}
             Delete
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
     </Container>

--- a/frontend/src/pages/Monitor/NetworkDetailPage.tsx
+++ b/frontend/src/pages/Monitor/NetworkDetailPage.tsx
@@ -1,6 +1,7 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useEffect, useState, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Container, Row, Col, Card, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Alert, Badge, Button, Card, Container, Form, OverlayTrigger, Popover, Row, Col } from '@govtechsg/sgds-react';
 import { monitorService } from '@/features/monitor/services/monitorService';
 import type {
   Network,
@@ -27,9 +28,9 @@ const SEVERITY_FILTERS: SeverityFilter[] = ['ALL', 'CRITICAL', 'WARNING', 'INFO'
 const MonitorInfoCard = () => {
   const [collapsed, setCollapsed] = useState(true);
   return (
-    <div className="card mb-4" style={{ overflow: 'hidden' }}>
-      <div
-        className="card-header d-flex align-items-center justify-content-between"
+    <Card className="mb-4" style={{ overflow: 'hidden' }}>
+      <Card.Header
+        className="d-flex align-items-center justify-content-between"
         style={{
           cursor: 'pointer',
           userSelect: 'none',
@@ -42,9 +43,9 @@ const MonitorInfoCard = () => {
           How network monitoring works
         </h6>
         <i className={`bi bi-chevron-${collapsed ? 'down' : 'up'} text-muted`}></i>
-      </div>
+      </Card.Header>
       {!collapsed && (
-        <div className="card-body small text-muted">
+        <Card.Body className="small text-muted">
           <p className="mb-2">
             Each PCAP you add becomes a <strong>snapshot</strong> ordered by its capture time.
             After adding a second snapshot, the system automatically compares consecutive snapshots
@@ -73,18 +74,18 @@ const MonitorInfoCard = () => {
           </ul>
           <p className="mb-2">
             <strong>Severity guide:</strong>{' '}
-            <span className="badge bg-danger me-1">CRITICAL</span> security-relevant (potential ARP spoof, gateway hijack) ·{' '}
-            <span className="badge bg-warning text-dark me-1">WARNING</span> notable change requiring review ·{' '}
-            <span className="badge bg-info text-dark">INFO</span> informational drift
+            <Badge bg="danger" className="me-1">CRITICAL</Badge> security-relevant (potential ARP spoof, gateway hijack) ·{' '}
+            <Badge bg="warning" text="dark" className="me-1">WARNING</Badge> notable change requiring review ·{' '}
+            <Badge bg="info" text="dark">INFO</Badge> informational drift
           </p>
           <p className="mb-0">
             Click any filename in the <strong>Capture Timeline</strong> to open the network diagram for
             that snapshot. Changed nodes are highlighted by severity colour — click a highlighted node
             to see exactly what changed.
           </p>
-        </div>
+        </Card.Body>
       )}
-    </div>
+    </Card>
   );
 };
 
@@ -194,7 +195,7 @@ export const NetworkDetailPage = () => {
   if (loading) {
     return (
       <Container className="py-5 text-center">
-        <div className="spinner-border text-primary" role="status" />
+        <Spinner animation="border" className="text-primary" />
       </Container>
     );
   }
@@ -202,10 +203,10 @@ export const NetworkDetailPage = () => {
   if (error || !network) {
     return (
       <Container className="py-4">
-        <div className="alert alert-danger">{error ?? 'Network not found.'}</div>
-        <button type="button" className="btn btn-secondary" onClick={() => navigate('/monitor')}>
+        <Alert variant="danger">{error ?? 'Network not found.'}</Alert>
+        <Button type="button" variant="secondary" onClick={() => navigate('/monitor')}>
           Back to Monitor
-        </button>
+        </Button>
       </Container>
     );
   }
@@ -214,13 +215,15 @@ export const NetworkDetailPage = () => {
     <Container className="py-4">
       {/* Header */}
       <div className="mb-4">
-        <button
+        <Button
           type="button"
-          className="btn btn-sm btn-outline-secondary mb-2"
+          size="sm"
+          variant="outline-secondary"
+          className="mb-2"
           onClick={() => navigate('/monitor')}
         >
           <i className="bi bi-arrow-left me-1"></i>All Networks
-        </button>
+        </Button>
         <div className="d-flex align-items-start justify-content-between flex-wrap gap-2 mt-3">
           <div>
             <h3 className="mb-1">{network.name}</h3>
@@ -233,16 +236,17 @@ export const NetworkDetailPage = () => {
                 Updated {lastUpdated.toLocaleTimeString()}
               </small>
             )}
-            <button
+            <Button
               type="button"
-              className="btn btn-sm btn-outline-secondary"
+              size="sm"
+              variant="outline-secondary"
               onClick={() => loadAll(false)}
               title="Refresh now"
             >
               <i className="bi bi-arrow-clockwise"></i>
-            </button>
-            <select
-              className="form-select form-select-sm"
+            </Button>
+            <Form.Select
+              size="sm"
               style={{ width: 'auto' }}
               value={pollInterval}
               onChange={e => setPollInterval(Number(e.target.value))}
@@ -253,7 +257,7 @@ export const NetworkDetailPage = () => {
               <option value={60}>Every 1m</option>
               <option value={300}>Every 5m</option>
               <option value={0}>Manual only</option>
-            </select>
+            </Form.Select>
           </div>
         </div>
       </div>
@@ -280,11 +284,11 @@ export const NetworkDetailPage = () => {
       {/* Traffic Overview Chart */}
       {snapshots.length >= 2 && (
         <Card className="mb-4">
-          <div className="card-header">
+          <Card.Header>
             <h6 className="mb-0">
               <i className="bi bi-bar-chart-line me-2"></i>Traffic Overview
             </h6>
-          </div>
+          </Card.Header>
           <Card.Body>
             <SnapshotTrafficChart snapshots={snapshots} />
           </Card.Body>
@@ -293,11 +297,11 @@ export const NetworkDetailPage = () => {
 
       {/* Change Events */}
       <Card className="mb-4" style={{ overflow: 'hidden' }}>
-        <div className="card-header d-flex justify-content-between align-items-center">
+        <Card.Header className="d-flex justify-content-between align-items-center">
           <h6 className="mb-0">
             <i className="bi bi-activity me-2"></i>Change Events
             {filteredEvents.length > 0 && (
-              <span className="badge bg-secondary ms-2">{filteredEvents.length}</span>
+              <Badge bg="secondary" className="ms-2">{filteredEvents.length}</Badge>
             )}
             <OverlayTrigger
               trigger="click"
@@ -310,17 +314,17 @@ export const NetworkDetailPage = () => {
                     <p className="mb-2 text-muted">Changes are compared against the immediately preceding snapshot by capture time. The first snapshot is the baseline and produces no events.</p>
                     <ul className="mb-0 ps-3">
                       <li className="mb-2">
-                        <span className="badge bg-danger me-1">CRITICAL</span>
+                        <Badge bg="danger" className="me-1">CRITICAL</Badge>
                         <code>IP_MAC_DRIFT</code> — IP claimed by a different MAC (potential ARP spoofing)<br />
                         <code>GATEWAY_CHANGE</code> — default gateway IP changed
                       </li>
                       <li className="mb-2">
-                        <span className="badge bg-warning text-dark me-1">WARNING</span>
+                        <Badge bg="warning" text="dark" className="me-1">WARNING</Badge>
                         <code>MAC_ADDED</code> — new device appeared<br />
                         <code>IP_MAC_DRIFT</code> — known MAC moved to a new IP (DHCP drift)
                       </li>
                       <li>
-                        <span className="badge bg-info text-dark me-1">INFO</span>
+                        <Badge bg="info" text="dark" className="me-1">INFO</Badge>
                         <code>PROTOCOL_ADDED</code> / <code>APP_ADDED</code> — new layer-7 protocol or app<br />
                         <code>ASN_CHANGE</code> — top external peer shifted ISP / ASN<br />
                         <code>VPN_DRIFT</code> — VPN usage appeared or disappeared
@@ -330,41 +334,44 @@ export const NetworkDetailPage = () => {
                 </Popover>
               }
             >
-              <button
+              <Button
                 type="button"
-                className="btn btn-sm btn-link text-muted p-0 ms-2"
+                size="sm"
+                variant="link"
+                className="text-muted p-0 ms-2"
                 style={{ fontSize: '0.85rem', verticalAlign: 'middle' }}
                 title="What's detected"
               >
                 <i className="bi bi-info-circle"></i>
-              </button>
+              </Button>
             </OverlayTrigger>
           </h6>
           <div className="d-flex align-items-center gap-2 flex-wrap">
             {/* Severity pills */}
             <div className="d-flex gap-1">
               {SEVERITY_FILTERS.map(f => (
-                <button
+                <Button
                   key={f}
                   type="button"
-                  className={`btn btn-sm ${
+                  size="sm"
+                  variant={
                     severityFilter === f
-                      ? f === 'CRITICAL' ? 'btn-danger'
-                        : f === 'WARNING' ? 'btn-warning'
-                        : f === 'INFO' ? 'btn-info'
-                        : 'btn-primary'
-                      : 'btn-outline-secondary'
-                  }`}
+                      ? f === 'CRITICAL' ? 'danger'
+                        : f === 'WARNING' ? 'warning'
+                        : f === 'INFO' ? 'info'
+                        : 'primary'
+                      : 'outline-secondary'
+                  }
                   onClick={() => { setSeverityFilter(f); setEventPage(1); }}
                 >
                   {f}
-                </button>
+                </Button>
               ))}
             </div>
             {/* Change type select */}
             {CHANGE_TYPES.length > 2 && (
-              <select
-                className="form-select form-select-sm"
+              <Form.Select
+                size="sm"
                 style={{ width: 'auto' }}
                 value={changeTypeFilter}
                 onChange={e => { setChangeTypeFilter(e.target.value); setEventPage(1); }}
@@ -372,23 +379,24 @@ export const NetworkDetailPage = () => {
                 {CHANGE_TYPES.map(t => (
                   <option key={t} value={t}>{t === 'ALL' ? 'All types' : t}</option>
                 ))}
-              </select>
+              </Form.Select>
             )}
             {/* Reviewed filter */}
             <div className="d-flex gap-1">
               {(['ALL', 'UNREVIEWED', 'REVIEWED'] as const).map(r => (
-                <button
+                <Button
                   key={r}
                   type="button"
-                  className={`btn btn-sm ${reviewedFilter === r ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                  size="sm"
+                  variant={reviewedFilter === r ? 'secondary' : 'outline-secondary'}
                   onClick={() => { setReviewedFilter(r); setEventPage(1); }}
                 >
                   {r === 'ALL' ? 'All' : r === 'UNREVIEWED' ? 'Unreviewed' : 'Reviewed'}
-                </button>
+                </Button>
               ))}
             </div>
           </div>
-        </div>
+        </Card.Header>
 
 
         <Card.Body className="p-0">
@@ -487,14 +495,16 @@ export const NetworkDetailPage = () => {
                 </Popover>
               }
             >
-              <button
+              <Button
                 type="button"
-                className="btn btn-sm btn-link text-muted p-0 ms-2"
+                size="sm"
+                variant="link"
+                className="text-muted p-0 ms-2"
                 style={{ fontSize: '0.85rem' }}
                 title="About baseline definitions"
               >
                 <i className="bi bi-info-circle"></i>
-              </button>
+              </Button>
             </OverlayTrigger>
           </div>
           <BaselineDefinitionPanel

--- a/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
+++ b/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { Modal } from '@govtechsg/sgds-react';
+import { Alert, Button, Card, Form, Modal } from '@govtechsg/sgds-react';
 import type { GraphNode } from '@/features/network/types';
 import {
   useNetworkData,
@@ -373,28 +373,28 @@ export const NetworkDiagramPage = () => {
 
       {CONVERSATION_LIMIT_ENABLED &&
         (stats.isLimited ? (
-          <div className="alert alert-warning mb-3">
+          <Alert variant="warning" className="mb-3">
             <i className="bi bi-exclamation-triangle me-2"></i>
             <strong>Performance limit active:</strong> Showing top{' '}
             {stats.displayedConversations?.toLocaleString()} of{' '}
             {stats.totalConversations?.toLocaleString()} conversations by packet count. Set{' '}
             <code>VITE_NETWORK_DIAGRAM_CONVERSATION_LIMIT=false</code> to render all.
-          </div>
+          </Alert>
         ) : (
-          <div className="alert alert-info mb-3">
+          <Alert variant="info" className="mb-3">
             <i className="bi bi-info-circle me-2"></i>
             <strong>Performance limit enabled</strong> — all{' '}
             {stats.totalConversations?.toLocaleString()} conversations are within the 500-connection
             limit and fully rendered.
-          </div>
+          </Alert>
         ))}
 
       {/* Row 1: Network Statistics */}
-      <div className="card mb-3">
-        <div className="card-header">
+      <Card className="mb-3">
+        <Card.Header>
           <strong>Diagram Overview</strong>
-        </div>
-        <div className="card-body py-2 px-3">
+        </Card.Header>
+        <Card.Body className="py-2 px-3">
           <div className="d-flex align-items-center gap-3 flex-wrap">
             {[
               { label: 'Nodes', value: stats.totalNodes.toLocaleString() },
@@ -413,8 +413,8 @@ export const NetworkDiagramPage = () => {
               {filteredNodes.length} nodes · {filteredEdges.length} connections shown
             </div>
           </div>
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
 
       {stats.totalNodes > MAX_DIAGRAM_NODES &&
         (() => {
@@ -426,16 +426,17 @@ export const NetworkDiagramPage = () => {
             setCustomInput('');
           };
           return (
-            <div className="alert alert-info mb-3">
+            <Alert variant="info" className="mb-3">
               <div className="d-flex align-items-start gap-2 flex-wrap">
-                <button
-                  className="btn btn-link p-0 border-0 mt-1 flex-shrink-0"
+                <Button
+                  variant="link"
+                  className="p-0 border-0 mt-1 flex-shrink-0"
                   style={{ lineHeight: 1 }}
                   title="How is significance determined?"
                   onClick={() => setShowSignificanceModal(true)}
                 >
                   <i className="bi bi-info-circle"></i>
-                </button>
+                </Button>
                 <div className="flex-grow-1">
                   <div>
                     {hiddenNodes > 0 ? (
@@ -454,27 +455,29 @@ export const NetworkDiagramPage = () => {
                   <div className="d-flex align-items-center gap-2 mt-2 flex-wrap">
                     <span className="text-muted small fw-semibold me-1">Show:</span>
                     {presets.map(p => (
-                      <button
+                      <Button
                         key={p}
-                        className={`btn btn-sm ${nodeLimit === p ? 'btn-info' : 'btn-outline-secondary'}`}
+                        size="sm"
+                        variant={nodeLimit === p ? 'info' : 'outline-secondary'}
                         style={{ minWidth: 52 }}
                         onClick={() => setNodeLimit(p)}
                       >
                         Top {p}
-                      </button>
+                      </Button>
                     ))}
-                    <button
-                      className={`btn btn-sm ${nodeLimit >= totalNodes ? 'btn-info' : 'btn-outline-secondary'}`}
+                    <Button
+                      size="sm"
+                      variant={nodeLimit >= totalNodes ? 'info' : 'outline-secondary'}
                       style={{ minWidth: 52 }}
                       onClick={() => setNodeLimit(totalNodes)}
                     >
                       All {totalNodes}
-                    </button>
+                    </Button>
                     <span className="text-muted small ms-2 me-1">or</span>
                     <div className="input-group input-group-sm" style={{ width: 120 }}>
-                      <input
+                      <Form.Control
                         type="number"
-                        className="form-control form-control-sm"
+                        size="sm"
                         placeholder="Custom…"
                         min={1}
                         max={totalNodes}
@@ -487,25 +490,27 @@ export const NetworkDiagramPage = () => {
                   </div>
                 </div>
               </div>
-            </div>
+            </Alert>
           );
         })()}
 
       {/* Row 2: Graph full width */}
       <div className="row">
         <div className="col-12">
-          <div className={`card${isFullscreen ? ' nd-css-fullscreen' : ''}`} ref={graphCardRef}>
-            <div className="card-header d-flex justify-content-between align-items-center">
+          <Card className={isFullscreen ? 'nd-css-fullscreen' : ''} ref={graphCardRef}>
+            <Card.Header className="d-flex justify-content-between align-items-center">
               <strong>Topology Diagram</strong>
-              <button
-                className="btn btn-link btn-sm p-0 text-muted"
+              <Button
+                variant="link"
+                size="sm"
+                className="p-0 text-muted"
                 onClick={toggleFullscreen}
                 title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
               >
                 <i className={`bi ${isFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'}`} />
-              </button>
-            </div>
-            <div className="card-body p-0 network-diagram-graph-body">
+              </Button>
+            </Card.Header>
+            <Card.Body className="p-0 network-diagram-graph-body">
               <NetworkGraph
                 key={layoutType}
                 nodes={filteredNodes}
@@ -518,8 +523,8 @@ export const NetworkDiagramPage = () => {
                 onFilterClick={() => setShowFilterModal(true)}
                 activeFilterCount={activeFilterCount}
               />
-            </div>
-          </div>
+            </Card.Body>
+          </Card>
         </div>
       </div>
 
@@ -591,9 +596,9 @@ export const NetworkDiagramPage = () => {
           />
         </Modal.Body>
         <Modal.Footer>
-          <button className="btn btn-secondary" onClick={() => setShowFilterModal(false)}>
+          <Button variant="secondary" onClick={() => setShowFilterModal(false)}>
             Close
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
 
@@ -645,9 +650,9 @@ export const NetworkDiagramPage = () => {
           </table>
         </Modal.Body>
         <Modal.Footer>
-          <button className="btn btn-secondary" onClick={() => setShowSignificanceModal(false)}>
+          <Button variant="secondary" onClick={() => setShowSignificanceModal(false)}>
             Close
-          </button>
+          </Button>
         </Modal.Footer>
       </Modal>
     </div>

--- a/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
+++ b/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { Modal } from '@govtechsg/sgds-react';
+import { Alert, Button, Card, Modal } from '@govtechsg/sgds-react';
 import type { AnalysisData } from '@/types';
 import {
   intelligenceService,
@@ -242,8 +242,8 @@ export const NetworkIntelligencePage = () => {
       <SummaryStatsBar data={data} />
 
       {/* Cluster graph */}
-      <div className={`card mb-4${isFullscreen ? ' nd-css-fullscreen' : ''}`} ref={graphCardRef}>
-        <div className="card-header d-flex justify-content-between align-items-center">
+      <Card className={`mb-4${isFullscreen ? ' nd-css-fullscreen' : ''}`} ref={graphCardRef}>
+        <Card.Header className="d-flex justify-content-between align-items-center">
           <div>
             <h6 className="mb-0">
               <i className="bi bi-diagram-3 me-2" />
@@ -251,20 +251,22 @@ export const NetworkIntelligencePage = () => {
             </h6>
             <small className="text-muted">Click a cluster node to see its member IPs and statistics.</small>
           </div>
-          <button
-            className="btn btn-link btn-sm p-0 text-muted"
+          <Button
+            variant="link"
+            size="sm"
+            className="p-0 text-muted"
             onClick={() => setIsFullscreen(f => !f)}
             title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
           >
             <i className={`bi ${isFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'}`} />
-          </button>
-        </div>
-        <div className="card-body intel-cluster-card-body">
+          </Button>
+        </Card.Header>
+        <Card.Body className="intel-cluster-card-body">
           {clusterError && (
-            <div className="alert alert-warning py-2" role="alert">
+            <Alert variant="warning" className="py-2">
               <i className="bi bi-exclamation-triangle me-2" />
               {clusterError}
-            </div>
+            </Alert>
           )}
           <ClusterGraph
             data={clusterData}
@@ -277,8 +279,8 @@ export const NetworkIntelligencePage = () => {
             selectedCluster={selectedCluster}
             onSelectedClusterChange={setSelectedCluster}
           />
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
 
       {/* Filter modal */}
       <Modal

--- a/frontend/src/pages/Story/StoryPage.tsx
+++ b/frontend/src/pages/Story/StoryPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { OverlayTrigger, Popover } from '@govtechsg/sgds-react';
+import { Alert, Button, Card, Form, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import { useOutletContext } from 'react-router-dom';
 import type { TimelineDataPoint } from '@/types';
 import type { AnalysisOutletContext } from '@/pages/Analysis/AnalysisPage';
@@ -42,14 +42,15 @@ function NarrativeInfoPopover() {
   );
   return (
     <OverlayTrigger trigger="click" placement="right" overlay={popover} rootClose>
-      <button
+      <Button
         type="button"
-        className="btn btn-link p-0 text-muted ms-2"
+        variant="link"
+        className="p-0 text-muted ms-2"
         style={{ lineHeight: 1 }}
         aria-label="About Narrative"
       >
         <i className="bi bi-info-circle" style={{ fontSize: '0.9rem' }}></i>
-      </button>
+      </Button>
     </OverlayTrigger>
   );
 }
@@ -126,44 +127,46 @@ export const StoryPage = () => {
     const remaining = contextError.contextLength - contextError.promptTokens;
     return (
       <div className="py-4">
-        <div className="alert alert-danger mb-3" role="alert">
-          <h5 className="alert-heading">
+        <Alert variant="danger" className="mb-3">
+          <Alert.Heading>
             <i className="bi bi-exclamation-triangle-fill me-2"></i>
             Prompt Too Large for Model
-          </h5>
+          </Alert.Heading>
           <p className="mb-0">
             The prompt used <strong>{contextError.promptTokens.toLocaleString()}</strong> tokens
             but the model's context window is{' '}
             <strong>{contextError.contextLength.toLocaleString()}</strong> tokens, leaving only{' '}
             <strong>{remaining.toLocaleString()}</strong> for the response.
           </p>
-        </div>
+        </Alert>
         <p className="text-muted small mb-2">
           Edit the prompt below to reduce its size (e.g. remove findings or aggregates sections),
           then retry:
         </p>
-        <textarea
-          className="form-control form-control-sm font-monospace mb-3"
+        <Form.Control
+          as="textarea"
+          size="sm"
+          className="font-monospace mb-3"
           rows={20}
           value={editablePrompt}
           onChange={e => setEditablePrompt(e.target.value)}
         />
         <div className="d-flex gap-2">
-          <button
-            className="btn btn-primary"
+          <Button
+            variant="primary"
             onClick={() => handleGenerateStory(editablePrompt)}
             disabled={generating}
           >
             <i className="bi bi-arrow-repeat me-2"></i>
             Retry with edited prompt
-          </button>
-          <button
-            className="btn btn-outline-secondary"
+          </Button>
+          <Button
+            variant="outline-secondary"
             onClick={() => { setContextError(null); setEditablePrompt(''); }}
             disabled={generating}
           >
             Start over
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -200,10 +203,10 @@ export const StoryPage = () => {
           <p className="text-muted mb-4">
             Generate an AI-powered narrative analysis of this network capture
           </p>
-          <button className="btn btn-primary" onClick={() => handleGenerateStory()}>
+          <Button variant="primary" onClick={() => handleGenerateStory()}>
             <i className="bi bi-magic me-2"></i>
             Generate Story
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -216,15 +219,16 @@ export const StoryPage = () => {
         <div className="col-12">
           <div className="d-flex align-items-center justify-content-between">
             <h4 className="mb-0">Network Traffic Story</h4>
-            <button
-              className="btn btn-outline-primary btn-sm"
+            <Button
+              variant="outline-primary"
+              size="sm"
               onClick={() => handleGenerateStory()}
               disabled={generating}
               title={generating ? 'Generating...' : 'Regenerate'}
             >
               <i className={`bi bi-arrow-clockwise${generating ? ' spin' : ''} me-1`}></i>
               {generating ? 'Generating...' : 'Regenerate'}
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -233,10 +237,10 @@ export const StoryPage = () => {
       {error && (
         <div className="row mb-3">
           <div className="col-12">
-            <div className="alert alert-danger py-2 mb-0" role="alert">
+            <Alert variant="danger" className="py-2 mb-0">
               <i className="bi bi-exclamation-triangle-fill me-2"></i>
               {error}
-            </div>
+            </Alert>
           </div>
         </div>
       )}
@@ -268,15 +272,15 @@ export const StoryPage = () => {
       {!loadingTimeline && timelineData.length > 0 && (
         <div className="row mb-4">
           <div className="col-12">
-            <div className="card">
-              <div className="card-body">
+            <Card>
+              <Card.Body>
                 <TrafficTimeline
                   data={timelineData}
                   granularity={granularity}
                   onGranularityChange={setGranularity}
                 />
-              </div>
-            </div>
+              </Card.Body>
+            </Card>
           </div>
         </div>
       )}
@@ -321,16 +325,16 @@ export const StoryPage = () => {
 
         {/* Story Event Timeline Section */}
         <div className="col-lg-4">
-          <div className="card sticky-top" style={{ top: '20px', zIndex: 10 }}>
-            <div className="card-body">
+          <Card className="sticky-top" style={{ top: '20px', zIndex: 10 }}>
+            <Card.Body>
               <h5 className="mb-3">Key Events</h5>
               {story.timeline && story.timeline.length > 0 ? (
                 <StoryTimeline events={story.timeline} />
               ) : (
                 <p className="text-muted small">No key events identified in this capture.</p>
               )}
-            </div>
-          </div>
+            </Card.Body>
+          </Card>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Timeline/TimelinePage.tsx
+++ b/frontend/src/pages/Timeline/TimelinePage.tsx
@@ -7,6 +7,7 @@ import {
   AUTO_GRANULARITY_MAX_DATAPOINTS,
 } from '@/features/timeline/constants';
 import { TrafficTimeline } from '@components/timeline/TrafficTimeline';
+import { Alert, Card } from '@govtechsg/sgds-react';
 import { LoadingSpinner } from '@components/common/LoadingSpinner';
 import { ErrorMessage } from '@components/common/ErrorMessage';
 
@@ -57,7 +58,7 @@ export const TimelinePage = () => {
   }
 
   if (timelineData.length === 0) {
-    return <div className="alert alert-warning">No timeline data available for this capture.</div>;
+    return <Alert variant="warning">No timeline data available for this capture.</Alert>;
   }
 
   // Calculate summary statistics
@@ -78,50 +79,50 @@ export const TimelinePage = () => {
 
       <div className="row mb-4">
         <div className="col-md-3">
-          <div className="card">
-            <div className="card-body text-center">
+          <Card>
+            <Card.Body className="text-center">
               <h6 className="text-muted mb-1">Total Packets</h6>
               <h3 className="mb-0">{totalPackets.toLocaleString()}</h3>
-            </div>
-          </div>
+            </Card.Body>
+          </Card>
         </div>
         <div className="col-md-3">
-          <div className="card">
-            <div className="card-body text-center">
+          <Card>
+            <Card.Body className="text-center">
               <h6 className="text-muted mb-1">Total Bytes</h6>
               <h3 className="mb-0">{(totalBytes / 1024 / 1024).toFixed(2)} MB</h3>
-            </div>
-          </div>
+            </Card.Body>
+          </Card>
         </div>
         <div className="col-md-3">
-          <div className="card">
-            <div className="card-body text-center">
+          <Card>
+            <Card.Body className="text-center">
               <h6 className="text-muted mb-1">Avg Packets/Min</h6>
               <h3 className="mb-0">{avgPackets.toLocaleString()}</h3>
-            </div>
-          </div>
+            </Card.Body>
+          </Card>
         </div>
         <div className="col-md-3">
-          <div className="card">
-            <div className="card-body text-center">
+          <Card>
+            <Card.Body className="text-center">
               <h6 className="text-muted mb-1">Peak Packets/Min</h6>
               <h3 className="mb-0">{maxPackets.toLocaleString()}</h3>
-            </div>
-          </div>
+            </Card.Body>
+          </Card>
         </div>
       </div>
 
       <div className="row">
         <div className="col-12">
-          <div className="card">
-            <div className="card-body">
+          <Card>
+            <Card.Body>
               <TrafficTimeline
                 data={timelineData}
                 granularity={granularity}
                 onGranularityChange={setGranularity}
               />
-            </div>
-          </div>
+            </Card.Body>
+          </Card>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Upload/UploadPage.tsx
+++ b/frontend/src/pages/Upload/UploadPage.tsx
@@ -1,6 +1,7 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Row, Col, Modal } from '@govtechsg/sgds-react';
+import { Button, Row, Col, Modal } from '@govtechsg/sgds-react';
 import { FileUploadZone } from '@components/upload/FileUploadZone';
 import { FileList } from '@components/upload/FileList';
 import { UploadProgress } from '@components/upload/UploadProgress';
@@ -147,13 +148,13 @@ export const UploadPage = () => {
               )}
             </Modal.Body>
             <Modal.Footer>
-              <button className="btn btn-outline-secondary btn-sm" onClick={handleCancelPending}>
+              <Button variant="outline-secondary" size="sm" onClick={handleCancelPending}>
                 Cancel
-              </button>
-              <button className="btn btn-primary btn-sm" onClick={handleConfirmUpload}>
+              </Button>
+              <Button variant="primary" size="sm" onClick={handleConfirmUpload}>
                 <i className="bi bi-upload me-1" />
                 Start upload
-              </button>
+              </Button>
             </Modal.Footer>
           </Modal>
 
@@ -171,11 +172,7 @@ export const UploadPage = () => {
               <Modal.Title>
                 {isUploading ? (
                   <>
-                    <span
-                      className="spinner-border spinner-border-sm me-2"
-                      role="status"
-                      aria-hidden="true"
-                    />
+                    <Spinner animation="border" size="sm" className="me-2" />
                     Uploading…
                   </>
                 ) : (


### PR DESCRIPTION
## Summary

Closes #307

Comprehensive audit and replacement of raw Bootstrap HTML with idiomatic SGDS React components across the entire frontend codebase, per the `CLAUDE.md` guideline to always use SGDS components first.

- **`<Button>`** — replaced `<button className="btn btn-*">` across 44+ files
- **`<Card>` / `<Card.Header>` / `<Card.Body>` / `<Card.Footer>`** — replaced raw `<div className="card*">` wrappers
- **`<Badge>`** — replaced `<span className="badge bg-*">` with `bg` and `text` props
- **`<Alert>`** — replaced `<div className="alert alert-*">` including dismissible variants
- **`<Form.Control>` / `<Form.Select>` / `<Form.Label>`** — replaced raw form elements
- **`<ButtonGroup>`** — replaced `<div className="btn-group">`
- **Raw Bootstrap modals** — two `<div className="modal show d-block">` patterns converted to `<Modal show={...}>`

**Note on `<Spinner>`:** Not exported from `@govtechsg/sgds-react`. A lightweight local shim (`src/components/common/Spinner/Spinner.tsx`) renders the Bootstrap `spinner-border` div, keeping JSX idiomatic across 26 files.

**`<a>` download links** retain Bootstrap `btn` classes intentionally — they require anchor semantics for file downloads.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified ✅)
- [ ] `docker compose up -d --build` succeeds (verified ✅)
- [ ] Visual check: Upload page, Analysis tabs, Compare, Filter Generator, Network Diagram, Monitor
- [ ] Dark mode visual check

🤖 Generated with [Claude Code](https://claude.com/claude-code)