### PR TITLE
ci: notify by email on new issue

### DIFF
--- a/.github/workflows/issue-notify.yml
+++ b/.github/workflows/issue-notify.yml
@@ -1,0 +1,29 @@
+name: Notify on new issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  notify:
+    if: github.event.issue.user.login != 'NotYuSheng'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send email notification
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: "New issue on TracePcap: ${{ github.event.issue.title }}"
+          to: notyusheng@gmail.com
+          from: TracePcap Notifications <${{ secrets.MAIL_USERNAME }}>
+          body: |
+            A new issue was opened by ${{ github.event.issue.user.login }}:
+
+            Title: ${{ github.event.issue.title }}
+            URL:   ${{ github.event.issue.html_url }}
+
+            ${{ github.event.issue.body }}

--- a/.github/workflows/issue-notify.yml
+++ b/.github/workflows/issue-notify.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send email notification
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7 # v3
         with:
           server_address: smtp.gmail.com
           server_port: 465


### PR DESCRIPTION
## Summary
- Add `.github/workflows/issue-notify.yml` that sends an email to notyusheng@gmail.com whenever a new issue is opened.
- Skips issues opened by the repo owner (`NotYuSheng`) to avoid self-notifications.
- Uses `dawidd6/action-send-mail` over Gmail SMTP with credentials from repo secrets.

## Required secrets
- `MAIL_USERNAME` — Gmail address used to send.
- `MAIL_PASSWORD` — Gmail app password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated GitHub Actions workflow that sends an email notification when new issues are opened, using repository secrets for SMTP authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->