### PR TITLE
fix: strip <think> blocks from LLM response in FilterService

### DIFF
--- a/backend/src/main/java/com/tracepcap/filter/service/FilterService.java
+++ b/backend/src/main/java/com/tracepcap/filter/service/FilterService.java
@@ -463,15 +463,17 @@ public class FilterService {
     return suggestions.isEmpty() ? null : suggestions;
   }
 
-  /** Clean JSON response by removing markdown code blocks if present */
+  /**
+   * Extract JSON object from LLM response, stripping markdown code fences,
+   * &lt;think&gt; reasoning blocks, and any other surrounding text.
+   */
   private String cleanJsonResponse(String response) {
     if (response == null) return null;
-    String cleaned = response.trim();
-    if (cleaned.startsWith("```")) {
-      int firstNewline = cleaned.indexOf('\n');
-      if (firstNewline != -1) cleaned = cleaned.substring(firstNewline + 1);
-      if (cleaned.endsWith("```")) cleaned = cleaned.substring(0, cleaned.lastIndexOf("```"));
-      cleaned = cleaned.trim();
+    String cleaned = response.replaceAll("```json\\s*", "").replaceAll("```\\s*", "").trim();
+    int start = cleaned.indexOf('{');
+    int end = cleaned.lastIndexOf('}');
+    if (start >= 0 && end > start) {
+      return cleaned.substring(start, end + 1);
     }
     return cleaned;
   }


### PR DESCRIPTION
## Summary

- Filter generation silently fails when using reasoning models (MiniMax, DeepSeek-R1, QwQ, etc.) that wrap output in `<think>...</think>` blocks before the actual JSON
- `cleanJsonResponse()` only stripped markdown code fences — the `<think>` preamble caused `objectMapper.readTree()` to throw `JsonProcessingException` on all 3 retries, resulting in an `LlmException` with no visible error to the user
- Fix: replace the fence-stripping logic with the same `indexOf('{')` / `lastIndexOf('}')` extraction already used in `StoryService.extractJson()`, which naturally skips any preamble

## Test plan

- [ ] With a reasoning model (e.g. MiniMax, DeepSeek-R1), open Filter Generator, type a query, and click Generate Filter — should return a valid filter instead of failing silently
- [ ] With a standard model, verify filter generation still works correctly
- [ ] Verify markdown-fenced JSON responses (`\`\`\`json ... \`\`\``) still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)