### PR TITLE
fix: restore Packets/Session tab visibility in conversation modal

### DIFF
--- a/frontend/src/assets/styles/sgds-overrides.css
+++ b/frontend/src/assets/styles/sgds-overrides.css
@@ -478,7 +478,7 @@
 .card-header button.nav-link {
   display: inline-block !important;
   padding: 0.5rem 1rem !important;
-  color: #495057 !important;
+  color: var(--tp-text-muted, #495057) !important;
   background-color: transparent !important;
   border: 1px solid transparent !important;
   border-top-left-radius: 0.3125rem !important;
@@ -489,14 +489,14 @@
 }
 
 .card-header button.nav-link.active {
-  color: #1d2939 !important;
-  background-color: #fff !important;
-  border-color: #dee2e6 #dee2e6 #fff !important;
+  color: var(--tp-text, #1d2939) !important;
+  background-color: var(--tp-surface, #fff) !important;
+  border-color: var(--tp-border, #dee2e6) var(--tp-border, #dee2e6) var(--tp-surface, #fff) !important;
 }
 
 .card-header button.nav-link:hover:not(.active) {
-  color: #1d2939 !important;
-  border-color: #e9ecef #e9ecef transparent !important;
+  color: var(--tp-text, #1d2939) !important;
+  border-color: var(--tp-border, #e9ecef) var(--tp-border, #e9ecef) transparent !important;
 }
 
 [data-theme='dark'] .card-header button.nav-link {

--- a/frontend/src/assets/styles/sgds-overrides.css
+++ b/frontend/src/assets/styles/sgds-overrides.css
@@ -464,3 +464,47 @@
   background-color: var(--tp-surface) !important;
   color: var(--tp-text) !important;
 }
+
+/* Restore visibility of nav-tab buttons inside card-header when inside an SGDS modal context.
+   SGDS .sgds.nav-tabs collapses the ul to width:0 via flex layout. */
+.card-header ul.nav-tabs {
+  display: flex !important;
+  flex-direction: row !important;
+  width: auto !important;
+  min-width: 0 !important;
+}
+
+
+.card-header button.nav-link {
+  display: inline-block !important;
+  padding: 0.5rem 1rem !important;
+  color: #495057 !important;
+  background-color: transparent !important;
+  border: 1px solid transparent !important;
+  border-top-left-radius: 0.3125rem !important;
+  border-top-right-radius: 0.3125rem !important;
+  cursor: pointer !important;
+  font-size: 1rem !important;
+  line-height: 1.5 !important;
+}
+
+.card-header button.nav-link.active {
+  color: #1d2939 !important;
+  background-color: #fff !important;
+  border-color: #dee2e6 #dee2e6 #fff !important;
+}
+
+.card-header button.nav-link:hover:not(.active) {
+  color: #1d2939 !important;
+  border-color: #e9ecef #e9ecef transparent !important;
+}
+
+[data-theme='dark'] .card-header button.nav-link {
+  color: var(--tp-text-muted, #adb5bd) !important;
+}
+
+[data-theme='dark'] .card-header button.nav-link.active {
+  color: var(--tp-text) !important;
+  background-color: var(--tp-surface) !important;
+  border-color: var(--tp-border) var(--tp-border) var(--tp-surface) !important;
+}

--- a/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
+++ b/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
@@ -461,7 +461,7 @@ export const ConversationDetail = ({
         </Card.Body>
       </div>
 
-      <div className="card">
+      <Card>
         <Card.Header>
           <ul className="nav nav-tabs card-header-tabs">
             <li className="nav-item">
@@ -628,7 +628,7 @@ export const ConversationDetail = ({
             <SessionTab conversationId={conversation.id} protocol={conversation.protocol.name} />
           </Card.Body>
         )}
-      </div>
+      </Card>
 
       {devicePopup && (
         <DeviceClassificationPopup info={devicePopup} onClose={() => setDevicePopup(null)} />

--- a/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
+++ b/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
@@ -226,7 +226,7 @@ export const ConversationDetail = ({
 
   return (
     <div className="conversation-detail">
-      <div className="card mb-4">
+      <Card className="mb-4">
         <Card.Header className="d-flex align-items-center justify-content-between">
           <h5 className="mb-0">Conversation Details</h5>
           {extractedCount != null && extractedCount > 0 && fileId && (
@@ -459,10 +459,10 @@ export const ConversationDetail = ({
             </div>
           </div>
         </Card.Body>
-      </div>
+      </Card>
 
-      <Card>
-        <Card.Header>
+      <div className="card">
+        <div className="card-header">
           <ul className="nav nav-tabs card-header-tabs">
             <li className="nav-item">
               <button
@@ -484,7 +484,7 @@ export const ConversationDetail = ({
               </button>
             </li>
           </ul>
-        </Card.Header>
+        </div>
 
         {activeTab === 'packets' && (
           <Card.Body className="p-0">
@@ -628,7 +628,7 @@ export const ConversationDetail = ({
             <SessionTab conversationId={conversation.id} protocol={conversation.protocol.name} />
           </Card.Body>
         )}
-      </Card>
+      </div>
 
       {devicePopup && (
         <DeviceClassificationPopup info={devicePopup} onClose={() => setDevicePopup(null)} />


### PR DESCRIPTION
## Root cause
SGDS `<Modal>` wraps content in `SGDSWrapper` which adds a `.sgds` class as an ancestor. This causes SGDS's `.sgds.nav-tabs` flex rules to collapse `ul.nav-tabs` to `width: 0`, making the Packets/Session tab buttons invisible and unclickable.

## Changes
- Add CSS overrides in `sgds-overrides.css` to restore `display: flex` and `width: auto` on `.card-header ul.nav-tabs`, and fix button visibility/styling using CSS variables with hex fallbacks
- Replace bare `<div className="card">` with SGDS `<Card>` for the conversation details card (first card only — the tabs card is intentionally kept as a plain `div.card` to avoid re-triggering the SGDS flex collapse)

## Test plan
- [ ] Open a conversation detail modal and verify Packets/Session tabs are visible and clickable
- [ ] Verify tabs work correctly in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)