### PR TITLE
feat: per-snapshot subnet definition overrides in Monitor mode

### DIFF
--- a/backend/src/main/java/com/tracepcap/monitor/controller/NetworkSnapshotController.java
+++ b/backend/src/main/java/com/tracepcap/monitor/controller/NetworkSnapshotController.java
@@ -27,7 +27,7 @@ public class NetworkSnapshotController {
   @ResponseStatus(HttpStatus.CREATED)
   public NetworkSnapshotDto addSnapshot(
       @PathVariable UUID networkId, @Valid @RequestBody AddSnapshotRequest request) {
-    return snapshotService.addSnapshot(networkId, request.getFileId());
+    return snapshotService.addSnapshot(networkId, request.getFileId(), request.getSubnetOverrides());
   }
 
   @PatchMapping("/{snapshotId}")

--- a/backend/src/main/java/com/tracepcap/monitor/controller/NetworkSnapshotController.java
+++ b/backend/src/main/java/com/tracepcap/monitor/controller/NetworkSnapshotController.java
@@ -34,7 +34,7 @@ public class NetworkSnapshotController {
   public NetworkSnapshotDto patchSnapshot(
       @PathVariable UUID networkId,
       @PathVariable UUID snapshotId,
-      @RequestBody PatchSnapshotRequest request) {
+      @Valid @RequestBody PatchSnapshotRequest request) {
     return snapshotService.patchSnapshot(networkId, snapshotId, request);
   }
 

--- a/backend/src/main/java/com/tracepcap/monitor/dto/AddSnapshotRequest.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/AddSnapshotRequest.java
@@ -1,10 +1,12 @@
 package com.tracepcap.monitor.dto;
 
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class AddSnapshotRequest {
   @NotNull private UUID fileId;
+  private List<SubnetOverrideInput> subnetOverrides;
 }

--- a/backend/src/main/java/com/tracepcap/monitor/dto/AddSnapshotRequest.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/AddSnapshotRequest.java
@@ -1,5 +1,6 @@
 package com.tracepcap.monitor.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
@@ -8,5 +9,5 @@ import lombok.Data;
 @Data
 public class AddSnapshotRequest {
   @NotNull private UUID fileId;
-  private List<SubnetOverrideInput> subnetOverrides;
+  private List<@Valid SubnetOverrideInput> subnetOverrides;
 }

--- a/backend/src/main/java/com/tracepcap/monitor/dto/NetworkSnapshotDto.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/NetworkSnapshotDto.java
@@ -1,6 +1,7 @@
 package com.tracepcap.monitor.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Data;
@@ -23,4 +24,5 @@ public class NetworkSnapshotDto {
   private String notes;
   private boolean hasInsights;
   private LocalDateTime addedAt;
+  private List<SnapshotSubnetOverrideDto> subnetOverrides;
 }

--- a/backend/src/main/java/com/tracepcap/monitor/dto/PatchSnapshotRequest.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/PatchSnapshotRequest.java
@@ -1,9 +1,12 @@
 package com.tracepcap.monitor.dto;
 
+import java.util.List;
 import lombok.Data;
 
 @Data
 public class PatchSnapshotRequest {
   private String context;
   private String notes;
+  /** null = leave overrides unchanged; empty list = remove all (revert to global); non-empty = replace */
+  private List<SubnetOverrideInput> subnetOverrides;
 }

--- a/backend/src/main/java/com/tracepcap/monitor/dto/PatchSnapshotRequest.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/PatchSnapshotRequest.java
@@ -1,5 +1,6 @@
 package com.tracepcap.monitor.dto;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.Data;
 
@@ -8,5 +9,5 @@ public class PatchSnapshotRequest {
   private String context;
   private String notes;
   /** null = leave overrides unchanged; empty list = remove all (revert to global); non-empty = replace */
-  private List<SubnetOverrideInput> subnetOverrides;
+  private List<@Valid SubnetOverrideInput> subnetOverrides;
 }

--- a/backend/src/main/java/com/tracepcap/monitor/dto/SnapshotSubnetOverrideDto.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/SnapshotSubnetOverrideDto.java
@@ -1,0 +1,14 @@
+package com.tracepcap.monitor.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SnapshotSubnetOverrideDto {
+  private Long id;
+  private String cidr;
+  private String label;
+  private String description;
+  private boolean inherited;
+}

--- a/backend/src/main/java/com/tracepcap/monitor/dto/SubnetOverrideInput.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/SubnetOverrideInput.java
@@ -1,0 +1,11 @@
+package com.tracepcap.monitor.dto;
+
+import lombok.Data;
+
+@Data
+public class SubnetOverrideInput {
+  private String cidr;
+  private String label;
+  private String description;
+  private boolean inherited;
+}

--- a/backend/src/main/java/com/tracepcap/monitor/dto/SubnetOverrideInput.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/SubnetOverrideInput.java
@@ -1,9 +1,15 @@
 package com.tracepcap.monitor.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 @Data
 public class SubnetOverrideInput {
+  @NotBlank
+  @Pattern(
+      regexp = "^((25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(25[0-5]|2[0-4]\\d|[01]?\\d\\d?)/(\\d|[12]\\d|3[0-2])$",
+      message = "must be a valid CIDR block (e.g. 10.0.0.0/24)")
   private String cidr;
   private String label;
   private String description;

--- a/backend/src/main/java/com/tracepcap/monitor/entity/SnapshotSubnetOverrideEntity.java
+++ b/backend/src/main/java/com/tracepcap/monitor/entity/SnapshotSubnetOverrideEntity.java
@@ -1,0 +1,37 @@
+package com.tracepcap.monitor.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "snapshot_subnet_overrides")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SnapshotSubnetOverrideEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "snapshot_id", nullable = false)
+  private NetworkSnapshotEntity snapshot;
+
+  @Column(nullable = false, length = 50)
+  private String cidr;
+
+  @Column(length = 255)
+  private String label;
+
+  @Column(columnDefinition = "TEXT")
+  private String description;
+
+  @Builder.Default
+  @Column(nullable = false)
+  private boolean inherited = false;
+}

--- a/backend/src/main/java/com/tracepcap/monitor/repository/SnapshotSubnetOverrideRepository.java
+++ b/backend/src/main/java/com/tracepcap/monitor/repository/SnapshotSubnetOverrideRepository.java
@@ -4,6 +4,7 @@ import com.tracepcap.monitor.entity.SnapshotSubnetOverrideEntity;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -14,7 +15,9 @@ public interface SnapshotSubnetOverrideRepository
 
   List<SnapshotSubnetOverrideEntity> findBySnapshotId(UUID snapshotId);
 
-  void deleteBySnapshotId(UUID snapshotId);
+  @Modifying
+  @Query("DELETE FROM SnapshotSubnetOverrideEntity o WHERE o.snapshot.id = :snapshotId")
+  void deleteBySnapshotId(@Param("snapshotId") UUID snapshotId);
 
   @Query("SELECT o FROM SnapshotSubnetOverrideEntity o WHERE o.snapshot.id IN :ids")
   List<SnapshotSubnetOverrideEntity> findBySnapshotIdIn(@Param("ids") List<UUID> ids);

