### PR TITLE
feat: edit network name and description from monitor listing page

### DIFF
--- a/backend/src/main/java/com/tracepcap/monitor/controller/NetworkController.java
+++ b/backend/src/main/java/com/tracepcap/monitor/controller/NetworkController.java
@@ -2,6 +2,7 @@ package com.tracepcap.monitor.controller;
 
 import com.tracepcap.monitor.dto.CreateNetworkRequest;
 import com.tracepcap.monitor.dto.NetworkDto;
+import com.tracepcap.monitor.dto.UpdateNetworkRequest;
 import com.tracepcap.monitor.service.NetworkService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -31,6 +32,12 @@ public class NetworkController {
   @ResponseStatus(HttpStatus.CREATED)
   public NetworkDto createNetwork(@Valid @RequestBody CreateNetworkRequest request) {
     return networkService.createNetwork(request);
+  }
+
+  @PatchMapping("/{networkId}")
+  public NetworkDto updateNetwork(
+      @PathVariable UUID networkId, @Valid @RequestBody UpdateNetworkRequest request) {
+    return networkService.updateNetwork(networkId, request);
   }
 
   @DeleteMapping("/{networkId}")

--- a/backend/src/main/java/com/tracepcap/monitor/dto/UpdateNetworkRequest.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/UpdateNetworkRequest.java
@@ -1,0 +1,10 @@
+package com.tracepcap.monitor.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UpdateNetworkRequest {
+  @NotBlank private String name;
+  private String description;
+}

--- a/backend/src/main/java/com/tracepcap/monitor/dto/UpdateNetworkRequest.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/UpdateNetworkRequest.java
@@ -1,10 +1,11 @@
 package com.tracepcap.monitor.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class UpdateNetworkRequest {
-  @NotBlank private String name;
+  @NotBlank @Size(max = 255) private String name;
   private String description;
 }

--- a/backend/src/main/java/com/tracepcap/monitor/service/NetworkService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/NetworkService.java
@@ -3,6 +3,7 @@ package com.tracepcap.monitor.service;
 import com.tracepcap.common.exception.ResourceNotFoundException;
 import com.tracepcap.monitor.dto.NetworkDto;
 import com.tracepcap.monitor.dto.CreateNetworkRequest;
+import com.tracepcap.monitor.dto.UpdateNetworkRequest;
 import com.tracepcap.monitor.entity.NetworkEntity;
 import com.tracepcap.insights.repository.NetworkInsightRepository;
 import com.tracepcap.monitor.repository.NetworkChangeEventRepository;
@@ -45,6 +46,13 @@ public class NetworkService {
             .name(request.getName().trim())
             .description(request.getDescription())
             .build();
+    return toDto(networkRepository.save(entity));
+  }
+
+  public NetworkDto updateNetwork(UUID networkId, UpdateNetworkRequest request) {
+    NetworkEntity entity = findOrThrow(networkId);
+    entity.setName(request.getName().trim());
+    entity.setDescription(request.getDescription());
     return toDto(networkRepository.save(entity));
   }
 

--- a/backend/src/main/java/com/tracepcap/monitor/service/NetworkService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/NetworkService.java
@@ -51,8 +51,12 @@ public class NetworkService {
 
   public NetworkDto updateNetwork(UUID networkId, UpdateNetworkRequest request) {
     NetworkEntity entity = findOrThrow(networkId);
-    entity.setName(request.getName().trim());
-    entity.setDescription(request.getDescription());
+    if (request.getName() != null) {
+      entity.setName(request.getName().trim());
+    }
+    if (request.getDescription() != null) {
+      entity.setDescription(request.getDescription().trim().isEmpty() ? null : request.getDescription().trim());
+    }
     return toDto(networkRepository.save(entity));
   }
 

--- a/docs/sample-files.rst
+++ b/docs/sample-files.rst
@@ -256,7 +256,12 @@ enabled. Wait for all eight to reach status *Completed*.
 **Step 2 — Create a Network Monitor session**
 
 Navigate to **Monitor** → **Create Network** → name it
-``Office Audit — Corp HQ`` (or similar).
+``Office Audit — Corp HQ`` and set the description to::
+
+    Corporate HQ office network — weekly PCAP captures from the managed switch spanning eight weeks. Segment covers staff workstations, servers, printers, and BYOD WiFi.
+
+The description is included in the LLM prompt when generating Network Insights,
+giving the model useful context about the environment and capture method.
 
 **Step 3 — Add snapshots**
 

--- a/frontend/src/components/monitor/EditNetworkModal/EditNetworkModal.tsx
+++ b/frontend/src/components/monitor/EditNetworkModal/EditNetworkModal.tsx
@@ -1,0 +1,107 @@
+import { Spinner } from '@components/common/Spinner/Spinner';
+import { useState, useEffect } from 'react';
+import { Alert, Button, Form, Modal } from '@govtechsg/sgds-react';
+
+interface EditNetworkModalProps {
+  show: boolean;
+  onHide: () => void;
+  initialName: string;
+  initialDescription: string | null;
+  onSave: (name: string, description: string) => Promise<void>;
+}
+
+export const EditNetworkModal = ({
+  show,
+  onHide,
+  initialName,
+  initialDescription,
+  onSave,
+}: EditNetworkModalProps) => {
+  const [name, setName] = useState(initialName);
+  const [description, setDescription] = useState(initialDescription ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (show) {
+      setName(initialName);
+      setDescription(initialDescription ?? '');
+      setError(null);
+    }
+  }, [show, initialName, initialDescription]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(name.trim(), description.trim());
+      onHide();
+    } catch {
+      setError('Failed to save changes. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleHide = () => {
+    if (saving) return;
+    onHide();
+  };
+
+  return (
+    <Modal show={show} onHide={handleHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>Edit Network</Modal.Title>
+      </Modal.Header>
+      <form onSubmit={handleSubmit}>
+        <Modal.Body>
+          {error && <Alert variant="danger" className="py-2">{error}</Alert>}
+          <Form.Group className="mb-3">
+            <Form.Label className="fw-semibold" htmlFor="edit-network-name">
+              Name <span className="text-danger">*</span>
+            </Form.Label>
+            <Form.Control
+              id="edit-network-name"
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={255}
+              required
+              autoFocus
+            />
+          </Form.Group>
+          <Form.Group className="mb-3">
+            <Form.Label className="fw-semibold" htmlFor="edit-network-desc">
+              Description
+            </Form.Label>
+            <Form.Control
+              id="edit-network-desc"
+              as="textarea"
+              rows={3}
+              placeholder="Optional description of this network segment"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+            />
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleHide} disabled={saving}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" disabled={saving || !name.trim()}>
+            {saving ? (
+              <>
+                <Spinner animation="border" size="sm" className="me-2" />
+                Saving…
+              </>
+            ) : (
+              'Save Changes'
+            )}
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+};

--- a/frontend/src/components/monitor/NetworkCard/NetworkCard.tsx
+++ b/frontend/src/components/monitor/NetworkCard/NetworkCard.tsx
@@ -4,29 +4,44 @@ import type { Network } from '@/features/monitor/types/monitor.types';
 interface NetworkCardProps {
   network: Network;
   onClick: () => void;
+  onEdit: () => void;
   onDelete: () => void;
 }
 
-export const NetworkCard = ({ network, onClick, onDelete }: NetworkCardProps) => {
+export const NetworkCard = ({ network, onClick, onEdit, onDelete }: NetworkCardProps) => {
   return (
     <Card className="h-100" style={{ cursor: 'pointer' }} onClick={onClick}>
       <Card.Body>
         <div className="d-flex justify-content-between align-items-start mb-2">
           <h5 className="mb-0 text-break">{network.name}</h5>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline-danger"
-            className="ms-2 flex-shrink-0"
-            onClick={e => {
-              e.stopPropagation();
-              onDelete();
-            }}
-            title="Delete network"
-            aria-label="Delete network"
-          >
-            <i className="bi bi-trash"></i>
-          </Button>
+          <div className="d-flex gap-1 ms-2 flex-shrink-0">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline-secondary"
+              onClick={e => {
+                e.stopPropagation();
+                onEdit();
+              }}
+              title="Edit network"
+              aria-label="Edit network"
+            >
+              <i className="bi bi-pencil"></i>
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline-danger"
+              onClick={e => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              title="Delete network"
+              aria-label="Delete network"
+            >
+              <i className="bi bi-trash"></i>
+            </Button>
+          </div>
         </div>
 
         {network.description && (

--- a/frontend/src/features/monitor/services/monitorService.ts
+++ b/frontend/src/features/monitor/services/monitorService.ts
@@ -23,7 +23,7 @@ export const monitorService = {
       .post<Network>(MONITOR_ENDPOINTS.NETWORKS, { name, description })
       .then(r => r.data),
 
-  updateNetwork: (id: string, name: string, description?: string): Promise<Network> =>
+  updateNetwork: (id: string, name: string, description: string): Promise<Network> =>
     apiClient
       .patch<Network>(MONITOR_ENDPOINTS.NETWORK(id), { name, description })
       .then(r => r.data),

--- a/frontend/src/features/monitor/services/monitorService.ts
+++ b/frontend/src/features/monitor/services/monitorService.ts
@@ -23,6 +23,11 @@ export const monitorService = {
       .post<Network>(MONITOR_ENDPOINTS.NETWORKS, { name, description })
       .then(r => r.data),
 
+  updateNetwork: (id: string, name: string, description?: string): Promise<Network> =>
+    apiClient
+      .patch<Network>(MONITOR_ENDPOINTS.NETWORK(id), { name, description })
+      .then(r => r.data),
+
   deleteNetwork: (id: string): Promise<void> =>
     apiClient.delete(MONITOR_ENDPOINTS.NETWORK(id)).then(() => undefined),
 

--- a/frontend/src/pages/Monitor/MonitorPage.tsx
+++ b/frontend/src/pages/Monitor/MonitorPage.tsx
@@ -44,7 +44,7 @@ export const MonitorPage = () => {
 
   const handleUpdate = async (name: string, description: string) => {
     if (!editNetwork) return;
-    const updated = await monitorService.updateNetwork(editNetwork.id, name, description || undefined);
+    const updated = await monitorService.updateNetwork(editNetwork.id, name, description);
     setNetworks(prev => prev.map(n => n.id === updated.id ? updated : n));
     setEditNetwork(null);
   };

--- a/frontend/src/pages/Monitor/MonitorPage.tsx
+++ b/frontend/src/pages/Monitor/MonitorPage.tsx
@@ -6,6 +6,7 @@ import { monitorService } from '@/features/monitor/services/monitorService';
 import type { Network } from '@/features/monitor/types/monitor.types';
 import { NetworkCard } from '@/components/monitor/NetworkCard/NetworkCard';
 import { CreateNetworkModal } from '@/components/monitor/CreateNetworkModal/CreateNetworkModal';
+import { EditNetworkModal } from '@/components/monitor/EditNetworkModal/EditNetworkModal';
 
 export const MonitorPage = () => {
   const navigate = useNavigate();
@@ -13,6 +14,7 @@ export const MonitorPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
+  const [editNetwork, setEditNetwork] = useState<Network | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -38,6 +40,13 @@ export const MonitorPage = () => {
   const handleCreate = async (name: string, description: string) => {
     const network = await monitorService.createNetwork(name, description);
     setNetworks(prev => [network, ...prev]);
+  };
+
+  const handleUpdate = async (name: string, description: string) => {
+    if (!editNetwork) return;
+    const updated = await monitorService.updateNetwork(editNetwork.id, name, description || undefined);
+    setNetworks(prev => prev.map(n => n.id === updated.id ? updated : n));
+    setEditNetwork(null);
   };
 
   const handleDelete = async (id: string) => {
@@ -131,6 +140,7 @@ export const MonitorPage = () => {
               <NetworkCard
                 network={network}
                 onClick={() => navigate(`/monitor/${network.id}`)}
+                onEdit={() => setEditNetwork(network)}
                 onDelete={() => setConfirmDeleteId(network.id)}
               />
             </Col>
@@ -142,6 +152,14 @@ export const MonitorPage = () => {
         show={showCreate}
         onHide={() => setShowCreate(false)}
         onCreate={handleCreate}
+      />
+
+      <EditNetworkModal
+        show={!!editNetwork}
+        onHide={() => setEditNetwork(null)}
+        initialName={editNetwork?.name ?? ''}
+        initialDescription={editNetwork?.description ?? null}
+        onSave={handleUpdate}
       />
 
       <Modal show={!!confirmDeleteId} onHide={() => setConfirmDeleteId(null)} centered>

--- a/frontend/src/pages/Monitor/NetworkDetailPage.tsx
+++ b/frontend/src/pages/Monitor/NetworkDetailPage.tsx
@@ -792,6 +792,7 @@ export const NetworkDetailPage = () => {
         onAdd={handleAddSnapshot}
       />
 
+
     </Container>
   );
 };


### PR DESCRIPTION
Closes #391

## Summary
- New `EditNetworkModal` component pre-populated with the current name and description
- Pencil icon button added to each `NetworkCard` on the `/monitor` listing page, to the left of the trash button
- New `PATCH /api/monitor/networks/{id}` backend endpoint backed by `UpdateNetworkRequest` DTO and `NetworkService.updateNetwork()`
- `monitorService.updateNetwork()` added on the frontend
- Walkthrough docs updated with a recommended description for the Office Audit demo network, noting it is fed to the LLM during insight generation

## Test plan
- [ ] Open `/monitor`, click the pencil on a network card — modal opens pre-filled
- [ ] Edit name and/or description, save — card updates immediately without page reload
- [ ] Cancel — no changes applied
- [ ] Verify description appears in LLM prompt by generating Network Insights after adding a description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for updating an existing network’s name and description from the network monitoring interface, including an Edit modal and saving state/feedback.
  * Updated the backend API to accept partial network updates for an existing network.

* **Documentation**
  * Improved the “Step 2 — Create a Network Monitor session” instructions with clearer, scenario-specific context for prompt generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->