### PR TITLE
docs: document private IP overrides and file retention settings

### DIFF
--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -38,8 +38,7 @@ File Retention
      - ``12``
      - Number of hours after upload before a file is automatically deleted
        (only applies when ``FILE_RETENTION_ENABLED=true``). Monitor Network
-       files are always exempt from automatic deletion regardless of this
-       setting.
+       files are exempt from automatic deletion by default.
 
 Nginx Configuration
 -------------------

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -19,6 +19,28 @@ Upload Configuration
      - Maximum PCAP file size in bytes (default 512 MB). Applies to both the
        Spring Boot backend and the nginx reverse proxy.
 
+File Retention
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Variable
+     - Default
+     - Description
+   * - ``FILE_RETENTION_ENABLED``
+     - ``true``
+     - Set to ``false`` to keep uploaded files indefinitely and disable the
+       automatic cleanup scheduler entirely. Useful for air-gapped or
+       long-term-audit deployments where evidence preservation is required.
+   * - ``FILE_RETENTION_HOURS``
+     - ``12``
+     - Number of hours after upload before a file is automatically deleted
+       (only applies when ``FILE_RETENTION_ENABLED=true``). Monitor Network
+       files are always exempt from automatic deletion regardless of this
+       setting.
+
 Nginx Configuration
 -------------------
 

--- a/docs/features/network-monitor.rst
+++ b/docs/features/network-monitor.rst
@@ -244,6 +244,40 @@ Click any IP badge to open the **Entity Detail** modal, which shows:
 
 Absent addresses follow the same greyed-out / strikethrough pattern.
 
+Private IP Overrides
+~~~~~~~~~~~~~~~~~~~~
+
+By default, TracePcap classifies addresses according to RFC 1918
+(``10.0.0.0/8``, ``172.16.0.0/12``, ``192.168.0.0/16``) and RFC 6598
+(``100.64.0.0/10``). Some networks use public IP address space internally
+(e.g. a terminal that is assigned a routable address but is physically
+on a private LAN). Private IP Overrides let you reclassify any public IP
+or CIDR range as internal so that change-detection and IP grouping treat
+it correctly.
+
+**How to add an override:**
+
+1. Open the network detail page and scroll to the **IP Addresses** drift panel.
+2. Expand the **Private IP Overrides** section at the bottom of the panel.
+3. Enter an IP address (e.g. ``203.0.113.42``) or a CIDR range
+   (e.g. ``203.0.113.0/24``). A bare IP is stored as a ``/32``.
+4. Optionally enter a label (e.g. ``Branch Office Router``).
+5. Click **Add override**.
+
+Overrides take effect immediately. Matching IPs move from the **Public**
+group into the **Private** group (or into the appropriate subnet group if
+subnet definitions are also configured). They are also excluded from
+ASN/gateway change analysis — so a gateway change involving an overridden
+IP will not generate a ``GATEWAY_CHANGE`` or ``ASN_CHANGE`` event.
+
+Overrides are global across all networks. To remove one, click the trash
+icon next to it in the list.
+
+.. note::
+
+   Overrides affect IP *classification* only. Traffic to and from overridden
+   addresses is still captured, analysed, and displayed normally.
+
 Baseline Definitions
 --------------------
 
@@ -758,3 +792,28 @@ Entity notes are global (not per-network). All endpoints are prefixed with ``/ap
    * - ``DELETE``
      - ``/api/entity-notes?entityType={type}&entityKey={key}``
      - Delete a note.
+
+Private IP Overrides
+~~~~~~~~~~~~~~~~~~~~
+
+Overrides are global (not per-network). All endpoints are prefixed with
+``/api/custom-private-ranges``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 45 45
+
+   * - Method
+     - Path
+     - Description
+   * - ``GET``
+     - ``/api/custom-private-ranges``
+     - List all private IP overrides.
+   * - ``POST``
+     - ``/api/custom-private-ranges``
+     - Create an override. Body: ``{ "cidr": "string", "label": "string?" }``.
+       A bare IP (e.g. ``"203.0.113.42"``) is automatically normalised to
+       ``/32``. Returns 400 if the CIDR is invalid or already exists.
+   * - ``DELETE``
+     - ``/api/custom-private-ranges/{id}``
+     - Delete an override by ID.