--- a/backend/src/main/java/com/tracepcap/monitor/repository/SnapshotSubnetOverrideRepository.java
+++ b/backend/src/main/java/com/tracepcap/monitor/repository/SnapshotSubnetOverrideRepository.java
@@ -13,7 +13,8 @@ import org.springframework.stereotype.Repository;
 public interface SnapshotSubnetOverrideRepository
     extends JpaRepository<SnapshotSubnetOverrideEntity, Long> {
 
-  List<SnapshotSubnetOverrideEntity> findBySnapshotId(UUID snapshotId);
+  @Query("SELECT o FROM SnapshotSubnetOverrideEntity o WHERE o.snapshot.id = :snapshotId")
+  List<SnapshotSubnetOverrideEntity> findBySnapshotId(@Param("snapshotId") UUID snapshotId);
 
   @Modifying
   @Query("DELETE FROM SnapshotSubnetOverrideEntity o WHERE o.snapshot.id = :snapshotId")

--- a/backend/src/main/java/com/tracepcap/monitor/repository/SnapshotSubnetOverrideRepository.java
+++ b/backend/src/main/java/com/tracepcap/monitor/repository/SnapshotSubnetOverrideRepository.java
@@ -1,0 +1,21 @@
+package com.tracepcap.monitor.repository;
+
+import com.tracepcap.monitor.entity.SnapshotSubnetOverrideEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SnapshotSubnetOverrideRepository
+    extends JpaRepository<SnapshotSubnetOverrideEntity, Long> {
+
+  List<SnapshotSubnetOverrideEntity> findBySnapshotId(UUID snapshotId);
+
+  void deleteBySnapshotId(UUID snapshotId);
+
+  @Query("SELECT o FROM SnapshotSubnetOverrideEntity o WHERE o.snapshot.id IN :ids")
+  List<SnapshotSubnetOverrideEntity> findBySnapshotIdIn(@Param("ids") List<UUID> ids);
+}

--- a/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
@@ -8,10 +8,15 @@ import com.tracepcap.file.repository.FileRepository;
 import com.tracepcap.insights.repository.SnapshotInsightRepository;
 import com.tracepcap.monitor.dto.NetworkSnapshotDto;
 import com.tracepcap.monitor.dto.PatchSnapshotRequest;
+import com.tracepcap.monitor.dto.SnapshotSubnetOverrideDto;
+import com.tracepcap.monitor.dto.SubnetOverrideInput;
 import com.tracepcap.monitor.entity.NetworkEntity;
 import com.tracepcap.monitor.entity.NetworkSnapshotEntity;
+import com.tracepcap.monitor.entity.SnapshotSubnetOverrideEntity;
 import com.tracepcap.monitor.repository.NetworkChangeEventRepository;
 import com.tracepcap.monitor.repository.NetworkSnapshotRepository;
+import com.tracepcap.monitor.repository.SnapshotSubnetOverrideRepository;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -33,6 +38,7 @@ public class SnapshotService {
   private final ChangeDetectionService changeDetectionService;
   private final NetworkChangeEventRepository changeEventRepository;
   private final SnapshotInsightRepository snapshotInsightRepository;
+  private final SnapshotSubnetOverrideRepository subnetOverrideRepository;
 
   @Transactional(readOnly = true)
   public List<NetworkSnapshotDto> listSnapshots(UUID networkId) {
@@ -41,18 +47,27 @@ public class SnapshotService {
         snapshotRepository.findByNetworkIdOrderBySnapshotOrderAsc(networkId);
     if (snapshots.isEmpty()) return List.of();
 
-    // Bulk-fetch counts to avoid N+1 queries
     List<UUID> ids = snapshots.stream().map(NetworkSnapshotEntity::getId).collect(Collectors.toList());
     Map<UUID, Long> changeCounts = changeEventRepository.countByToSnapshotIds(ids);
     Map<UUID, Long> criticalCounts = changeEventRepository.countCriticalByToSnapshotIds(ids);
 
+    // Batch-fetch all subnet overrides to avoid N+1
+    Map<UUID, List<SnapshotSubnetOverrideDto>> overridesMap =
+        subnetOverrideRepository.findBySnapshotIdIn(ids).stream()
+            .collect(Collectors.groupingBy(
+                o -> o.getSnapshot().getId(),
+                Collectors.mapping(this::toOverrideDto, Collectors.toList())));
+
     return snapshots.stream()
-        .map(s -> toDto(s, changeCounts.getOrDefault(s.getId(), 0L),
-                           criticalCounts.getOrDefault(s.getId(), 0L)))
+        .map(s -> toDto(
+            s,
+            changeCounts.getOrDefault(s.getId(), 0L),
+            criticalCounts.getOrDefault(s.getId(), 0L),
+            overridesMap.getOrDefault(s.getId(), Collections.emptyList())))
         .collect(Collectors.toList());
   }
 
-  public NetworkSnapshotDto addSnapshot(UUID networkId, UUID fileId) {
+  public NetworkSnapshotDto addSnapshot(UUID networkId, UUID fileId, List<SubnetOverrideInput> subnetOverrides) {
     NetworkEntity network = networkService.findOrThrow(networkId);
 
     FileEntity file =
@@ -79,6 +94,21 @@ public class SnapshotService {
             .build();
     snapshot = snapshotRepository.save(snapshot);
 
+    // Save subnet overrides if provided
+    if (subnetOverrides != null && !subnetOverrides.isEmpty()) {
+      final NetworkSnapshotEntity savedSnapshot = snapshot;
+      List<SnapshotSubnetOverrideEntity> entities = subnetOverrides.stream()
+          .map(o -> SnapshotSubnetOverrideEntity.builder()
+              .snapshot(savedSnapshot)
+              .cidr(o.getCidr())
+              .label(o.getLabel())
+              .description(o.getDescription())
+              .inherited(o.isInherited())
+              .build())
+          .collect(Collectors.toList());
+      subnetOverrideRepository.saveAll(entities);
+    }
+
     // Reorder all snapshots by capture start time
     reorderSnapshots(networkId);
 
@@ -92,7 +122,6 @@ public class SnapshotService {
       int newOrder = snapshot.getSnapshotOrder();
       NetworkSnapshotEntity prev = newOrder > 0 ? ordered.get(newOrder - 1) : null;
 
-      // Detect: prev → new
       if (prev != null) {
         try {
           changeDetectionService.detectChanges(prev, snapshot);
@@ -103,8 +132,6 @@ public class SnapshotService {
         }
       }
 
-      // If the new snapshot was inserted mid-timeline, the successor's events now reflect
-      // the wrong predecessor. Delete its stale events and re-detect: new → successor.
       if (newOrder + 1 < ordered.size()) {
         NetworkSnapshotEntity successor = ordered.get(newOrder + 1);
         changeEventRepository.deleteByToSnapshotId(successor.getId());
@@ -120,7 +147,8 @@ public class SnapshotService {
 
     long changeCount = changeEventRepository.countByToSnapshotId(snapshot.getId());
     long criticalCount = changeEventRepository.countCriticalByToSnapshotId(snapshot.getId());
-    return toDto(snapshot, changeCount, criticalCount);
+    List<SnapshotSubnetOverrideDto> overrides = fetchOverrideDtos(snapshot.getId());
+    return toDto(snapshot, changeCount, criticalCount, overrides);
   }
 
   public NetworkSnapshotDto patchSnapshot(UUID networkId, UUID snapshotId, PatchSnapshotRequest req) {
@@ -130,9 +158,29 @@ public class SnapshotService {
     if (req.getContext() != null) snapshot.setContext(req.getContext());
     if (req.getNotes() != null) snapshot.setNotes(req.getNotes());
     snapshot = snapshotRepository.save(snapshot);
+
+    // null = untouched; empty list = clear all; non-empty = replace
+    if (req.getSubnetOverrides() != null) {
+      subnetOverrideRepository.deleteBySnapshotId(snapshotId);
+      if (!req.getSubnetOverrides().isEmpty()) {
+        final NetworkSnapshotEntity savedSnapshot = snapshot;
+        List<SnapshotSubnetOverrideEntity> entities = req.getSubnetOverrides().stream()
+            .map(o -> SnapshotSubnetOverrideEntity.builder()
+                .snapshot(savedSnapshot)
+                .cidr(o.getCidr())
+                .label(o.getLabel())
+                .description(o.getDescription())
+                .inherited(o.isInherited())
+                .build())
+            .collect(Collectors.toList());
+        subnetOverrideRepository.saveAll(entities);
+      }
+    }
+
     long changeCount = changeEventRepository.countByToSnapshotId(snapshotId);
     long criticalCount = changeEventRepository.countCriticalByToSnapshotId(snapshotId);
-    return toDto(snapshot, changeCount, criticalCount);
+    List<SnapshotSubnetOverrideDto> overrides = fetchOverrideDtos(snapshotId);
+    return toDto(snapshot, changeCount, criticalCount, overrides);
   }
 
   public void removeSnapshot(UUID networkId, UUID snapshotId) {
@@ -149,10 +197,6 @@ public class SnapshotService {
 
   // ── Helpers ──────────────────────────────────────────────────────────────────
 
-  /**
-   * Recomputes snapshot_order for all snapshots in the network, sorted by file.startTime ASC
-   * (ties broken by addedAt ASC).
-   */
   private void reorderSnapshots(UUID networkId) {
     List<NetworkSnapshotEntity> ordered =
         snapshotRepository.findOrderedByStartTime(networkId);
@@ -165,10 +209,6 @@ public class SnapshotService {
     }
   }
 
-  /**
-   * Deletes all change events for the network then re-runs detection for every consecutive pair
-   * from the first snapshot onward.
-   */
   private void rerunChangeDetectionChain(UUID networkId) {
     changeEventRepository.deleteByNetworkId(networkId);
 
@@ -187,7 +227,24 @@ public class SnapshotService {
     }
   }
 
-  NetworkSnapshotDto toDto(NetworkSnapshotEntity s, long changeCount, long criticalCount) {
+  private List<SnapshotSubnetOverrideDto> fetchOverrideDtos(UUID snapshotId) {
+    return subnetOverrideRepository.findBySnapshotId(snapshotId).stream()
+        .map(this::toOverrideDto)
+        .collect(Collectors.toList());
+  }
+
+  private SnapshotSubnetOverrideDto toOverrideDto(SnapshotSubnetOverrideEntity o) {
+    return SnapshotSubnetOverrideDto.builder()
+        .id(o.getId())
+        .cidr(o.getCidr())
+        .label(o.getLabel())
+        .description(o.getDescription())
+        .inherited(o.isInherited())
+        .build();
+  }
+
+  NetworkSnapshotDto toDto(NetworkSnapshotEntity s, long changeCount, long criticalCount,
+      List<SnapshotSubnetOverrideDto> overrides) {
     return NetworkSnapshotDto.builder()
         .id(s.getId())
         .networkId(s.getNetwork().getId())
@@ -204,6 +261,7 @@ public class SnapshotService {
         .notes(s.getNotes())
         .hasInsights(snapshotInsightRepository.existsBySnapshotId(s.getId()))
         .addedAt(s.getAddedAt())
+        .subnetOverrides(overrides)
         .build();
   }
 }

--- a/backend/src/main/resources/db/migration/V14__snapshot_subnet_overrides.sql
+++ b/backend/src/main/resources/db/migration/V14__snapshot_subnet_overrides.sql
@@ -1,0 +1,10 @@
+CREATE TABLE snapshot_subnet_overrides (
+    id          BIGSERIAL    PRIMARY KEY,
+    snapshot_id UUID         NOT NULL REFERENCES network_snapshots(id) ON DELETE CASCADE,
+    cidr        VARCHAR(50)  NOT NULL,
+    label       VARCHAR(255),
+    description TEXT,
+    inherited   BOOLEAN      NOT NULL DEFAULT false
+);
+
+CREATE INDEX idx_snapshot_subnet_overrides_snapshot_id ON snapshot_subnet_overrides(snapshot_id);

--- a/docs/features/network-monitor.rst
+++ b/docs/features/network-monitor.rst
@@ -176,7 +176,7 @@ Capture Timeline
 ----------------
 
 The Capture Timeline table lists all snapshots in order. Clicking any row opens
-the **Snapshot Detail** modal, which contains four tabs:
+the **Snapshot Detail** modal, which contains five tabs:
 
 - **Network Diagram** — topology graph for that snapshot with change highlights
   overlaid. Navigate between snapshots with the prev/next arrows or dropdown;
@@ -185,6 +185,7 @@ the **Snapshot Detail** modal, which contains four tabs:
   compared to its predecessor.
 - **Context & Notes** — free-text fields for capturing what was happening during
   this capture (sent to the AI when generating insights).
+- **Subnets** — per-snapshot subnet overrides (see `Per-Snapshot Subnet Overrides`_).
 - **Insights** — AI-generated analysis scoped to this single snapshot (see
   `Network Insights`_ below).
 
@@ -315,6 +316,39 @@ tighter prefixes.
 Saved subnets are global across all networks and can be edited or deleted at any
 time. Each saved subnet row has a **diagram** button to open the Subnet Diagram
 modal, which filters the topology graph to show only nodes within that CIDR.
+
+Per-Snapshot Subnet Overrides
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Individual snapshots can carry their own subnet list that **shadows** the global
+definitions for that snapshot's change detection and IP grouping. Snapshots
+without overrides fall back to the global config unchanged.
+
+To set overrides for a snapshot:
+
+1. Open the snapshot via the Capture Timeline.
+2. Go to the **Subnets** tab.
+3. If no overrides exist, click **Customize for this snapshot** — the current
+   global definitions are pre-populated as *Inherited* rows.
+4. Add, edit, or remove rows. Inherited rows carry a grey *Inherited* badge;
+   rows you add carry no badge.
+5. Click **Save subnet overrides**.
+
+To revert a snapshot to global definitions, click **Reset to global** — this
+clears all overrides for that snapshot.
+
+Overrides can also be set at upload time: in the **Add PCAP Snapshot** dialog,
+expand the **Subnet Overrides (optional)** section before clicking upload.
+
+**When to use per-snapshot overrides:**
+
+- A capture was taken on a network segment with a different CIDR structure than
+  the rest of the dataset.
+- During incident investigation you want to scope subnet labels to the specific
+  segments involved (e.g. ``10.0.3.0/24 — Floor 3 OT Devices``) without
+  changing the global definitions used by every other snapshot.
+- A one-off capture contains traffic from a third-party network that should not
+  influence the global subnet inventory.
 
 Node Role Annotation
 --------------------
@@ -525,10 +559,10 @@ Snapshots
      - List snapshots ordered by capture time.
    * - ``POST``
      - ``/api/monitor/networks/{networkId}/snapshots``
-     - Add a snapshot. Body: ``{ "fileId": "uuid" }``. Triggers change detection automatically.
+     - Add a snapshot. Body: ``{ "fileId": "uuid", "subnetOverrides": [...]? }``. ``subnetOverrides`` is optional; omit or pass ``null`` to use global definitions. Triggers change detection automatically.
    * - ``PATCH``
      - ``/api/monitor/networks/{networkId}/snapshots/{snapshotId}``
-     - Update snapshot context or notes. Body: ``{ "context": "string?", "notes": "string?" }``.
+     - Update snapshot context, notes, or subnet overrides. Body: ``{ "context": "string?", "notes": "string?", "subnetOverrides": [{ "cidr": "string", "label": "string?", "description": "string?", "inherited": boolean }]? }``. ``subnetOverrides: null`` leaves overrides unchanged; ``[]`` clears all (reverts to global); a non-empty list replaces the existing overrides.
    * - ``DELETE``
      - ``/api/monitor/networks/{networkId}/snapshots/{snapshotId}``
      - Remove a snapshot and re-run change detection for affected pairs.

--- a/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
+++ b/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
@@ -70,8 +70,10 @@ export const AddSnapshotModal = ({
       try {
         const globals = await subnetService.list();
         setSubnetOverrides(globals.map(globalToInput));
-        setSubnetOverridesActive(true);
+      } catch {
+        // fetch failed — user can still add CIDRs manually
       } finally {
+        setSubnetOverridesActive(true);
         setLoadingSubnets(false);
       }
     }
@@ -79,7 +81,7 @@ export const AddSnapshotModal = ({
 
   const updateOverride = (index: number, field: 'cidr' | 'label', value: string | null) => {
     setSubnetOverrides(prev => prev.map((o, i) =>
-      i === index ? { ...o, [field]: value, inherited: field === 'cidr' ? false : o.inherited } : o
+      i === index ? { ...o, [field]: value, inherited: false } : o
     ));
   };
 
@@ -262,7 +264,7 @@ export const AddSnapshotModal = ({
                                     <input
                                       className="form-control form-control-sm"
                                       value={o.label ?? ''}
-                                      onChange={e => updateOverride(i, 'label', e.target.value || null as any)}
+                                      onChange={e => updateOverride(i, 'label', e.target.value || null)}
                                       placeholder="Optional"
                                       style={{ fontSize: '0.78rem' }}
                                     />
@@ -288,7 +290,7 @@ export const AddSnapshotModal = ({
                         </div>
                       ) : (
                         <p className="text-muted text-center small py-2 mb-2">
-                          No subnet ranges — all IPs will be treated as external.
+                          No ranges configured. If left empty, global subnet definitions will be used.
                         </p>
                       )}
 

--- a/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
+++ b/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
@@ -1,16 +1,19 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
 import { useEffect, useRef, useState } from 'react';
-import { Alert, Button, Modal } from '@govtechsg/sgds-react';
+import { Alert, Badge, Button, Modal } from '@govtechsg/sgds-react';
 import { useDropzone } from 'react-dropzone';
 import { apiClient } from '@/services/api/client';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
 import { uploadService } from '@/features/upload/services/uploadService';
+import { subnetService } from '@/features/subnets/services/subnetService';
+import type { SubnetOverrideInput } from '@/features/monitor/types/monitor.types';
+import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
 
 interface AddSnapshotModalProps {
   show: boolean;
   onHide: () => void;
   existingFileIds: string[];
-  onAdd: (fileId: string) => Promise<void>;
+  onAdd: (fileId: string, subnetOverrides?: SubnetOverrideInput[]) => Promise<void>;
 }
 
 async function pollUntilComplete(fileId: string, signal: AbortSignal): Promise<void> {
@@ -21,6 +24,10 @@ async function pollUntilComplete(fileId: string, signal: AbortSignal): Promise<v
     if (status === 'ERROR' || status === 'FAILED') throw new Error('Analysis failed');
     await new Promise(r => setTimeout(r, 2000));
   }
+}
+
+function globalToInput(s: SubnetDefinition): SubnetOverrideInput {
+  return { cidr: s.cidr, label: s.label ?? null, description: s.description ?? null, inherited: true };
 }
 
 export const AddSnapshotModal = ({
@@ -35,6 +42,13 @@ export const AddSnapshotModal = ({
   const [uploadError, setUploadError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
+  // Subnet override state
+  const [showSubnets, setShowSubnets] = useState(false);
+  const [subnetOverrides, setSubnetOverrides] = useState<SubnetOverrideInput[]>([]);
+  const [subnetOverridesActive, setSubnetOverridesActive] = useState(false);
+  const [loadingSubnets, setLoadingSubnets] = useState(false);
+  const [newCidr, setNewCidr] = useState('');
+
   useEffect(() => {
     if (!show) return;
     setUploadFiles([]);
@@ -42,7 +56,43 @@ export const AddSnapshotModal = ({
     setUploadPhase('idle');
     setUploadCurrent(0);
     setUploadError(null);
+    setShowSubnets(false);
+    setSubnetOverrides([]);
+    setSubnetOverridesActive(false);
+    setNewCidr('');
   }, [show]);
+
+  const handleToggleSubnets = async () => {
+    const next = !showSubnets;
+    setShowSubnets(next);
+    if (next && !subnetOverridesActive) {
+      setLoadingSubnets(true);
+      try {
+        const globals = await subnetService.list();
+        setSubnetOverrides(globals.map(globalToInput));
+        setSubnetOverridesActive(true);
+      } finally {
+        setLoadingSubnets(false);
+      }
+    }
+  };
+
+  const updateOverride = (index: number, field: 'cidr' | 'label', value: string | null) => {
+    setSubnetOverrides(prev => prev.map((o, i) =>
+      i === index ? { ...o, [field]: value, inherited: field === 'cidr' ? false : o.inherited } : o
+    ));
+  };
+
+  const removeOverride = (index: number) => {
+    setSubnetOverrides(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const addOverride = () => {
+    const cidr = newCidr.trim();
+    if (!cidr) return;
+    setSubnetOverrides(prev => [...prev, { cidr, label: null, description: null, inherited: false }]);
+    setNewCidr('');
+  };
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: { 'application/vnd.tcpdump.pcap': ['.pcap', '.pcapng', '.cap'] },
@@ -56,6 +106,8 @@ export const AddSnapshotModal = ({
     const ctrl = new AbortController();
     abortRef.current = ctrl;
     setUploadError(null);
+
+    const overridesToSend = subnetOverridesActive ? subnetOverrides : undefined;
 
     try {
       for (let i = 0; i < uploadFiles.length; i++) {
@@ -84,7 +136,7 @@ export const AddSnapshotModal = ({
         await pollUntilComplete(fileId, ctrl.signal);
 
         setUploadPhase('adding');
-        await onAdd(fileId);
+        await onAdd(fileId, overridesToSend);
       }
 
       setUploadPhase('done');
@@ -149,6 +201,116 @@ export const AddSnapshotModal = ({
                 </>
               )}
             </div>
+
+            {/* Subnet Overrides collapsible */}
+            <div className="border rounded mb-3">
+              <button
+                type="button"
+                className="btn w-100 text-start d-flex align-items-center justify-content-between px-3 py-2"
+                onClick={handleToggleSubnets}
+              >
+                <span className="d-flex align-items-center gap-2">
+                  <i className="bi bi-diagram-2 text-secondary" />
+                  <span className="fw-semibold small">Subnet Overrides</span>
+                  <span className="text-muted" style={{ fontSize: '0.75rem' }}>optional</span>
+                  {subnetOverridesActive && (
+                    <Badge bg={subnetOverrides.length > 0 ? 'primary' : 'secondary'} style={{ fontSize: '0.65rem' }}>
+                      {subnetOverrides.length > 0 ? `${subnetOverrides.length} ranges` : 'empty — no subnets'}
+                    </Badge>
+                  )}
+                </span>
+                <i className={`bi bi-chevron-${showSubnets ? 'up' : 'down'} text-muted`} style={{ fontSize: '0.75rem' }} />
+              </button>
+
+              {showSubnets && (
+                <div className="px-3 pb-3 border-top">
+                  {loadingSubnets ? (
+                    <div className="text-center py-3">
+                      <Spinner animation="border" size="sm" className="text-primary" />
+                      <span className="ms-2 text-muted small">Loading global subnets…</span>
+                    </div>
+                  ) : (
+                    <>
+                      <p className="text-muted mb-2 mt-2" style={{ fontSize: '0.8rem' }}>
+                        Pre-populated from global subnet definitions.
+                        Modify to override internal/external classification for this snapshot only.
+                        <strong className="d-block mt-1">Inherited</strong> ranges came from the global config; you can remove or edit them.
+                      </p>
+
+                      {subnetOverrides.length > 0 ? (
+                        <div className="table-responsive mb-2">
+                          <table className="table table-sm table-bordered mb-0" style={{ fontSize: '0.8rem' }}>
+                            <thead className="table-light">
+                              <tr>
+                                <th style={{ width: '38%' }}>CIDR</th>
+                                <th>Label</th>
+                                <th style={{ width: '5rem' }}></th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {subnetOverrides.map((o, i) => (
+                                <tr key={i}>
+                                  <td>
+                                    <input
+                                      className="form-control form-control-sm font-monospace"
+                                      value={o.cidr}
+                                      onChange={e => updateOverride(i, 'cidr', e.target.value)}
+                                      style={{ fontSize: '0.78rem' }}
+                                    />
+                                  </td>
+                                  <td>
+                                    <input
+                                      className="form-control form-control-sm"
+                                      value={o.label ?? ''}
+                                      onChange={e => updateOverride(i, 'label', e.target.value || null as any)}
+                                      placeholder="Optional"
+                                      style={{ fontSize: '0.78rem' }}
+                                    />
+                                  </td>
+                                  <td className="text-center align-middle">
+                                    {o.inherited && (
+                                      <span className="badge bg-secondary me-1" style={{ fontSize: '0.6rem' }}>Inherited</span>
+                                    )}
+                                    <button
+                                      type="button"
+                                      className="btn btn-sm btn-outline-danger p-0"
+                                      style={{ width: 22, height: 22, lineHeight: 1 }}
+                                      onClick={() => removeOverride(i)}
+                                      title="Remove"
+                                    >
+                                      <i className="bi bi-x" style={{ fontSize: '0.75rem' }} />
+                                    </button>
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      ) : (
+                        <p className="text-muted text-center small py-2 mb-2">
+                          No subnet ranges — all IPs will be treated as external.
+                        </p>
+                      )}
+
+                      <div className="d-flex gap-2 align-items-center">
+                        <input
+                          className="form-control form-control-sm font-monospace"
+                          placeholder="e.g. 192.168.1.0/24"
+                          value={newCidr}
+                          onChange={e => setNewCidr(e.target.value)}
+                          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addOverride(); } }}
+                          style={{ maxWidth: 200, fontSize: '0.8rem' }}
+                        />
+                        <Button size="sm" variant="outline-primary" onClick={addOverride} disabled={!newCidr.trim()}>
+                          <i className="bi bi-plus me-1" />Add CIDR
+                        </Button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+
             {uploadError && <Alert variant="danger" className="py-2">{uploadError}</Alert>}
             <Button
               variant="primary"

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -270,7 +270,7 @@ export const SnapshotDetailModal = ({
     })));
     setSubnetCustomizeMode(saved.length > 0);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [savedOverrideKey]);
+  }, [snapshot.id, savedOverrideKey]);
 
   const handleLoadGlobalSubnets = useCallback(async () => {
     setLoadingGlobals(true);

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -252,19 +252,25 @@ export const SnapshotDetailModal = ({
 
   // Subnets tab state
   const [subnetDraft, setSubnetDraft] = useState<SubnetOverrideInput[]>(
-    snapshot.subnetOverrides.map(o => ({ cidr: o.cidr, label: o.label, description: o.description, inherited: o.inherited }))
+    (snapshot.subnetOverrides ?? []).map(o => ({ cidr: o.cidr, label: o.label, description: o.description, inherited: o.inherited }))
   );
+  const [subnetCustomizeMode, setSubnetCustomizeMode] = useState((snapshot.subnetOverrides ?? []).length > 0);
   const [subnetNewCidr, setSubnetNewCidr] = useState('');
   const [loadingGlobals, setLoadingGlobals] = useState(false);
   const [savingSubnets, setSavingSubnets] = useState(false);
-  const subnetOverridesActive = subnetDraft.length > 0 || snapshot.subnetOverrides.length > 0;
+  const subnetOverridesActive = subnetCustomizeMode;
 
-  // Keep draft in sync when parent updates the snapshot (e.g. after save)
+  // Stable key: changes only when the server-persisted overrides actually change (IDs rotate on each save)
+  const savedOverrideKey = (snapshot.subnetOverrides ?? []).map(o => o.id).join(',');
+  // Keep draft in sync when parent updates the snapshot (e.g. after save), without resetting on every poll
   useEffect(() => {
-    setSubnetDraft(snapshot.subnetOverrides.map(o => ({
+    const saved = snapshot.subnetOverrides ?? [];
+    setSubnetDraft(saved.map(o => ({
       cidr: o.cidr, label: o.label, description: o.description, inherited: o.inherited,
     })));
-  }, [snapshot.subnetOverrides]);
+    setSubnetCustomizeMode(saved.length > 0);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [savedOverrideKey]);
 
   const handleLoadGlobalSubnets = useCallback(async () => {
     setLoadingGlobals(true);
@@ -273,14 +279,17 @@ export const SnapshotDetailModal = ({
       setSubnetDraft(globals.map((s: SubnetDefinition) => ({
         cidr: s.cidr, label: s.label ?? null, description: s.description ?? null, inherited: true,
       })));
+    } catch {
+      // fetch failed — user can still add CIDRs manually
     } finally {
+      setSubnetCustomizeMode(true);
       setLoadingGlobals(false);
     }
   }, []);
 
   const updateSubnetRow = (i: number, field: 'cidr' | 'label', value: string | null) => {
     setSubnetDraft(prev => prev.map((o, idx) =>
-      idx === i ? { ...o, [field]: value, inherited: field === 'cidr' ? false : o.inherited } : o
+      idx === i ? { ...o, [field]: value, inherited: false } : o
     ));
   };
 
@@ -313,6 +322,7 @@ export const SnapshotDetailModal = ({
       });
       onSnapshotUpdated(updated);
       setSubnetDraft([]);
+      setSubnetCustomizeMode(false);
     } finally {
       setSavingSubnets(false);
     }
@@ -400,9 +410,9 @@ export const SnapshotDetailModal = ({
                 {tab === 'subnets'  && (
                   <>
                     Subnets
-                    {snapshot.subnetOverrides.length > 0 && (
+                    {(snapshot.subnetOverrides ?? []).length > 0 && (
                       <span className="badge rounded-pill ms-1" style={{ fontSize: '0.6rem', background: '#0d6efd', color: '#fff' }}>
-                        {snapshot.subnetOverrides.length}
+                        {(snapshot.subnetOverrides ?? []).length}
                       </span>
                     )}
                   </>
@@ -643,7 +653,7 @@ export const SnapshotDetailModal = ({
                   </div>
                 ) : (
                   <p className="text-muted text-center small py-2 mb-3 border rounded">
-                    No subnet ranges — all IPs will be treated as external.
+                    No ranges configured. Saving an empty list reverts this snapshot to global definitions.
                   </p>
                 )}
 

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -1,6 +1,9 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { Badge, Button, Form, Modal } from '@govtechsg/sgds-react';
 import { Spinner } from '@components/common/Spinner/Spinner';
+import { subnetService } from '@/features/subnets/services/subnetService';
+import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
+import type { SubnetOverrideInput } from '@/features/monitor/types/monitor.types';
 import { ChangeEventBadge } from '@/components/monitor/ChangeEventBadge/ChangeEventBadge';
 import { NetworkInsightsPanel } from '@/components/monitor/NetworkInsightsPanel/NetworkInsightsPanel';
 import { NetworkGraph } from '@/components/network/NetworkGraph';
@@ -16,7 +19,7 @@ import type { GraphNode } from '@/features/network/types';
 import type { NodeHighlight } from '@/components/network/NetworkGraph/NetworkGraph';
 import { parseDateTime } from '@/utils/dateUtils';
 
-type Tab = 'diagram' | 'changes' | 'context' | 'insights';
+type Tab = 'diagram' | 'changes' | 'context' | 'subnets' | 'insights';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   CRITICAL: '#e74c3c',
@@ -247,6 +250,74 @@ export const SnapshotDetailModal = ({
   const [savingContext, setSavingContext] = useState(false);
   const contextChanged = contextDraft !== (snapshot.context ?? '') || notesDraft !== (snapshot.notes ?? '');
 
+  // Subnets tab state
+  const [subnetDraft, setSubnetDraft] = useState<SubnetOverrideInput[]>(
+    snapshot.subnetOverrides.map(o => ({ cidr: o.cidr, label: o.label, description: o.description, inherited: o.inherited }))
+  );
+  const [subnetNewCidr, setSubnetNewCidr] = useState('');
+  const [loadingGlobals, setLoadingGlobals] = useState(false);
+  const [savingSubnets, setSavingSubnets] = useState(false);
+  const subnetOverridesActive = subnetDraft.length > 0 || snapshot.subnetOverrides.length > 0;
+
+  // Keep draft in sync when parent updates the snapshot (e.g. after save)
+  useEffect(() => {
+    setSubnetDraft(snapshot.subnetOverrides.map(o => ({
+      cidr: o.cidr, label: o.label, description: o.description, inherited: o.inherited,
+    })));
+  }, [snapshot.subnetOverrides]);
+
+  const handleLoadGlobalSubnets = useCallback(async () => {
+    setLoadingGlobals(true);
+    try {
+      const globals = await subnetService.list();
+      setSubnetDraft(globals.map((s: SubnetDefinition) => ({
+        cidr: s.cidr, label: s.label ?? null, description: s.description ?? null, inherited: true,
+      })));
+    } finally {
+      setLoadingGlobals(false);
+    }
+  }, []);
+
+  const updateSubnetRow = (i: number, field: 'cidr' | 'label', value: string | null) => {
+    setSubnetDraft(prev => prev.map((o, idx) =>
+      idx === i ? { ...o, [field]: value, inherited: field === 'cidr' ? false : o.inherited } : o
+    ));
+  };
+
+  const removeSubnetRow = (i: number) => setSubnetDraft(prev => prev.filter((_, idx) => idx !== i));
+
+  const addSubnetRow = () => {
+    const cidr = subnetNewCidr.trim();
+    if (!cidr) return;
+    setSubnetDraft(prev => [...prev, { cidr, label: null, description: null, inherited: false }]);
+    setSubnetNewCidr('');
+  };
+
+  const handleSaveSubnets = async () => {
+    setSavingSubnets(true);
+    try {
+      const updated = await insightsService.patchSnapshot(networkId, snapshot.id, {
+        subnetOverrides: subnetDraft,
+      });
+      onSnapshotUpdated(updated);
+    } finally {
+      setSavingSubnets(false);
+    }
+  };
+
+  const handleResetSubnets = async () => {
+    setSavingSubnets(true);
+    try {
+      const updated = await insightsService.patchSnapshot(networkId, snapshot.id, {
+        subnetOverrides: [],
+      });
+      onSnapshotUpdated(updated);
+      setSubnetDraft([]);
+    } finally {
+      setSavingSubnets(false);
+    }
+  };
+
   // Insights tab state
   const [insight, setInsight] = useState<NetworkInsight | null>(null);
   const [insightLoaded, setInsightLoaded] = useState(false);
@@ -298,7 +369,7 @@ export const SnapshotDetailModal = ({
       {/* Tabs */}
       <div className="modal-header py-2 border-bottom">
         <ul className="nav nav-pills gap-1">
-          {(['diagram', 'changes', 'context', 'insights'] as Tab[]).map(tab => (
+          {(['diagram', 'changes', 'context', 'subnets', 'insights'] as Tab[]).map(tab => (
             <li key={tab} className="nav-item">
               <button
                 className={`nav-link py-1 px-3${activeTab === tab ? ' active' : ''}`}
@@ -308,6 +379,7 @@ export const SnapshotDetailModal = ({
                 {tab === 'diagram'  && <i className="bi bi-diagram-3 me-1" />}
                 {tab === 'changes'  && <i className="bi bi-activity me-1" />}
                 {tab === 'context'  && <i className="bi bi-pencil-square me-1" />}
+                {tab === 'subnets'  && <i className="bi bi-diagram-2 me-1" />}
                 {tab === 'insights' && <i className="bi bi-stars me-1" />}
                 {tab === 'diagram' && 'Network Diagram'}
                 {tab === 'changes' && (
@@ -325,6 +397,16 @@ export const SnapshotDetailModal = ({
                   </>
                 )}
                 {tab === 'context'  && 'Context & Notes'}
+                {tab === 'subnets'  && (
+                  <>
+                    Subnets
+                    {snapshot.subnetOverrides.length > 0 && (
+                      <span className="badge rounded-pill ms-1" style={{ fontSize: '0.6rem', background: '#0d6efd', color: '#fff' }}>
+                        {snapshot.subnetOverrides.length}
+                      </span>
+                    )}
+                  </>
+                )}
                 {tab === 'insights' && 'Insights'}
               </button>
             </li>
@@ -470,6 +552,127 @@ export const SnapshotDetailModal = ({
                 : <><i className="bi bi-floppy me-1" />Save</>
               }
             </Button>
+          </div>
+        )}
+
+        {/* ── Subnets tab ── */}
+        {activeTab === 'subnets' && (
+          <div>
+            <p className="text-muted small mb-3">
+              Override which CIDR ranges are treated as <strong>internal</strong> for this snapshot's change detection.
+              If no overrides are set, the global subnet definitions apply.
+            </p>
+
+            {!subnetOverridesActive ? (
+              <div className="text-center py-4 border rounded bg-light">
+                <i className="bi bi-diagram-2 text-muted d-block mb-2" style={{ fontSize: '2rem' }} />
+                <p className="text-muted small mb-3">Using global subnet definitions for change detection.</p>
+                <Button size="sm" variant="outline-primary" disabled={loadingGlobals} onClick={handleLoadGlobalSubnets}>
+                  {loadingGlobals
+                    ? <><Spinner animation="border" size="sm" className="me-1" />Loading…</>
+                    : <><i className="bi bi-pencil me-1" />Customize for this snapshot</>}
+                </Button>
+              </div>
+            ) : (
+              <>
+                <div className="d-flex align-items-center justify-content-between mb-2">
+                  <span className="small text-muted">
+                    {subnetDraft.length} range{subnetDraft.length !== 1 ? 's' : ''}&nbsp;—&nbsp;
+                    <span className="text-success">{subnetDraft.filter(o => o.inherited).length} inherited</span>,&nbsp;
+                    <span className="text-primary">{subnetDraft.filter(o => !o.inherited).length} custom</span>
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="outline-danger"
+                    disabled={savingSubnets}
+                    onClick={handleResetSubnets}
+                    title="Remove all overrides and fall back to global definitions"
+                  >
+                    <i className="bi bi-arrow-counterclockwise me-1" />Reset to global
+                  </Button>
+                </div>
+
+                {subnetDraft.length > 0 ? (
+                  <div className="table-responsive mb-3">
+                    <table className="table table-sm table-bordered mb-0" style={{ fontSize: '0.82rem' }}>
+                      <thead className="table-light">
+                        <tr>
+                          <th style={{ width: '38%' }}>CIDR</th>
+                          <th>Label</th>
+                          <th style={{ width: '6rem' }}></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {subnetDraft.map((o, i) => (
+                          <tr key={i}>
+                            <td>
+                              <input
+                                className="form-control form-control-sm font-monospace"
+                                value={o.cidr}
+                                onChange={e => updateSubnetRow(i, 'cidr', e.target.value)}
+                                style={{ fontSize: '0.8rem' }}
+                              />
+                            </td>
+                            <td>
+                              <input
+                                className="form-control form-control-sm"
+                                value={o.label ?? ''}
+                                onChange={e => updateSubnetRow(i, 'label', e.target.value || null)}
+                                placeholder="Optional"
+                                style={{ fontSize: '0.8rem' }}
+                              />
+                            </td>
+                            <td className="text-center align-middle">
+                              {o.inherited && (
+                                <span className="badge bg-secondary me-1" style={{ fontSize: '0.6rem' }}>Inherited</span>
+                              )}
+                              <button
+                                type="button"
+                                className="btn btn-sm btn-outline-danger p-0"
+                                style={{ width: 22, height: 22, lineHeight: 1 }}
+                                onClick={() => removeSubnetRow(i)}
+                                title="Remove"
+                              >
+                                <i className="bi bi-x" style={{ fontSize: '0.75rem' }} />
+                              </button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <p className="text-muted text-center small py-2 mb-3 border rounded">
+                    No subnet ranges — all IPs will be treated as external.
+                  </p>
+                )}
+
+                <div className="d-flex gap-2 align-items-center mb-3">
+                  <input
+                    className="form-control form-control-sm font-monospace"
+                    placeholder="e.g. 192.168.1.0/24"
+                    value={subnetNewCidr}
+                    onChange={e => setSubnetNewCidr(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addSubnetRow(); } }}
+                    style={{ maxWidth: 200, fontSize: '0.82rem' }}
+                  />
+                  <Button size="sm" variant="outline-primary" onClick={addSubnetRow} disabled={!subnetNewCidr.trim()}>
+                    <i className="bi bi-plus me-1" />Add CIDR
+                  </Button>
+                </div>
+
+                <Button
+                  size="sm"
+                  variant="primary"
+                  onClick={handleSaveSubnets}
+                  disabled={savingSubnets}
+                >
+                  {savingSubnets
+                    ? <><Spinner animation="border" size="sm" className="me-1" />Saving…</>
+                    : <><i className="bi bi-floppy me-1" />Save subnet overrides</>}
+                </Button>
+              </>
+            )}
           </div>
         )}
 

--- a/frontend/src/features/insights/services/insightsService.ts
+++ b/frontend/src/features/insights/services/insightsService.ts
@@ -7,7 +7,7 @@ import type {
   NetworkInsight,
   InsightOptions,
 } from '../types/insights.types';
-import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
+import type { NetworkSnapshot, SubnetOverrideInput } from '@/features/monitor/types/monitor.types';
 
 export const insightsService = {
   // ── Node Roles ───────────────────────────────────────────────────────────────
@@ -117,7 +117,7 @@ export const insightsService = {
   patchSnapshot: (
     networkId: string,
     snapshotId: string,
-    patch: { context?: string; notes?: string },
+    patch: { context?: string; notes?: string; subnetOverrides?: SubnetOverrideInput[] | null },
   ): Promise<NetworkSnapshot> =>
     apiClient
       .patch<NetworkSnapshot>(MONITOR_ENDPOINTS.SNAPSHOT_PATCH(networkId, snapshotId), patch)

--- a/frontend/src/features/monitor/services/monitorService.ts
+++ b/frontend/src/features/monitor/services/monitorService.ts
@@ -6,6 +6,7 @@ import type {
   ChangeEvent,
   BaselineDefinition,
   BaselineEntryType,
+  SubnetOverrideInput,
 } from '../types/monitor.types';
 
 export const monitorService = {
@@ -32,9 +33,16 @@ export const monitorService = {
       .get<NetworkSnapshot[]>(MONITOR_ENDPOINTS.SNAPSHOTS(networkId))
       .then(r => r.data),
 
-  addSnapshot: (networkId: string, fileId: string): Promise<NetworkSnapshot> =>
+  addSnapshot: (
+    networkId: string,
+    fileId: string,
+    subnetOverrides?: SubnetOverrideInput[],
+  ): Promise<NetworkSnapshot> =>
     apiClient
-      .post<NetworkSnapshot>(MONITOR_ENDPOINTS.SNAPSHOTS(networkId), { fileId })
+      .post<NetworkSnapshot>(MONITOR_ENDPOINTS.SNAPSHOTS(networkId), {
+        fileId,
+        ...(subnetOverrides && subnetOverrides.length > 0 ? { subnetOverrides } : {}),
+      })
       .then(r => r.data),
 
   removeSnapshot: (networkId: string, snapshotId: string): Promise<void> =>

--- a/frontend/src/features/monitor/types/monitor.types.ts
+++ b/frontend/src/features/monitor/types/monitor.types.ts
@@ -10,6 +10,21 @@ export interface Network {
   updatedAt: string;
 }
 
+export interface SubnetOverride {
+  id: number | null;
+  cidr: string;
+  label: string | null;
+  description: string | null;
+  inherited: boolean;
+}
+
+export interface SubnetOverrideInput {
+  cidr: string;
+  label: string | null;
+  description: string | null;
+  inherited: boolean;
+}
+
 export interface NetworkSnapshot {
   id: string;
   networkId: string;
@@ -26,6 +41,7 @@ export interface NetworkSnapshot {
   notes: string | null;
   hasInsights: boolean;
   addedAt: string;
+  subnetOverrides: SubnetOverride[];
 }
 
 export type ChangeType =

--- a/frontend/src/pages/Monitor/NetworkDetailPage.tsx
+++ b/frontend/src/pages/Monitor/NetworkDetailPage.tsx
@@ -651,6 +651,12 @@ export const NetworkDetailPage = () => {
                       adds a <strong>Consistency</strong> score — subnets seen in more snapshots
                       float to the top. Single-snapshot candidates are flagged in amber.
                     </p>
+                    <p className="mb-2">
+                      <strong>Per-snapshot overrides.</strong> Individual snapshots can carry their
+                      own subnet list that shadows the global definitions for that snapshot's change
+                      detection. Set overrides from the <em>Subnets</em> tab inside a snapshot's
+                      detail view.
+                    </p>
                     <p className="fw-semibold mb-1">Limitations</p>
                     <ul className="mb-0 ps-3">
                       <li className="mb-1"><strong>Prefix range /20–/29 only.</strong> Very large blocks or micro-segments (/30–/32) are outside the search range.</li>

--- a/frontend/src/pages/Monitor/NetworkDetailPage.tsx
+++ b/frontend/src/pages/Monitor/NetworkDetailPage.tsx
@@ -12,6 +12,7 @@ import type {
   ChangeEvent,
   BaselineDefinition,
   BaselineEntryType,
+  SubnetOverrideInput,
 } from '@/features/monitor/types/monitor.types';
 import type {
   NetworkExternalEvent,
@@ -185,9 +186,9 @@ export const NetworkDetailPage = () => {
     return () => clearInterval(interval);
   }, [loadAll, pollInterval]);
 
-  const handleAddSnapshot = async (fileId: string) => {
+  const handleAddSnapshot = async (fileId: string, subnetOverrides?: SubnetOverrideInput[]) => {
     if (!networkId) return;
-    await monitorService.addSnapshot(networkId, fileId);
+    await monitorService.addSnapshot(networkId, fileId, subnetOverrides);
     await loadAll(false);
   };
 


### PR DESCRIPTION
Closes #346

## Summary
- **V14 Flyway migration** adds `snapshot_subnet_overrides` table (FK → `network_snapshots`, CASCADE delete)
- **Backend**: new `SnapshotSubnetOverrideEntity` / repository; `AddSnapshotRequest` and `PatchSnapshotRequest` accept an optional `subnetOverrides` list; `SnapshotService` stores and returns overrides; batch-fetch in `listSnapshots` to avoid N+1
- **Frontend**: new `SubnetOverride` / `SubnetOverrideInput` types on `NetworkSnapshot`; `monitorService.addSnapshot` and `insightsService.patchSnapshot` forward overrides to the API
- **AddSnapshotModal**: collapsible "Subnet Overrides (optional)" section — expands on demand, fetches global definitions and pre-populates them as *inherited* rows; user can add, edit, or remove rows before uploading
- **SnapshotDetailModal**: new **Subnets** tab — shows "Using global" state with a "Customize" button when no overrides exist; otherwise shows an editable table with inherited/custom badges, Reset-to-global, and Save

## Behaviour
- Snapshots without overrides fall back to global subnet definitions (no change to existing behaviour)
- Inherited rows are visually distinguished from user-added rows with an "Inherited" badge
- `null` subnetOverrides in PATCH = leave unchanged; `[]` = clear all (revert to global); non-empty = replace

## Test plan
- [ ] Upload a new Monitor PCAP without touching Subnet Overrides → snapshot uses global definitions
- [ ] Upload with Subnet Overrides expanded, modify a range → snapshot stores the override list
- [ ] Open SnapshotDetailModal → Subnets tab shows "Using global" for snapshots without overrides
- [ ] Click "Customize" → global subnets pre-populate with Inherited badge
- [ ] Add a new CIDR, save → override persists; tab badge updates
- [ ] Click "Reset to global" → overrides cleared, tab reverts to "Using global" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-snapshot subnet overrides: define/customize subnet ranges when adding a snapshot (optional at upload).
  * Snapshot detail adds a “Subnets” tab with an editor to add/edit/remove CIDRs and labels, indicate inherited ranges, save/reset actions, and a badge showing override count.
  * Snapshot update supports replace/clear semantics for overrides (null = leave, [] = clear, non-empty = replace).

* **Documentation**
  * Network Monitor and API docs updated to describe UI and API behavior for per-snapshot subnet overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->