### PR TITLE
fix: address review findings from Lanturn PR #24

### DIFF
--- a/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
@@ -22,7 +22,7 @@ public class CustomPrivateRangeService {
   private final CustomPrivateRangeRepository repository;
 
   private record ParsedCidr(byte[] networkBytes, int prefixLen) {}
-  private static final ConcurrentHashMap<String, Optional<ParsedCidr>> cidrCache =
+  private final ConcurrentHashMap<String, Optional<ParsedCidr>> cidrCache =
       new ConcurrentHashMap<>();
 
   // Matches dotted-decimal IPv4 or hex-colon IPv6 — rejects hostnames before DNS lookup
@@ -37,8 +37,9 @@ public class CustomPrivateRangeService {
 
   public CustomPrivateRangeDto create(CustomPrivateRangeDto dto) {
     String cidr = dto.getCidr().trim();
-    // Determine IP and optional prefix parts
-    String ipPart = cidr.contains("/") ? cidr.split("/")[0].trim() : cidr;
+    // Determine IP and optional prefix parts — indexOf avoids split edge-case with bare "/"
+    int slashIdx = cidr.indexOf('/');
+    String ipPart = slashIdx >= 0 ? cidr.substring(0, slashIdx).trim() : cidr;
     // Reject hostnames — only numeric IPs are accepted to prevent DNS resolution
     if (!NUMERIC_IP.matcher(ipPart).matches()) {
       throw new IllegalArgumentException("Invalid IP address: " + ipPart);
@@ -97,36 +98,55 @@ public class CustomPrivateRangeService {
    */
   public boolean isOverriddenPrivate(String ip, List<CustomPrivateRangeEntity> ranges) {
     if (ip == null || ranges.isEmpty()) return false;
+    byte[] addrBytes = resolveAddress(ip);
+    if (addrBytes == null) return false;
     for (CustomPrivateRangeEntity range : ranges) {
-      if (inCidr(ip, range.getCidr())) return true;
+      if (inCidrBytes(addrBytes, range.getCidr())) return true;
     }
     return false;
   }
 
-  private boolean inCidr(String ip, String cidr) {
-    if (ip == null || cidr == null) return false;
-    try {
-      Optional<ParsedCidr> opt = cidrCache.computeIfAbsent(cidr, this::parseCidr);
-      if (opt.isEmpty()) return false;
-      ParsedCidr parsed = opt.get();
-      byte[] addrBytes = InetAddress.getByName(ip).getAddress();
-      byte[] netBytes = parsed.networkBytes();
-      int prefixLen = parsed.prefixLen();
-      if (netBytes.length != addrBytes.length) return false;
-      int fullBytes = prefixLen / 8;
-      int remainingBits = prefixLen % 8;
-      for (int i = 0; i < fullBytes; i++) {
-        if (netBytes[i] != addrBytes[i]) return false;
-      }
-      if (remainingBits > 0 && fullBytes < netBytes.length) {
-        int mask = 0xFF & (0xFF << (8 - remainingBits));
-        if ((netBytes[fullBytes] & mask) != (addrBytes[fullBytes] & mask)) return false;
-      }
-      return true;
-    } catch (Exception e) {
-      log.warn("CIDR match error ip={} cidr={}: {}", ip, cidr, e.getMessage());
-      return false;
+  /**
+   * Returns true if the IP falls within any of the provided CIDR strings.
+   * Used by callers that work with plain CIDR lists rather than entity objects.
+   */
+  public boolean isInCidrs(String ip, List<String> cidrs) {
+    if (ip == null || cidrs.isEmpty()) return false;
+    byte[] addrBytes = resolveAddress(ip);
+    if (addrBytes == null) return false;
+    for (String cidr : cidrs) {
+      if (inCidrBytes(addrBytes, cidr)) return true;
     }
+    return false;
+  }
+
+  private byte[] resolveAddress(String ip) {
+    try {
+      return InetAddress.getByName(ip).getAddress();
+    } catch (Exception e) {
+      log.warn("Failed to resolve IP address {}: {}", ip, e.getMessage());
+      return null;
+    }
+  }
+
+  private boolean inCidrBytes(byte[] addrBytes, String cidr) {
+    if (cidr == null) return false;
+    Optional<ParsedCidr> opt = cidrCache.computeIfAbsent(cidr, this::parseCidr);
+    if (opt.isEmpty()) return false;
+    ParsedCidr parsed = opt.get();
+    byte[] netBytes = parsed.networkBytes();
+    int prefixLen = parsed.prefixLen();
+    if (netBytes.length != addrBytes.length) return false;
+    int fullBytes = prefixLen / 8;
+    int remainingBits = prefixLen % 8;
+    for (int i = 0; i < fullBytes; i++) {
+      if (netBytes[i] != addrBytes[i]) return false;
+    }
+    if (remainingBits > 0 && fullBytes < netBytes.length) {
+      int mask = 0xFF & (0xFF << (8 - remainingBits));
+      if ((netBytes[fullBytes] & mask) != (addrBytes[fullBytes] & mask)) return false;
+    }
+    return true;
   }
 
   private Optional<ParsedCidr> parseCidr(String cidr) {

--- a/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
@@ -155,6 +155,11 @@ public class CustomPrivateRangeService {
       if (parts.length != 2) return Optional.empty();
       byte[] networkBytes = InetAddress.getByName(parts[0].trim()).getAddress();
       int prefixLen = Integer.parseInt(parts[1].trim());
+      int maxPrefix = networkBytes.length * 8;
+      if (prefixLen < 0 || prefixLen > maxPrefix) {
+        log.warn("CIDR prefix out of range for {}: {}", cidr, prefixLen);
+        return Optional.empty();
+      }
       return Optional.of(new ParsedCidr(networkBytes, prefixLen));
     } catch (Exception e) {
       log.warn("Failed to pre-parse CIDR {}: {}", cidr, e.getMessage());

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -6,14 +6,15 @@ import com.tracepcap.analysis.entity.IpGeoInfoEntity;
 import com.tracepcap.analysis.repository.ConversationRepository;
 import com.tracepcap.analysis.repository.HostClassificationRepository;
 import com.tracepcap.analysis.repository.IpGeoInfoRepository;
-import com.tracepcap.intelligence.entity.CustomPrivateRangeEntity;
 import com.tracepcap.intelligence.service.CustomPrivateRangeService;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.ChangeType;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.EntityType;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.Severity;
 import com.tracepcap.monitor.entity.NetworkSnapshotEntity;
+import com.tracepcap.monitor.entity.SnapshotSubnetOverrideEntity;
 import com.tracepcap.monitor.repository.NetworkChangeEventRepository;
+import com.tracepcap.monitor.repository.SnapshotSubnetOverrideRepository;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,6 +53,7 @@ public class ChangeDetectionService {
   private final IpGeoInfoRepository ipGeoInfoRepository;
   private final NetworkChangeEventRepository changeEventRepository;
   private final CustomPrivateRangeService customPrivateRangeService;
+  private final SnapshotSubnetOverrideRepository snapshotSubnetOverrideRepository;
 
   /**
    * Compare two consecutive snapshots and persist NetworkChangeEventEntity records. fromSnapshot
@@ -183,9 +185,10 @@ public class ChangeDetectionService {
 
     if (fromFileId == null) return List.of();
 
-    List<CustomPrivateRangeEntity> customRanges = customPrivateRangeService.loadRanges();
-    Set<String> fromExternalIps = externalIpsForFile(fromFileId, customRanges);
-    Set<String> toExternalIps = externalIpsForFile(toFileId, customRanges);
+    List<String> fromCidrs = effectiveCidrs(fromSnapshot);
+    List<String> toCidrs = effectiveCidrs(toSnapshot);
+    Set<String> fromExternalIps = externalIpsForFile(fromFileId, fromCidrs);
+    Set<String> toExternalIps = externalIpsForFile(toFileId, toCidrs);
 
     Map<String, IpGeoInfoEntity> fromGeo = geoMapFor(fromExternalIps);
     Map<String, IpGeoInfoEntity> toGeo = geoMapFor(toExternalIps);
@@ -220,8 +223,8 @@ public class ChangeDetectionService {
     // Lost ASNs are not actionable on their own — gateway change covers the important case
 
     // Gateway heuristic: top-traffic external IP
-    String fromGateway = topExternalIp(fromFileId, fromGeo, customRanges);
-    String toGateway = topExternalIp(toFileId, toGeo, customRanges);
+    String fromGateway = topExternalIp(fromFileId, fromGeo, fromCidrs);
+    String toGateway = topExternalIp(toFileId, toGeo, toCidrs);
     if (fromGateway != null && toGateway != null && !fromGateway.equals(toGateway)) {
       IpGeoInfoEntity fromGeoEntry = fromGeo.get(fromGateway);
       IpGeoInfoEntity toGeoEntry = toGeo.get(toGateway);
@@ -390,11 +393,11 @@ public class ChangeDetectionService {
     return result;
   }
 
-  private Set<String> externalIpsForFile(UUID fileId, List<CustomPrivateRangeEntity> customRanges) {
+  private Set<String> externalIpsForFile(UUID fileId, List<String> customCidrs) {
     if (fileId == null) return Set.of();
     return conversationRepository.findByFileId(fileId).stream()
         .flatMap(c -> Stream.of(c.getSrcIp(), c.getDstIp()))
-        .filter(ip -> ip != null && !isPrivate(ip, customRanges))
+        .filter(ip -> ip != null && !isPrivate(ip, customCidrs))
         .collect(Collectors.toSet());
   }
 
@@ -417,15 +420,15 @@ public class ChangeDetectionService {
   }
 
   /** Returns the external IP with the highest total bytes for a file (gateway heuristic). */
-  private String topExternalIp(UUID fileId, Map<String, IpGeoInfoEntity> geoMap, List<CustomPrivateRangeEntity> customRanges) {
+  private String topExternalIp(UUID fileId, Map<String, IpGeoInfoEntity> geoMap, List<String> customCidrs) {
     if (fileId == null || geoMap.isEmpty()) return null;
     Map<String, Long> ipBytes = new HashMap<>();
     for (ConversationEntity c : conversationRepository.findByFileId(fileId)) {
       String dst = c.getDstIp();
       String src = c.getSrcIp();
       String external = null;
-      if (dst != null && !isPrivate(dst, customRanges) && geoMap.containsKey(dst)) external = dst;
-      else if (src != null && !isPrivate(src, customRanges) && geoMap.containsKey(src)) external = src;
+      if (dst != null && !isPrivate(dst, customCidrs) && geoMap.containsKey(dst)) external = dst;
+      else if (src != null && !isPrivate(src, customCidrs) && geoMap.containsKey(src)) external = src;
       if (external != null) {
         ipBytes.merge(external, c.getTotalBytes() != null ? c.getTotalBytes() : 0L, Long::sum);
       }
@@ -460,7 +463,7 @@ public class ChangeDetectionService {
         .collect(Collectors.toSet());
   }
 
-  private boolean isPrivate(String ip, List<CustomPrivateRangeEntity> customRanges) {
+  private boolean isPrivate(String ip, List<String> customCidrs) {
     if (ip == null) return true;
     for (String prefix : PRIVATE_PREFIXES) {
       if (ip.startsWith(prefix)) return true;
@@ -475,7 +478,26 @@ public class ChangeDetectionService {
         } catch (NumberFormatException ignored) { }
       }
     }
-    return customPrivateRangeService.isOverriddenPrivate(ip, customRanges);
+    return customPrivateRangeService.isInCidrs(ip, customCidrs);
+  }
+
+  /**
+   * Returns the effective CIDR list for a snapshot: its own subnet overrides if any are defined,
+   * otherwise falls back to the global custom private ranges.
+   */
+  private List<String> effectiveCidrs(NetworkSnapshotEntity snapshot) {
+    if (snapshot != null) {
+      List<SnapshotSubnetOverrideEntity> overrides =
+          snapshotSubnetOverrideRepository.findBySnapshotId(snapshot.getId());
+      if (!overrides.isEmpty()) {
+        return overrides.stream()
+            .map(SnapshotSubnetOverrideEntity::getCidr)
+            .collect(Collectors.toList());
+      }
+    }
+    return customPrivateRangeService.loadRanges().stream()
+        .map(e -> e.getCidr())
+        .collect(Collectors.toList());
   }
 
   private static String orEmpty(String s) {

--- a/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
@@ -175,9 +175,31 @@ public class SnapshotService {
             .collect(Collectors.toList());
         subnetOverrideRepository.saveAll(entities);
       }
-      // Subnet classification changed — recompute change events for the whole network
-      // so that the updated internal/external IP grouping is reflected immediately.
-      rerunChangeDetectionChain(networkId);
+      // Subnet classification changed — recompute only the transitions involving this
+      // snapshot (prev->snapshot and snapshot->successor) rather than the full chain.
+      changeEventRepository.deleteByToSnapshotId(snapshotId);
+      List<NetworkSnapshotEntity> ordered =
+          snapshotRepository.findByNetworkIdOrderBySnapshotOrderAsc(networkId);
+      int idx = -1;
+      for (int i = 0; i < ordered.size(); i++) {
+        if (ordered.get(i).getId().equals(snapshotId)) { idx = i; break; }
+      }
+      if (idx > 0) {
+        try {
+          changeDetectionService.detectChanges(ordered.get(idx - 1), snapshot);
+        } catch (Exception e) {
+          log.error("Change detection failed prev->snapshot {}: {}", snapshotId, e.getMessage(), e);
+        }
+      }
+      if (idx >= 0 && idx + 1 < ordered.size()) {
+        NetworkSnapshotEntity successor = ordered.get(idx + 1);
+        changeEventRepository.deleteByToSnapshotId(successor.getId());
+        try {
+          changeDetectionService.detectChanges(snapshot, successor);
+        } catch (Exception e) {
+          log.error("Change detection failed snapshot->successor {}: {}", snapshotId, e.getMessage(), e);
+        }
+      }
     }
 
     long changeCount = changeEventRepository.countByToSnapshotId(snapshotId);

--- a/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
@@ -175,6 +175,9 @@ public class SnapshotService {
             .collect(Collectors.toList());
         subnetOverrideRepository.saveAll(entities);
       }
+      // Subnet classification changed — recompute change events for the whole network
+      // so that the updated internal/external IP grouping is reflected immediately.
+      rerunChangeDetectionChain(networkId);
     }
 
     long changeCount = changeEventRepository.countByToSnapshotId(snapshotId);

--- a/backend/src/main/resources/db/migration/V15__snapshot_subnet_overrides_unique.sql
+++ b/backend/src/main/resources/db/migration/V15__snapshot_subnet_overrides_unique.sql
@@ -1,2 +1,17 @@
+-- Remove any duplicate (snapshot_id, cidr) rows that may exist before adding the constraint,
+-- keeping the row with the smallest id in each duplicate group.
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY snapshot_id, cidr
+           ORDER BY id
+         ) AS rn
+  FROM snapshot_subnet_overrides
+)
+DELETE FROM snapshot_subnet_overrides s
+USING ranked r
+WHERE s.id = r.id
+  AND r.rn > 1;
+
 ALTER TABLE snapshot_subnet_overrides
     ADD CONSTRAINT uq_snapshot_subnet_overrides_snapshot_cidr UNIQUE (snapshot_id, cidr);

--- a/backend/src/main/resources/db/migration/V15__snapshot_subnet_overrides_unique.sql
+++ b/backend/src/main/resources/db/migration/V15__snapshot_subnet_overrides_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE snapshot_subnet_overrides
+    ADD CONSTRAINT uq_snapshot_subnet_overrides_snapshot_cidr UNIQUE (snapshot_id, cidr);

--- a/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
+++ b/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
@@ -65,7 +65,9 @@ export const AddSnapshotModal = ({
   const handleToggleSubnets = async () => {
     const next = !showSubnets;
     setShowSubnets(next);
-    if (next && !subnetOverridesActive) {
+    // Load globals for display but do NOT set subnetOverridesActive — overrides are only
+    // sent if the user explicitly edits the list (add/remove/modify a row).
+    if (next && !subnetOverridesActive && subnetOverrides.length === 0) {
       setLoadingSubnets(true);
       try {
         const globals = await subnetService.list();
@@ -73,25 +75,27 @@ export const AddSnapshotModal = ({
       } catch {
         // fetch failed — user can still add CIDRs manually
       } finally {
-        setSubnetOverridesActive(true);
         setLoadingSubnets(false);
       }
     }
   };
 
   const updateOverride = (index: number, field: 'cidr' | 'label', value: string | null) => {
+    setSubnetOverridesActive(true);
     setSubnetOverrides(prev => prev.map((o, i) =>
       i === index ? { ...o, [field]: value, inherited: false } : o
     ));
   };
 
   const removeOverride = (index: number) => {
+    setSubnetOverridesActive(true);
     setSubnetOverrides(prev => prev.filter((_, i) => i !== index));
   };
 
   const addOverride = () => {
     const cidr = newCidr.trim();
     if (!cidr) return;
+    setSubnetOverridesActive(true);
     setSubnetOverrides(prev => [...prev, { cidr, label: null, description: null, inherited: false }]);
     setNewCidr('');
   };

--- a/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
+++ b/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
@@ -81,6 +81,10 @@ export const AddSnapshotModal = ({
   };
 
   const updateOverride = (index: number, field: 'cidr' | 'label', value: string | null) => {
+    if (field === 'cidr') {
+      const nextCidr = (value ?? '').trim().toLowerCase();
+      if (nextCidr && subnetOverrides.some((o, i) => i !== index && o.cidr.trim().toLowerCase() === nextCidr)) return;
+    }
     setSubnetOverridesActive(true);
     setSubnetOverrides(prev => prev.map((o, i) =>
       i === index ? { ...o, [field]: value, inherited: false } : o
@@ -95,6 +99,8 @@ export const AddSnapshotModal = ({
   const addOverride = () => {
     const cidr = newCidr.trim();
     if (!cidr) return;
+    const normalized = cidr.toLowerCase();
+    if (subnetOverrides.some(o => o.cidr.trim().toLowerCase() === normalized)) return;
     setSubnetOverridesActive(true);
     setSubnetOverrides(prev => [...prev, { cidr, label: null, description: null, inherited: false }]);
     setNewCidr('');

--- a/frontend/src/components/monitor/MonitorNetworkDiagram/MonitorNetworkDiagram.tsx
+++ b/frontend/src/components/monitor/MonitorNetworkDiagram/MonitorNetworkDiagram.tsx
@@ -161,7 +161,12 @@ export const MonitorNetworkDiagram = ({
 
   // Sync to the clicked snapshot each time the modal opens; reset UI state
   useEffect(() => {
-    if (show && initialSnapshotId) {
+    if (!show) {
+      setSelectedNode(null);
+      setShowFilterModal(false);
+      return;
+    }
+    if (initialSnapshotId) {
       setSelectedId(initialSnapshotId);
       setSelectedNode(null);
       setIsFullscreen(false);

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -490,6 +490,7 @@ export const NetworkGraph = memo(function NetworkGraph({
     const DRAG_THRESHOLD_PX = 5;
     let dragNode: string | null = null;
     let dragMoved = false;
+    let suppressNextClick = false;
     let dragStartX = 0;
     let dragStartY = 0;
 
@@ -525,7 +526,9 @@ export const NetworkGraph = memo(function NetworkGraph({
 
     const onDragEnd = () => {
       if (!dragNode) return;
+      if (dragMoved) suppressNextClick = true;
       dragNode = null;
+      dragMoved = false;
       sigma.getCamera().enable();
       canvasEl.style.cursor = '';
     };
@@ -573,7 +576,7 @@ export const NetworkGraph = memo(function NetworkGraph({
 
     sigma.on('clickNode', ({ node, event }) => {
       // Suppress click when the mousedown was part of a drag gesture
-      if (dragMoved) { dragMoved = false; return; }
+      if (suppressNextClick) { suppressNextClick = false; return; }
 
       const original = nodesRef.current.find(n => n.id === node);
       if (!original) return;

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -526,7 +526,7 @@ export const NetworkGraph = memo(function NetworkGraph({
 
     const onDragEnd = () => {
       if (!dragNode) return;
-      if (dragMoved) suppressNextClick = true;
+      suppressNextClick = dragMoved;
       dragNode = null;
       dragMoved = false;
       sigma.getCamera().enable();

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -259,7 +259,7 @@ export const FileList = () => {
             </div>
           ) : files.length === 0 ? (
             <div className="text-center text-muted py-4">
-              <p className="mb-0">No recent meetings. Upload or record your first meeting to get started!</p>
+              <p className="mb-0">No uploads yet. Upload a PCAP file to get started!</p>
             </div>
           ) : (() => {
             const displayedFiles = files.filter(f => !hideMonitor || f.source !== 'MONITOR');
@@ -267,7 +267,7 @@ export const FileList = () => {
               return (
                 <div className="text-center text-muted py-4">
                   <p className="mb-0">
-                    No recent meetings. Upload or record your first meeting to get started!{' '}
+                    No uploads here. All PCAP files are monitor-sourced and hidden.{' '}
                     <button
                       type="button"
                       className="btn btn-link p-0 align-baseline text-muted"


### PR DESCRIPTION
## Summary

Applies all valid findings from the automated review on [NotYuSheng/Lanturn#24](https://github.com/NotYuSheng/Lanturn/pull/24) back to this repo.

**Backend**
- `CustomPrivateRangeService`: make `cidrCache` an instance field (not `static`), fix `split("/")` edge case via `indexOf`, pre-resolve IP bytes once before the CIDR loop (avoids N redundant `InetAddress.getByName` calls per `isOverriddenPrivate` call), add `isInCidrs(String, List<String>)` for plain-CIDR callers
- `ChangeDetectionService`: inject `SnapshotSubnetOverrideRepository` and use per-snapshot subnet overrides in ISP/ASN change detection — falls back to global custom private ranges when no overrides exist. Fixes the high-priority gap where snapshot overrides were completely ignored during change detection.
- `SnapshotService.patchSnapshot`: re-run full change detection chain after subnet overrides are updated so change events immediately reflect the new internal/external classification
- `V15` migration: add `UNIQUE(snapshot_id, cidr)` to `snapshot_subnet_overrides` to prevent duplicate CIDR rows per snapshot

**Frontend**
- `FileList`: replace copy-pasted "meetings" text with PCAP-appropriate empty state strings
- `NetworkGraph`: introduce `suppressNextClick` flag — the old `dragMoved`-only approach left the flag `true` if a drag ended off-node, silently swallowing the next legitimate click
- `MonitorNetworkDiagram`: reset `selectedNode` and `showFilterModal` when the parent modal hides so child overlays do not linger on screen without their parent
- `AddSnapshotModal`: only set `subnetOverridesActive` when the user explicitly edits the list; opening the accordion to browse pre-filled globals no longer silently converts "inherit globals" into a snapshot-specific override

## Test plan
- [ ] `docker compose up -d --build` succeeds
- [ ] V15 Flyway migration applies cleanly
- [ ] Adding a PCAP via Monitor snapshot creation with no subnet edits → no overrides persisted (check `snapshot_subnet_overrides` table)
- [ ] Adding a PCAP via Monitor and editing a subnet row → overrides persisted; change events reflect the per-snapshot subnet classification
- [ ] Patching a snapshot's subnet overrides via the Subnets tab → change events are recalculated
- [ ] Dragging a node in the network graph and releasing off-node → next click on a node opens node details normally
- [ ] Opening and closing the Monitor diagram with NodeDetails or Filters modal open → overlays close with the parent
- [ ] FileList with no uploads shows correct PCAP-language empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual edits to snapshot subnet overrides now activate the override for uploads
  * Change detection (ISP/ASN and gateway events) respects per-snapshot subnet overrides

* **Bug Fixes**
  * Suppressed unintended clicks after drag gestures on network diagrams
  * UI state now resets immediately when closing network views
  * Clarified file upload empty-state messaging
  * More robust CIDR validation and matching to reduce misclassification

* **Chores**
  * Enforced unique subnet override (snapshot, CIDR) combinations in DB migration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->