### PR TITLE
fix: bump nDPI version from 5.0.0-5922 to 5.0.0-5933

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@ FROM eclipse-temurin:21-jre-jammy
 # nDPI version pin — bump this arg to upgrade nDPI without changing anything else.
 # Current pinned version is sourced from ntop's stable apt repo for Ubuntu 22.04.
 # To find available versions: apt-cache policy ndpi (after adding ntop repo).
-ARG NDPI_VERSION=5.0.0-5922
+ARG NDPI_VERSION=5.0.0-5933
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- The pinned nDPI version `5.0.0-5922` was removed from the ntop stable apt repo for Ubuntu 22.04, causing backend image builds to fail with exit code 100 (package not found)
- Bumped `NDPI_VERSION` in `backend/Dockerfile` to `5.0.0-5933`, the current available version

## Test plan
- [ ] Run `docker compose up -d --build` and confirm the backend image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)