### PR TITLE
fix: add scroll chevrons to analysis nav-tabs on narrow screens

### DIFF
--- a/frontend/src/assets/styles/index.css
+++ b/frontend/src/assets/styles/index.css
@@ -102,6 +102,53 @@ body {
   color: var(--tp-text-muted);
 }
 
+/* Analysis page nav-tabs: single scrollable row with fade + scroll buttons */
+.nav-tabs-scroll-wrapper {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.nav.nav-tabs {
+  flex: 1 1 0;
+  width: 0;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.nav.nav-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.nav-tabs-scroll-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  align-self: stretch;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--tp-border);
+  color: var(--tp-text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s;
+}
+
+.nav-tabs-scroll-btn:first-child {
+  margin-right: 2px;
+}
+
+.nav-tabs-scroll-btn:last-child {
+  margin-left: 2px;
+}
+
+.nav-tabs-scroll-btn:hover {
+  color: var(--tp-text);
+}
+
 /* Upload progress scroll row */
 .upload-progress-scroll {
   display: flex;

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
-import React, { useState, useEffect, useRef, useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
 import { Button, Card } from '@govtechsg/sgds-react';
 import { useParams, Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { useAnalysisData } from '@features/analysis/hooks/useAnalysisData';
@@ -111,19 +111,26 @@ export const AnalysisPage = () => {
   const [totalFindings, setTotalFindings] = useState<number | undefined>(undefined);
   const [totalRiskMatrix, setTotalRiskMatrix] = useState<number | undefined>(undefined);
   const storyTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const tabsRef = useRef<HTMLUListElement>(null);
-  const [tabsScrollLeft, setTabsScrollLeft] = useState(0);
+  const tabsRef = useRef<HTMLUListElement | null>(null);
+  const tabsRoRef = useRef<ResizeObserver | null>(null);
+  const [tabsScrolledRight, setTabsScrolledRight] = useState(false);
   const [tabsOverflows, setTabsOverflows] = useState(false);
+  const [tabsAtEnd, setTabsAtEnd] = useState(false);
 
   const tabsRefCallback = useCallback((el: HTMLUListElement | null) => {
-    (tabsRef as React.MutableRefObject<HTMLUListElement | null>).current = el;
+    tabsRef.current = el;
+    tabsRoRef.current?.disconnect();
     if (!el) return;
-    const check = () => setTabsOverflows(el.scrollWidth > el.clientWidth);
+    const check = () => {
+      setTabsOverflows(el.scrollWidth > el.clientWidth);
+      setTabsAtEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 1);
+    };
     check();
     setTimeout(check, 50);
     setTimeout(check, 300);
     const ro = new ResizeObserver(check);
     ro.observe(el);
+    tabsRoRef.current = ro;
   }, []);
 
   useEffect(() => {
@@ -423,7 +430,7 @@ export const AnalysisPage = () => {
       <div className="nav-tabs-scroll-wrapper">
         <button
           className="nav-tabs-scroll-btn"
-          style={{ visibility: tabsOverflows && tabsScrollLeft > 0 ? 'visible' : 'hidden' }}
+          style={{ visibility: tabsScrolledRight ? 'visible' : 'hidden' }}
           onClick={() => { tabsRef.current?.scrollBy({ left: -150, behavior: 'smooth' }); }}
           aria-label="Scroll tabs left"
         >
@@ -433,7 +440,12 @@ export const AnalysisPage = () => {
           ref={tabsRefCallback}
           className="nav nav-tabs"
           style={{ borderBottom: 'none', paddingTop: '1px' }}
-          onScroll={e => setTabsScrollLeft((e.currentTarget as HTMLUListElement).scrollLeft)}
+          onScroll={e => {
+            const el = e.currentTarget as HTMLUListElement;
+            const s = el.scrollLeft;
+            if ((tabsScrolledRight) !== (s > 0)) setTabsScrolledRight(s > 0);
+            setTabsAtEnd(s + el.clientWidth >= el.scrollWidth - 1);
+          }}
         >
         <li className="nav-item">
           <button
@@ -502,10 +514,10 @@ export const AnalysisPage = () => {
         </ul>
         <button
           className="nav-tabs-scroll-btn"
-          style={{ visibility: tabsOverflows ? 'visible' : 'hidden' }}
+          style={{ visibility: tabsOverflows && !tabsAtEnd ? 'visible' : 'hidden' }}
           onClick={() => { tabsRef.current?.scrollBy({ left: 150, behavior: 'smooth' }); }}
           aria-label="Scroll tabs right"
-          tabIndex={tabsOverflows ? 0 : -1}
+          tabIndex={tabsOverflows && !tabsAtEnd ? 0 : -1}
         >
           <i className="bi bi-chevron-right"></i>
         </button>

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
-import { useState, useEffect, useRef, useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
 import { Button, Card } from '@govtechsg/sgds-react';
 import { useParams, Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { useAnalysisData } from '@features/analysis/hooks/useAnalysisData';
@@ -111,6 +111,20 @@ export const AnalysisPage = () => {
   const [totalFindings, setTotalFindings] = useState<number | undefined>(undefined);
   const [totalRiskMatrix, setTotalRiskMatrix] = useState<number | undefined>(undefined);
   const storyTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const tabsRef = useRef<HTMLUListElement>(null);
+  const [tabsScrollLeft, setTabsScrollLeft] = useState(0);
+  const [tabsOverflows, setTabsOverflows] = useState(false);
+
+  const tabsRefCallback = useCallback((el: HTMLUListElement | null) => {
+    (tabsRef as React.MutableRefObject<HTMLUListElement | null>).current = el;
+    if (!el) return;
+    const check = () => setTabsOverflows(el.scrollWidth > el.clientWidth);
+    check();
+    setTimeout(check, 50);
+    setTimeout(check, 300);
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+  }, []);
 
   useEffect(() => {
     apiClient
@@ -406,10 +420,21 @@ export const AnalysisPage = () => {
       </div>
 
       {/* Navigation Tabs */}
-      <ul
-        className="nav nav-tabs"
-        style={{ borderBottom: 'none', paddingTop: '1px' }}
-      >
+      <div className="nav-tabs-scroll-wrapper">
+        <button
+          className="nav-tabs-scroll-btn"
+          style={{ visibility: tabsOverflows && tabsScrollLeft > 0 ? 'visible' : 'hidden' }}
+          onClick={() => { tabsRef.current?.scrollBy({ left: -150, behavior: 'smooth' }); }}
+          aria-label="Scroll tabs left"
+        >
+          <i className="bi bi-chevron-left"></i>
+        </button>
+        <ul
+          ref={tabsRefCallback}
+          className="nav nav-tabs"
+          style={{ borderBottom: 'none', paddingTop: '1px' }}
+          onScroll={e => setTabsScrollLeft((e.currentTarget as HTMLUListElement).scrollLeft)}
+        >
         <li className="nav-item">
           <button
             style={{ whiteSpace: 'nowrap' }}
@@ -474,7 +499,17 @@ export const AnalysisPage = () => {
             <i className="bi bi-globe-europe-africa me-2"></i>Network Intelligence
           </button>
         </li>
-      </ul>
+        </ul>
+        <button
+          className="nav-tabs-scroll-btn"
+          style={{ visibility: tabsOverflows ? 'visible' : 'hidden' }}
+          onClick={() => { tabsRef.current?.scrollBy({ left: 150, behavior: 'smooth' }); }}
+          aria-label="Scroll tabs right"
+          tabIndex={tabsOverflows ? 0 : -1}
+        >
+          <i className="bi bi-chevron-right"></i>
+        </button>
+      </div>
 
       {/* Tab Content */}
       <Card>


### PR DESCRIPTION
## Summary

- Wraps `nav-tabs` in a flex container with left/right chevron buttons that appear when tabs overflow horizontally
- Moves `overflow-x: auto`, `flex-wrap: nowrap`, and `width: 0` to the CSS class so the browser correctly constrains the list before measurement
- Hides the scrollbar visually while keeping scroll functionality
- Uses a ref callback for reliable post-layout DOM measurement

## Background

This is a recurring regression — see #315 for the full history. The fix has been accidentally reverted twice (#311) because `overflow-x: auto` looks like it causes a scrollbar. The chevrons + hidden scrollbar solve both problems cleanly.

Closes #236
Closes #315

## Test plan
- [ ] Open an analysis page and narrow the browser to ~500px width
- [ ] Right chevron `›` appears when tabs overflow
- [ ] Clicking it scrolls the tabs right smoothly
- [ ] Left chevron `‹` appears after scrolling right
- [ ] No visible scrollbar at any width
- [ ] At full width, both chevrons are hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)