### PR TITLE
feat: allow public IPs to be manually labelled as private

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ PCAP, PCAPNG, CAP (max 512MB default, configurable via `MAX_UPLOAD_SIZE_BYTES`)
 
 ## How Network Monitor Works
 
-The Monitor is designed for black-box analysis — it assumes you know nothing about the network upfront and builds understanding from the traffic itself:
+The Monitor is designed for black-box retrospective analysis — it assumes you know nothing about the network upfront and builds understanding from the traffic itself:
 
 - **No prior knowledge needed** — subnet structure, device roles, and topology are all inferred from observed traffic
 - **Snapshots, not agents** — there is no persistent sensor; you feed in PCAPs and the tool compares them

--- a/backend/src/main/java/com/tracepcap/file/service/StorageServiceImpl.java
+++ b/backend/src/main/java/com/tracepcap/file/service/StorageServiceImpl.java
@@ -36,11 +36,13 @@ public class StorageServiceImpl implements StorageService {
       if (contentType == null || contentType.isBlank()) {
         contentType = "application/octet-stream";
       }
-      minioClient.putObject(
-          PutObjectArgs.builder().bucket(minioConfig.getBucket()).object(fileName).stream(
-                  file.getInputStream(), file.getSize(), -1)
-              .contentType(contentType)
-              .build());
+      try (var is = file.getInputStream()) {
+        minioClient.putObject(
+            PutObjectArgs.builder().bucket(minioConfig.getBucket()).object(fileName).stream(
+                    is, file.getSize(), -1)
+                .contentType(contentType)
+                .build());
+      }
 
       log.info("Successfully uploaded file: {} to MinIO", fileName);
       return fileName;

--- a/backend/src/main/java/com/tracepcap/intelligence/controller/CustomPrivateRangeController.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/controller/CustomPrivateRangeController.java
@@ -1,0 +1,42 @@
+package com.tracepcap.intelligence.controller;
+
+import com.tracepcap.intelligence.dto.CustomPrivateRangeDto;
+import com.tracepcap.intelligence.service.CustomPrivateRangeService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/custom-private-ranges")
+@RequiredArgsConstructor
+public class CustomPrivateRangeController {
+
+  private final CustomPrivateRangeService service;
+
+  @GetMapping
+  public List<CustomPrivateRangeDto> list() {
+    return service.list();
+  }
+
+  @PostMapping
+  public ResponseEntity<?> create(@RequestBody CustomPrivateRangeDto dto) {
+    if (dto.getCidr() == null || dto.getCidr().isBlank()) {
+      return ResponseEntity.badRequest().body("IP address or CIDR is required");
+    }
+    try {
+      return ResponseEntity.ok(service.create(dto));
+    } catch (DataIntegrityViolationException e) {
+      return ResponseEntity.badRequest().body("This CIDR is already in the list");
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    service.delete(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/src/main/java/com/tracepcap/intelligence/dto/CustomPrivateRangeDto.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/dto/CustomPrivateRangeDto.java
@@ -1,0 +1,16 @@
+package com.tracepcap.intelligence.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomPrivateRangeDto {
+  private Long id;
+  private String cidr;
+  private String label;
+}

--- a/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
@@ -1,0 +1,30 @@
+package com.tracepcap.intelligence.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "custom_private_ranges")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomPrivateRangeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String cidr;
+
+  @Column
+  private String label;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/tracepcap/intelligence/repository/CustomPrivateRangeRepository.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/repository/CustomPrivateRangeRepository.java
@@ -1,0 +1,9 @@
+package com.tracepcap.intelligence.repository;
+
+import com.tracepcap.intelligence.entity.CustomPrivateRangeEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomPrivateRangeRepository extends JpaRepository<CustomPrivateRangeEntity, Long> {
+  List<CustomPrivateRangeEntity> findAllByOrderByCreatedAtDesc();
+}

--- a/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,10 @@ public class CustomPrivateRangeService {
   private static final ConcurrentHashMap<String, Optional<ParsedCidr>> cidrCache =
       new ConcurrentHashMap<>();
 
+  // Matches dotted-decimal IPv4 or hex-colon IPv6 — rejects hostnames before DNS lookup
+  private static final Pattern NUMERIC_IP =
+      Pattern.compile("^(\\d{1,3}\\.){3}\\d{1,3}$|^[0-9a-fA-F]*:[0-9a-fA-F:.]*$");
+
   public List<CustomPrivateRangeDto> list() {
     return repository.findAllByOrderByCreatedAtDesc().stream()
         .map(e -> CustomPrivateRangeDto.builder().id(e.getId()).cidr(e.getCidr()).label(e.getLabel()).build())
@@ -32,13 +37,19 @@ public class CustomPrivateRangeService {
 
   public CustomPrivateRangeDto create(CustomPrivateRangeDto dto) {
     String cidr = dto.getCidr().trim();
+    // Determine IP and optional prefix parts
+    String ipPart = cidr.contains("/") ? cidr.split("/")[0].trim() : cidr;
+    // Reject hostnames — only numeric IPs are accepted to prevent DNS resolution
+    if (!NUMERIC_IP.matcher(ipPart).matches()) {
+      throw new IllegalArgumentException("Invalid IP address: " + ipPart);
+    }
     // Normalise bare IP to /32 or /128
     if (!cidr.contains("/")) {
       try {
-        InetAddress addr = InetAddress.getByName(cidr);
-        cidr = cidr + (addr.getAddress().length == 4 ? "/32" : "/128");
+        InetAddress addr = InetAddress.getByName(ipPart);
+        cidr = addr.getHostAddress() + (addr.getAddress().length == 4 ? "/32" : "/128");
       } catch (Exception e) {
-        throw new IllegalArgumentException("Invalid IP address: " + cidr);
+        throw new IllegalArgumentException("Invalid IP address: " + ipPart);
       }
     }
     // Validate CIDR
@@ -50,23 +61,29 @@ public class CustomPrivateRangeService {
       int prefix = Integer.parseInt(parts[1].trim());
       if (prefix < 0 || prefix > prefixMax)
         throw new IllegalArgumentException("Prefix length out of range for " + cidr);
+      cidr = addr.getHostAddress() + "/" + prefix;
     } catch (IllegalArgumentException e) {
       throw e;
     } catch (Exception e) {
       throw new IllegalArgumentException("Invalid IP address in CIDR: " + cidr);
     }
     String label = dto.getLabel() != null && !dto.getLabel().isBlank() ? dto.getLabel().trim() : null;
+    if (label != null && label.length() > 255) {
+      throw new IllegalArgumentException("Label cannot exceed 255 characters");
+    }
     CustomPrivateRangeEntity entity = CustomPrivateRangeEntity.builder()
         .cidr(cidr)
         .label(label)
         .createdAt(LocalDateTime.now())
         .build();
     entity = repository.save(entity);
+    cidrCache.clear();
     return CustomPrivateRangeDto.builder().id(entity.getId()).cidr(entity.getCidr()).label(entity.getLabel()).build();
   }
 
   public void delete(Long id) {
     repository.deleteById(id);
+    cidrCache.clear();
   }
 
   /** Loads all custom private ranges for use in batch classification. */

--- a/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
@@ -1,0 +1,127 @@
+package com.tracepcap.intelligence.service;
+
+import com.tracepcap.intelligence.dto.CustomPrivateRangeDto;
+import com.tracepcap.intelligence.entity.CustomPrivateRangeEntity;
+import com.tracepcap.intelligence.repository.CustomPrivateRangeRepository;
+import java.net.InetAddress;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomPrivateRangeService {
+
+  private final CustomPrivateRangeRepository repository;
+
+  private record ParsedCidr(byte[] networkBytes, int prefixLen) {}
+  private static final ConcurrentHashMap<String, Optional<ParsedCidr>> cidrCache =
+      new ConcurrentHashMap<>();
+
+  public List<CustomPrivateRangeDto> list() {
+    return repository.findAllByOrderByCreatedAtDesc().stream()
+        .map(e -> CustomPrivateRangeDto.builder().id(e.getId()).cidr(e.getCidr()).label(e.getLabel()).build())
+        .collect(Collectors.toList());
+  }
+
+  public CustomPrivateRangeDto create(CustomPrivateRangeDto dto) {
+    String cidr = dto.getCidr().trim();
+    // Normalise bare IP to /32 or /128
+    if (!cidr.contains("/")) {
+      try {
+        InetAddress addr = InetAddress.getByName(cidr);
+        cidr = cidr + (addr.getAddress().length == 4 ? "/32" : "/128");
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Invalid IP address: " + cidr);
+      }
+    }
+    // Validate CIDR
+    String[] parts = cidr.split("/");
+    if (parts.length != 2) throw new IllegalArgumentException("Invalid CIDR format: " + cidr);
+    try {
+      InetAddress addr = InetAddress.getByName(parts[0].trim());
+      int prefixMax = (addr.getAddress().length == 4) ? 32 : 128;
+      int prefix = Integer.parseInt(parts[1].trim());
+      if (prefix < 0 || prefix > prefixMax)
+        throw new IllegalArgumentException("Prefix length out of range for " + cidr);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid IP address in CIDR: " + cidr);
+    }
+    String label = dto.getLabel() != null && !dto.getLabel().isBlank() ? dto.getLabel().trim() : null;
+    CustomPrivateRangeEntity entity = CustomPrivateRangeEntity.builder()
+        .cidr(cidr)
+        .label(label)
+        .createdAt(LocalDateTime.now())
+        .build();
+    entity = repository.save(entity);
+    return CustomPrivateRangeDto.builder().id(entity.getId()).cidr(entity.getCidr()).label(entity.getLabel()).build();
+  }
+
+  public void delete(Long id) {
+    repository.deleteById(id);
+  }
+
+  /** Loads all custom private ranges for use in batch classification. */
+  public List<CustomPrivateRangeEntity> loadRanges() {
+    return repository.findAllByOrderByCreatedAtDesc();
+  }
+
+  /**
+   * Returns true if the IP falls within any of the preloaded custom private ranges.
+   * Call {@link #loadRanges()} once and reuse the list across many IP checks.
+   */
+  public boolean isOverriddenPrivate(String ip, List<CustomPrivateRangeEntity> ranges) {
+    if (ip == null || ranges.isEmpty()) return false;
+    for (CustomPrivateRangeEntity range : ranges) {
+      if (inCidr(ip, range.getCidr())) return true;
+    }
+    return false;
+  }
+
+  private boolean inCidr(String ip, String cidr) {
+    if (ip == null || cidr == null) return false;
+    try {
+      Optional<ParsedCidr> opt = cidrCache.computeIfAbsent(cidr, this::parseCidr);
+      if (opt.isEmpty()) return false;
+      ParsedCidr parsed = opt.get();
+      byte[] addrBytes = InetAddress.getByName(ip).getAddress();
+      byte[] netBytes = parsed.networkBytes();
+      int prefixLen = parsed.prefixLen();
+      if (netBytes.length != addrBytes.length) return false;
+      int fullBytes = prefixLen / 8;
+      int remainingBits = prefixLen % 8;
+      for (int i = 0; i < fullBytes; i++) {
+        if (netBytes[i] != addrBytes[i]) return false;
+      }
+      if (remainingBits > 0 && fullBytes < netBytes.length) {
+        int mask = 0xFF & (0xFF << (8 - remainingBits));
+        if ((netBytes[fullBytes] & mask) != (addrBytes[fullBytes] & mask)) return false;
+      }
+      return true;
+    } catch (Exception e) {
+      log.warn("CIDR match error ip={} cidr={}: {}", ip, cidr, e.getMessage());
+      return false;
+    }
+  }
+
+  private Optional<ParsedCidr> parseCidr(String cidr) {
+    try {
+      String[] parts = cidr.split("/");
+      if (parts.length != 2) return Optional.empty();
+      byte[] networkBytes = InetAddress.getByName(parts[0].trim()).getAddress();
+      int prefixLen = Integer.parseInt(parts[1].trim());
+      return Optional.of(new ParsedCidr(networkBytes, prefixLen));
+    } catch (Exception e) {
+      log.warn("Failed to pre-parse CIDR {}: {}", cidr, e.getMessage());
+      return Optional.empty();
+    }
+  }
+}

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -6,6 +6,8 @@ import com.tracepcap.analysis.entity.IpGeoInfoEntity;
 import com.tracepcap.analysis.repository.ConversationRepository;
 import com.tracepcap.analysis.repository.HostClassificationRepository;
 import com.tracepcap.analysis.repository.IpGeoInfoRepository;
+import com.tracepcap.intelligence.entity.CustomPrivateRangeEntity;
+import com.tracepcap.intelligence.service.CustomPrivateRangeService;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.ChangeType;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.EntityType;
@@ -49,6 +51,7 @@ public class ChangeDetectionService {
   private final ConversationRepository conversationRepository;
   private final IpGeoInfoRepository ipGeoInfoRepository;
   private final NetworkChangeEventRepository changeEventRepository;
+  private final CustomPrivateRangeService customPrivateRangeService;
 
   /**
    * Compare two consecutive snapshots and persist NetworkChangeEventEntity records. fromSnapshot
@@ -180,8 +183,9 @@ public class ChangeDetectionService {
 
     if (fromFileId == null) return List.of();
 
-    Set<String> fromExternalIps = externalIpsForFile(fromFileId);
-    Set<String> toExternalIps = externalIpsForFile(toFileId);
+    List<CustomPrivateRangeEntity> customRanges = customPrivateRangeService.loadRanges();
+    Set<String> fromExternalIps = externalIpsForFile(fromFileId, customRanges);
+    Set<String> toExternalIps = externalIpsForFile(toFileId, customRanges);
 
     Map<String, IpGeoInfoEntity> fromGeo = geoMapFor(fromExternalIps);
     Map<String, IpGeoInfoEntity> toGeo = geoMapFor(toExternalIps);
@@ -216,8 +220,8 @@ public class ChangeDetectionService {
     // Lost ASNs are not actionable on their own — gateway change covers the important case
 
     // Gateway heuristic: top-traffic external IP
-    String fromGateway = topExternalIp(fromFileId, fromGeo);
-    String toGateway = topExternalIp(toFileId, toGeo);
+    String fromGateway = topExternalIp(fromFileId, fromGeo, customRanges);
+    String toGateway = topExternalIp(toFileId, toGeo, customRanges);
     if (fromGateway != null && toGateway != null && !fromGateway.equals(toGateway)) {
       IpGeoInfoEntity fromGeoEntry = fromGeo.get(fromGateway);
       IpGeoInfoEntity toGeoEntry = toGeo.get(toGateway);
@@ -386,11 +390,11 @@ public class ChangeDetectionService {
     return result;
   }
 
-  private Set<String> externalIpsForFile(UUID fileId) {
+  private Set<String> externalIpsForFile(UUID fileId, List<CustomPrivateRangeEntity> customRanges) {
     if (fileId == null) return Set.of();
     return conversationRepository.findByFileId(fileId).stream()
         .flatMap(c -> Stream.of(c.getSrcIp(), c.getDstIp()))
-        .filter(ip -> ip != null && !isPrivate(ip))
+        .filter(ip -> ip != null && !isPrivate(ip, customRanges))
         .collect(Collectors.toSet());
   }
 
@@ -413,15 +417,15 @@ public class ChangeDetectionService {
   }
 
   /** Returns the external IP with the highest total bytes for a file (gateway heuristic). */
-  private String topExternalIp(UUID fileId, Map<String, IpGeoInfoEntity> geoMap) {
+  private String topExternalIp(UUID fileId, Map<String, IpGeoInfoEntity> geoMap, List<CustomPrivateRangeEntity> customRanges) {
     if (fileId == null || geoMap.isEmpty()) return null;
     Map<String, Long> ipBytes = new HashMap<>();
     for (ConversationEntity c : conversationRepository.findByFileId(fileId)) {
       String dst = c.getDstIp();
       String src = c.getSrcIp();
       String external = null;
-      if (dst != null && !isPrivate(dst) && geoMap.containsKey(dst)) external = dst;
-      else if (src != null && !isPrivate(src) && geoMap.containsKey(src)) external = src;
+      if (dst != null && !isPrivate(dst, customRanges) && geoMap.containsKey(dst)) external = dst;
+      else if (src != null && !isPrivate(src, customRanges) && geoMap.containsKey(src)) external = src;
       if (external != null) {
         ipBytes.merge(external, c.getTotalBytes() != null ? c.getTotalBytes() : 0L, Long::sum);
       }
@@ -456,7 +460,7 @@ public class ChangeDetectionService {
         .collect(Collectors.toSet());
   }
 
-  private static boolean isPrivate(String ip) {
+  private boolean isPrivate(String ip, List<CustomPrivateRangeEntity> customRanges) {
     if (ip == null) return true;
     for (String prefix : PRIVATE_PREFIXES) {
       if (ip.startsWith(prefix)) return true;
@@ -471,7 +475,7 @@ public class ChangeDetectionService {
         } catch (NumberFormatException ignored) { }
       }
     }
-    return false;
+    return customPrivateRangeService.isOverriddenPrivate(ip, customRanges);
   }
 
   private static String orEmpty(String s) {

--- a/backend/src/main/resources/db/migration/V13__custom_private_ranges.sql
+++ b/backend/src/main/resources/db/migration/V13__custom_private_ranges.sql
@@ -1,0 +1,6 @@
+CREATE TABLE custom_private_ranges (
+    id         BIGSERIAL    PRIMARY KEY,
+    cidr       VARCHAR(50)  NOT NULL UNIQUE,
+    label      VARCHAR(255),
+    created_at TIMESTAMP    NOT NULL DEFAULT NOW()
+);

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -151,8 +151,9 @@ function PrivateOverridesSection({
     try {
       await customPrivateRangeService.delete(id);
       onDeleted(id);
-    } catch {
-      // ignore
+    } catch (e: unknown) {
+      const msg = (e as { response?: { data?: unknown } })?.response?.data;
+      setAddError(typeof msg === 'string' ? msg : 'Failed to delete range');
     }
   };
 

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -4,6 +4,8 @@ import { Button } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
 import type { NetworkSnapshot, AbsentEntity } from '@/features/monitor/types/monitor.types';
 import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
+import { customPrivateRangeService } from '@/features/intelligence/services/customPrivateRangeService';
+import type { CustomPrivateRange } from '@/features/intelligence/types/customPrivateRange.types';
 import { EntityDetailModal } from '@components/common/EntityDetailModal';
 
 interface IpDriftPanelProps {
@@ -27,8 +29,13 @@ interface ConversationsResponse {
   data: ConversationSummary[];
 }
 
-function isPrivateIp(ip: string): boolean {
+function isRfc1918(ip: string): boolean {
   return /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|169\.254\.|f[cd][0-9a-f]{2}:|fe80:)/i.test(ip);
+}
+
+function isPrivateIp(ip: string, customRanges: CustomPrivateRange[]): boolean {
+  if (isRfc1918(ip)) return true;
+  return customRanges.some(r => ipInCidr(ip, r.cidr));
 }
 
 function ipToInt(ip: string): number {
@@ -45,7 +52,6 @@ function ipInCidr(ip: string, cidr: string): boolean {
     return false;
   }
 }
-
 
 function stringHue(s: string): number {
   let h = 0;
@@ -108,11 +114,135 @@ function IpBadgeGroup({
   );
 }
 
+function PrivateOverridesSection({
+  customRanges,
+  onSaved,
+  onDeleted,
+}: {
+  customRanges: CustomPrivateRange[];
+  onSaved: (r: CustomPrivateRange) => void;
+  onDeleted: (id: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [cidr, setCidr] = useState('');
+  const [label, setLabel] = useState('');
+  const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const handleAdd = async () => {
+    const trimmed = cidr.trim();
+    if (!trimmed) return;
+    setAdding(true);
+    setAddError(null);
+    try {
+      const created = await customPrivateRangeService.create(trimmed, label.trim());
+      onSaved(created);
+      setCidr('');
+      setLabel('');
+    } catch (e: unknown) {
+      const msg = (e as { response?: { data?: unknown } })?.response?.data;
+      setAddError(typeof msg === 'string' ? msg : 'Failed to add range');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await customPrivateRangeService.delete(id);
+      onDeleted(id);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="mt-3 pt-2 border-top">
+      <button
+        type="button"
+        className="btn btn-link btn-sm p-0 text-muted text-decoration-none d-flex align-items-center gap-1"
+        style={{ fontSize: '0.8rem' }}
+        onClick={() => setOpen(o => !o)}
+      >
+        <i className={`bi bi-chevron-${open ? 'up' : 'down'}`}></i>
+        <i className="bi bi-lock ms-1"></i>
+        Private IP overrides
+        {customRanges.length > 0 && (
+          <span className="badge bg-secondary ms-1" style={{ fontSize: '0.7rem' }}>
+            {customRanges.length}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="mt-2" style={{ fontSize: '0.82rem' }}>
+          <p className="text-muted mb-2" style={{ fontSize: '0.78rem' }}>
+            Add a public IP or CIDR that should be treated as internal (e.g. a public address used by a private terminal).
+          </p>
+          {customRanges.length > 0 && (
+            <table className="table table-sm table-borderless mb-2">
+              <tbody>
+                {customRanges.map(r => (
+                  <tr key={r.id}>
+                    <td className="font-monospace py-1 ps-0">{r.cidr}</td>
+                    <td className="text-muted py-1">{r.label ?? <em>—</em>}</td>
+                    <td className="text-end py-1 pe-0">
+                      <button
+                        type="button"
+                        className="btn btn-link btn-sm p-0 text-danger"
+                        onClick={() => handleDelete(r.id)}
+                        title="Remove override"
+                      >
+                        <i className="bi bi-trash"></i>
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+          <div className="d-flex gap-2 flex-wrap align-items-center">
+            <input
+              type="text"
+              className="form-control form-control-sm font-monospace"
+              style={{ maxWidth: 180 }}
+              placeholder="IP or CIDR"
+              value={cidr}
+              onChange={e => setCidr(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleAdd()}
+            />
+            <input
+              type="text"
+              className="form-control form-control-sm"
+              style={{ maxWidth: 160 }}
+              placeholder="Label (optional)"
+              value={label}
+              onChange={e => setLabel(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleAdd()}
+            />
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={handleAdd}
+              disabled={adding || !cidr.trim()}
+            >
+              {adding ? 'Adding…' : 'Add'}
+            </Button>
+          </div>
+          {addError && <div className="text-danger mt-1" style={{ fontSize: '0.78rem' }}>{addError}</div>}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => {
   const [selectedAbsent, setSelectedAbsent] = useState<AbsentEntity | null>(null);
   const [selectedIp, setSelectedIp] = useState<SelectedIp>(null);
   const [privateIps, setPrivateIps] = useState<EntityGroup>({ active: [], absent: [] });
   const [publicIps, setPublicIps] = useState<EntityGroup>({ active: [], absent: [] });
+  const [customRanges, setCustomRanges] = useState<CustomPrivateRange[]>([]);
   const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState('');
 
@@ -120,6 +250,10 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
   const latestSnap = sorted[sorted.length - 1];
   const latestFileId = latestSnap?.fileId ?? '';
   const latestStartTime = latestSnap?.startTime as unknown as string | null ?? null;
+
+  useEffect(() => {
+    customPrivateRangeService.list().then(setCustomRanges).catch(() => {});
+  }, []);
 
   useEffect(() => {
     if (sorted.length === 0) return;
@@ -172,12 +306,12 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
         return { active, absent };
       };
 
-      setPrivateIps(buildGroup(isPrivateIp));
-      setPublicIps(buildGroup(ip => !isPrivateIp(ip)));
+      setPrivateIps(buildGroup(ip => isPrivateIp(ip, customRanges)));
+      setPublicIps(buildGroup(ip => !isPrivateIp(ip, customRanges)));
       setLoading(false);
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [snapshots.map(s => s.id).join(',')]);
+  }, [snapshots.map(s => s.id).join(','), customRanges]);
 
   if (loading) {
     return <div className="text-muted small text-center py-3"><Spinner animation="border" size="sm" className="me-2" />Loading…</div>;
@@ -251,30 +385,32 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
               />
             </div>
           ))}
-          {(unmatchedActive.length > 0 || unmatchedAbsent.length > 0) && (
+          {unmatchedActive.filter(ip => isPrivateIp(ip, customRanges)).length > 0 || unmatchedAbsent.filter(e => isPrivateIp(e.key, customRanges)).length > 0 ? (
             <div className="mb-3">
               <small className="text-muted fw-semibold d-block mb-1">
-                <i className="bi bi-question-circle me-1"></i>Unmatched
+                <i className="bi bi-house me-1"></i>Private
               </small>
               <IpBadgeGroup
-                items={filterIps(unmatchedActive.filter(ip => isPrivateIp(ip)))}
-                absentItems={filterAbsent(unmatchedAbsent.filter(e => isPrivateIp(e.key)))}
+                items={filterIps(unmatchedActive.filter(ip => isPrivateIp(ip, customRanges)))}
+                absentItems={filterAbsent(unmatchedAbsent.filter(e => isPrivateIp(e.key, customRanges)))}
                 onAbsentClick={setSelectedAbsent}
                 onActiveClick={ip => setSelectedIp({ ip, fileId: latestFileId, isActive: true, lastSeenTime: latestStartTime })}
               />
-              {unmatchedActive.filter(ip => !isPrivateIp(ip)).length > 0 || unmatchedAbsent.filter(e => !isPrivateIp(e.key)).length > 0 ? (
-                <div className="mt-2">
-                  <small className="text-muted fst-italic d-block mb-1">Public</small>
-                  <IpBadgeGroup
-                    items={filterIps(unmatchedActive.filter(ip => !isPrivateIp(ip)))}
-                    absentItems={filterAbsent(unmatchedAbsent.filter(e => !isPrivateIp(e.key)))}
-                    onAbsentClick={setSelectedAbsent}
-                    onActiveClick={ip => setSelectedIp({ ip, fileId: latestFileId, isActive: true, lastSeenTime: latestStartTime })}
-                  />
-                </div>
-              ) : null}
             </div>
-          )}
+          ) : null}
+          {unmatchedActive.filter(ip => !isPrivateIp(ip, customRanges)).length > 0 || unmatchedAbsent.filter(e => !isPrivateIp(e.key, customRanges)).length > 0 ? (
+            <div className="mb-3">
+              <small className="text-muted fw-semibold d-block mb-1">
+                <i className="bi bi-globe me-1"></i>Public
+              </small>
+              <IpBadgeGroup
+                items={filterIps(unmatchedActive.filter(ip => !isPrivateIp(ip, customRanges)))}
+                absentItems={filterAbsent(unmatchedAbsent.filter(e => !isPrivateIp(e.key, customRanges)))}
+                onAbsentClick={setSelectedAbsent}
+                onActiveClick={ip => setSelectedIp({ ip, fileId: latestFileId, isActive: true, lastSeenTime: latestStartTime })}
+              />
+            </div>
+          ) : null}
         </>
       ) : (
         <>
@@ -312,6 +448,11 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
           Greyed-out addresses are no longer seen. Click for details.
         </small>
       )}
+      <PrivateOverridesSection
+        customRanges={customRanges}
+        onSaved={r => setCustomRanges(prev => [r, ...prev.filter(x => x.cidr !== r.cidr)])}
+        onDeleted={id => setCustomRanges(prev => prev.filter(r => r.id !== id))}
+      />
       {selectedAbsent && (
         <EntityDetailModal
           entityType="IP"

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -27,6 +27,7 @@ export const FileList = () => {
   const [pendingDeleteFile, setPendingDeleteFile] = useState<FileMetadata | null>(null);
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
   const [selectedForCompare, setSelectedForCompare] = useState<Set<string>>(new Set());
+  const [hideMonitor, setHideMonitor] = useState(true);
   const [showInfo, setShowInfo] = useState(false);
   const [showMultiSelectModal, setShowMultiSelectModal] = useState(false);
   const [merging, setMerging] = useState(false);
@@ -201,7 +202,17 @@ export const FileList = () => {
             </div>
           </div>
           {files.length > 0 && (
-            <div className="d-flex gap-2">
+            <div className="d-flex gap-2 align-items-center">
+              <Button
+                type="button"
+                variant={hideMonitor ? 'outline-secondary' : 'secondary'}
+                size="sm"
+                onClick={() => setHideMonitor(v => !v)}
+                title={hideMonitor ? 'Show monitor network files' : 'Hide monitor network files'}
+              >
+                <i className={`bi bi-${hideMonitor ? 'eye-slash' : 'eye'} me-1`}></i>
+                Monitor files
+              </Button>
               {selectedForCompare.size >= 2 && (
                 <Button
                   type="button"
@@ -243,7 +254,7 @@ export const FileList = () => {
               className="list-group list-group-flush"
               style={{ maxHeight: '13.5rem', overflowY: 'auto' }}
             >
-              {files.map(file => (
+              {files.filter(f => !hideMonitor || f.source !== 'MONITOR').map(file => (
                 <div
                   key={file.fileId}
                   className="list-group-item d-flex justify-content-between align-items-center"
@@ -326,6 +337,8 @@ export const FileList = () => {
         <Card.Footer className="text-muted small">
           <AlertCircle size={14} className="me-1" />
           Files are automatically deleted after 12 hours
+          <span className="ms-2 text-muted">·</span>
+          <span className="ms-2">Monitor network files are exempt and will not expire</span>
         </Card.Footer>
       </Card>
 

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -207,7 +207,19 @@ export const FileList = () => {
                 type="button"
                 variant={hideMonitor ? 'outline-secondary' : 'secondary'}
                 size="sm"
-                onClick={() => setHideMonitor(v => !v)}
+                onClick={() => setHideMonitor(v => {
+                  const next = !v;
+                  if (next) {
+                    setSelectedForCompare(prev => {
+                      const monitorIds = new Set(files.filter(f => f.source === 'MONITOR').map(f => f.fileId));
+                      if ([...prev].every(id => !monitorIds.has(id))) return prev;
+                      const next = new Set(prev);
+                      monitorIds.forEach(id => next.delete(id));
+                      return next;
+                    });
+                  }
+                  return next;
+                })}
                 title={hideMonitor ? 'Show monitor network files' : 'Hide monitor network files'}
               >
                 <i className={`bi bi-${hideMonitor ? 'eye-slash' : 'eye'} me-1`}></i>

--- a/frontend/src/features/intelligence/services/customPrivateRangeService.ts
+++ b/frontend/src/features/intelligence/services/customPrivateRangeService.ts
@@ -1,0 +1,18 @@
+import { apiClient } from '@/services/api/client';
+import type { CustomPrivateRange } from '../types/customPrivateRange.types';
+
+export const customPrivateRangeService = {
+  async list(): Promise<CustomPrivateRange[]> {
+    const res = await apiClient.get<CustomPrivateRange[]>('/custom-private-ranges');
+    return res.data;
+  },
+
+  async create(cidr: string, label: string): Promise<CustomPrivateRange> {
+    const res = await apiClient.post<CustomPrivateRange>('/custom-private-ranges', { cidr, label });
+    return res.data;
+  },
+
+  async delete(id: number): Promise<void> {
+    await apiClient.delete(`/custom-private-ranges/${id}`);
+  },
+};

--- a/frontend/src/features/intelligence/types/customPrivateRange.types.ts
+++ b/frontend/src/features/intelligence/types/customPrivateRange.types.ts
@@ -1,0 +1,5 @@
+export interface CustomPrivateRange {
+  id: number;
+  cidr: string;
+  label: string | null;
+}


### PR DESCRIPTION
## Summary

- Adds a **Private IP Overrides** feature so end users can mark public IPs or CIDR ranges as internal (for cases where a public address is used by a private terminal)
- Overrides are managed inline inside the IP Addresses drift panel on the Monitor network detail page — collapsible section at the bottom
- IP panel layout cleaned up: subnet groups shown first, then remaining IPs fall into flat **Private** / **Public** sections
- **All Uploads**: new toggle button to hide monitor network files (hidden by default), plus a footer note that monitor files are exempt from the 12-hour deletion policy

## Changes

**Backend**
- `V13__custom_private_ranges.sql` — new `custom_private_ranges` table
- `CustomPrivateRangeController` — `GET/POST/DELETE /api/custom-private-ranges`
- `CustomPrivateRangeService` — CIDR validation, normalisation (bare IP → `/32`), and matching with parse cache
- `ChangeDetectionService` — loads custom ranges once per detection run; overridden IPs are excluded from ASN/gateway change analysis

**Frontend**
- `IpDriftPanel` — loads overrides on mount, reclassifies matching IPs into Private; embeds collapsible management UI (add/delete overrides with optional label)
- `FileList` — monitor file toggle (hidden by default); footer expiry note

## Test plan

- [ ] Add a public IP override in the IP Addresses panel → confirm it moves from Public to Private
- [ ] Add a CIDR range override → confirm all IPs in that range move to Private
- [ ] Remove an override → confirm IP moves back to Public
- [ ] With a subnet defined (e.g. `10.0.0.0/16`): confirm layout is subnet group → Private → Public (no "Unmatched" wrapper)
- [ ] All Uploads: confirm monitor files are hidden by default; toggle shows/hides them
- [ ] Validate error handling: duplicate CIDR, invalid IP, missing CIDR
- [ ] `GET/POST/DELETE /api/custom-private-ranges` smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage custom private IP ranges via the UI (view, add, delete) to override automatic IP classification.
  * Custom ranges are applied across analysis, affecting private/public grouping and gateway selection.
  * Toggle visibility of monitor files in the uploads list.
  * IP drift view now separates unmatched connections into Private and Public groups.

* **Bug Fixes**
  * Improved file upload resource handling for more reliable uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->