### PR TITLE
fix: hierarchical layout stuck on "Computing layout..." spinner

### DIFF
--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -541,14 +541,18 @@ export const NetworkGraph = memo(function NetworkGraph({
 
     // ── Layout ────────────────────────────────────────────────────────────────
 
+    let cancelled = false;
+
     if (layoutType === 'hierarchicalTd') {
       setLayouting(true);
       applyHierarchicalLayout(graph, elkRef.current!).then(() => {
+        if (cancelled) return;
         sigma.refresh();
         sigma.getCamera().animate({ ratio: 1 }, { duration: 400 });
         setLayouting(false);
         requestAnimationFrame(() => onLayoutCompleteRef.current?.());
       }).catch(err => {
+        if (cancelled) return;
         console.error('[NetworkGraph] ELK hierarchical layout failed:', err);
         setLayouting(false);
       });
@@ -562,6 +566,7 @@ export const NetworkGraph = memo(function NetworkGraph({
     }
 
     return () => {
+      cancelled = true;
       sigmaRef.current?.kill();
       sigmaRef.current = null;
       elkRef.current?.terminateWorker();

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -543,6 +543,12 @@ export const NetworkGraph = memo(function NetworkGraph({
 
     let cancelled = false;
 
+    if (!elkRef.current) {
+      elkRef.current = new ELK({
+        workerFactory: () => new Worker(ELK_WORKER_URL, { type: 'classic' }),
+      });
+    }
+
     if (layoutType === 'hierarchicalTd') {
       setLayouting(true);
       applyHierarchicalLayout(graph, elkRef.current!).then(() => {


### PR DESCRIPTION
Closes #331

## Summary
- Add a \`cancelled\` boolean flag scoped to each \`useEffect\` run in \`NetworkGraph\`
- Cleanup sets \`cancelled = true\` before terminating the ELK worker
- The ELK \`.then()\` / \`.catch()\` callbacks check \`cancelled\` and bail early, preventing a stale promise from a torn-down effect calling \`setLayouting(false)\` and interfering with the current run

**Note:** The primary cause of the spinner getting permanently stuck is if \`elk-worker.min.js\` is not served (returns 404) — the ELK promise never resolves or rejects. This file must exist in \`frontend/public/\`. TracePcap already has it; this fix addresses the secondary race condition on top of that.

## Test plan
- [ ] Switch to hierarchical layout — spinner should appear briefly then disappear once layout completes
- [ ] Toggle dark mode while hierarchical layout is active — layout should recompute without getting stuck
- [ ] Upload a new file while on hierarchical layout — layout should recompute cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)