--- a/docs/features/network-monitor.rst
+++ b/docs/features/network-monitor.rst
@@ -260,7 +260,8 @@ it correctly.
 1. Open the network detail page and scroll to the **IP Addresses** drift panel.
 2. Expand the **Private IP Overrides** section at the bottom of the panel.
 3. Enter an IP address (e.g. ``203.0.113.42``) or a CIDR range
-   (e.g. ``203.0.113.0/24``). A bare IP is stored as a ``/32``.
+   (e.g. ``203.0.113.0/24``). A bare IP is stored as a ``/32`` (or ``/128``
+   for IPv6).
 4. Optionally enter a label (e.g. ``Branch Office Router``).
 5. Click **Add override**.
 
@@ -813,7 +814,8 @@ Overrides are global (not per-network). All endpoints are prefixed with
      - ``/api/custom-private-ranges``
      - Create an override. Body: ``{ "cidr": "string", "label": "string?" }``.
        A bare IP (e.g. ``"203.0.113.42"``) is automatically normalised to
-       ``/32``. Returns 400 if the CIDR is invalid or already exists.
+       ``/32`` (or ``/128`` for IPv6). Returns 400 if the CIDR is invalid or
+       already exists.
    * - ``DELETE``
      - ``/api/custom-private-ranges/{id}``
      - Delete an override by ID.

--- a/docs/features/pcap-upload.rst
+++ b/docs/features/pcap-upload.rst
@@ -71,6 +71,6 @@ entirely (see :doc:`../configuration/environment-variables`).
 
 .. note::
 
-   Monitor Network files are **always exempt** from automatic deletion,
-   regardless of the retention settings. They persist until you manually delete
-   the network or the individual snapshot.
+   Monitor Network files are **exempt by default** from automatic deletion.
+   They persist until you manually delete the network or the individual
+   snapshot, unless a custom monitor retention period is explicitly configured.

--- a/docs/features/pcap-upload.rst
+++ b/docs/features/pcap-upload.rst
@@ -56,3 +56,21 @@ Managing Uploads
 The main file list shows all uploaded PCAPs with their status, size, upload
 date, and detected statistics. You can delete a file from this view, which
 removes both the database metadata and the object from MinIO.
+
+Monitor Network files are **hidden by default** in this list to reduce clutter
+when many snapshots have been uploaded. Use the **Show Monitor files** toggle
+(top-right of the file list) to include them.
+
+File Retention
+~~~~~~~~~~~~~~
+
+By default, uploaded files are automatically deleted **12 hours** after upload.
+This window is configurable via the ``FILE_RETENTION_HOURS`` environment
+variable. Set ``FILE_RETENTION_ENABLED=false`` to disable automatic deletion
+entirely (see :doc:`../configuration/environment-variables`).
+
+.. note::
+
+   Monitor Network files are **always exempt** from automatic deletion,
+   regardless of the retention settings. They persist until you manually delete
+   the network or the individual snapshot.


### PR DESCRIPTION
## Summary

Two features that slipped through without Sphinx docs coverage (identified via a PR audit against the last docs update on 2026-06-07):

### PR #349 — Private IP Overrides
- **`docs/features/network-monitor.rst`**: new "Private IP Overrides" subsection under the IP Addresses Panel — explains how to mark public IPs/CIDRs as internal, the effect on IP grouping and change detection exclusions, and how to remove overrides
- **`docs/features/network-monitor.rst`**: added `GET/POST/DELETE /api/custom-private-ranges` to the REST API Reference table
- **`docs/features/pcap-upload.rst`**: noted that monitor files are hidden by default in All Uploads and are always exempt from automatic deletion

### PR #282 — `FILE_RETENTION_ENABLED` env var
- **`docs/configuration/environment-variables.rst`**: new "File Retention" section documenting `FILE_RETENTION_ENABLED` (default `true`) and `FILE_RETENTION_HOURS` (default `12`), with note that monitor files are always exempt

## Test plan
- [ ] Review prose for accuracy against the implementation in `CustomPrivateRangeController`, `CustomPrivateRangeService`, and `FileCleanupService`
- [ ] Confirm API endpoint signatures match `CustomPrivateRangeController`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Documented configurable file retention (enabled by default, 12‑hour default) with option to disable auto-deletion; Monitor Network files are exempt from automatic cleanup unless a custom retention is set.
* Added Monitor file visibility toggle to show/hide monitor uploads in the upload list.
* Added Private IP Overrides docs and REST API reference for managing custom internal IP ranges; overrides apply immediately and globally, single IPs are normalized, and invalid/duplicate entries are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->