### PR TITLE
fix: guard against short timestamp strings in StoryService

### DIFF
--- a/backend/src/main/java/com/tracepcap/story/service/StoryService.java
+++ b/backend/src/main/java/com/tracepcap/story/service/StoryService.java
@@ -647,7 +647,7 @@ public class StoryService {
             String risks = ev.getFlowRisks() != null ? String.join(",", ev.getFlowRisks()) : "";
             String app = ev.getAppName() != null ? ev.getAppName() : "-";
             String startRaw = ev.getStartTime() != null ? ev.getStartTime() : "-";
-            String start = startRaw.length() >= 19 ? startRaw.substring(11, 19) : startRaw;
+            String start = startRaw.length() >= 11 ? startRaw.substring(11, Math.min(startRaw.length(), 19)) : startRaw;
             prompt.append(
                 String.format(
                     "| %s | %s | %d | %s | %s | %d | %s | %s |\n",
@@ -680,8 +680,7 @@ public class StoryService {
     prompt.append("| time | packets | bytes | notes |\n");
     prompt.append("|------|---------|-------|-------|\n");
     for (TimelineDataDto bin : bins) {
-      String tsRaw = bin.getTimestamp() != null ? bin.getTimestamp().toString() : "-";
-      String ts = tsRaw.length() >= 19 ? tsRaw.substring(0, 19) : tsRaw;
+      String ts = bin.getTimestamp() != null ? bin.getTimestamp().format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")) : "-";
       long bytes = bin.getBytes() != null ? bin.getBytes() : 0;
       String bytesHuman =
           bytes > 1_048_576

--- a/backend/src/main/java/com/tracepcap/story/service/StoryService.java
+++ b/backend/src/main/java/com/tracepcap/story/service/StoryService.java
@@ -646,7 +646,8 @@ public class StoryService {
           for (ConversationEvidence ev : step.getConversations()) {
             String risks = ev.getFlowRisks() != null ? String.join(",", ev.getFlowRisks()) : "";
             String app = ev.getAppName() != null ? ev.getAppName() : "-";
-            String start = ev.getStartTime() != null ? ev.getStartTime().substring(11, 19) : "-";
+            String startRaw = ev.getStartTime() != null ? ev.getStartTime() : "-";
+            String start = startRaw.length() >= 19 ? startRaw.substring(11, 19) : startRaw;
             prompt.append(
                 String.format(
                     "| %s | %s | %d | %s | %s | %d | %s | %s |\n",
@@ -679,7 +680,8 @@ public class StoryService {
     prompt.append("| time | packets | bytes | notes |\n");
     prompt.append("|------|---------|-------|-------|\n");
     for (TimelineDataDto bin : bins) {
-      String ts = bin.getTimestamp() != null ? bin.getTimestamp().toString().substring(0, 19) : "-";
+      String tsRaw = bin.getTimestamp() != null ? bin.getTimestamp().toString() : "-";
+      String ts = tsRaw.length() >= 19 ? tsRaw.substring(0, 19) : tsRaw;
       long bytes = bin.getBytes() != null ? bin.getBytes() : 0;
       String bytesHuman =
           bytes > 1_048_576


### PR DESCRIPTION
## Summary

Guards two unsafe `substring` calls in `StoryService.java` that assumed timestamps are always ≥19 chars, causing `StringIndexOutOfBoundsException` and a 500 error when generating a story narrative.

Closes #326

## Root Cause

- `ev.getStartTime().substring(11, 19)` — extracts time portion `HH:mm:ss`
- `bin.getTimestamp().toString().substring(0, 19)` — truncates to `yyyy-MM-ddTHH:mm:ss`

Both crash when the timestamp is only 16 chars (e.g. `2024-01-01T12:00`), which is valid ISO-8601 but shorter than assumed.

## Fix

Added a length check before each `substring` call — falls back to the full string if it's shorter than expected.

## Test Plan

- [ ] Upload a PCAP and trigger story generation — should complete without 500 error
- [ ] Verify short-format timestamps (16 chars) in timeline/conversation data are handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)