### PR TITLE
test: Playwright e2e smoke suite (guards #384 Alert regression)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,9 +33,11 @@ jobs:
         run: docker compose up -d --build
 
       - name: Wait for app to be ready
+        # Use 127.0.0.1, not localhost: Docker publishes the port on IPv4 only,
+        # but localhost can resolve to IPv6 (::1) first and fail to connect.
         run: |
           for i in $(seq 1 60); do
-            if [ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8888/api/files)" = "200" ]; then
+            if [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8888/api/files)" = "200" ]; then
               echo "App is up"; exit 0
             fi
             sleep 5
@@ -54,6 +56,8 @@ jobs:
 
       - name: Run e2e tests
         working-directory: frontend
+        env:
+          E2E_BASE_URL: http://127.0.0.1:8888
         run: npm run test:e2e
 
       - name: Upload Playwright report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,69 @@
+name: E2E Smoke Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - 'docker-compose.yml'
+      - 'nginx/**'
+      - '.github/workflows/e2e.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Playwright smoke tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build and start the stack
+        run: docker compose up -d --build
+
+      - name: Wait for app to be ready
+        run: |
+          for i in $(seq 1 60); do
+            if [ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8888/api/files)" = "200" ]; then
+              echo "App is up"; exit 0
+            fi
+            sleep 5
+          done
+          echo "App did not become ready in time"
+          docker compose logs --tail=100
+          exit 1
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        working-directory: frontend
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
+      - name: Dump stack logs on failure
+        if: failure()
+        run: docker compose logs --tail=200

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,11 @@ jobs:
     name: Playwright smoke tests
     runs-on: ubuntu-latest
 
+    # No .env file in CI (it's gitignored), so compose would default NGINX_PORT
+    # to 80. Pin it to 8888 to match the readiness check and the test baseURL.
+    env:
+      NGINX_PORT: '8888'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -27,3 +27,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+playwright-report/
+test-results/

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,29 @@
+# E2E smoke tests
+
+Playwright tests that drive the real app in a browser. They guard against
+runtime-only regressions that type-checking and builds miss — notably the
+React 19 issue where SGDS `Alert` rendered `null` and error states showed a
+blank screen instead of a message (issue #384).
+
+## Run locally
+
+1. Bring up the stack:
+   ```bash
+   docker compose up -d --build
+   ```
+2. From `frontend/`:
+   ```bash
+   npm ci
+   npx playwright install chromium
+   npm run test:e2e
+   ```
+
+The tests target `http://localhost:8888` by default; override with
+`E2E_BASE_URL`. The LLM-error tests force the `502` response via Playwright
+route interception, so they do not require a (un)reachable LLM.
+
+## What's covered
+
+- `smoke.spec.ts` — the app loads and primary navigation renders.
+- `llm-error.spec.ts` — Story and Filter Generator show a visible error alert
+  (not a blank container) when generation returns `502`.

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -32,15 +32,19 @@ export async function uploadAndProcessFixture(request: APIRequestContext): Promi
   const fileId: string = body.fileId ?? body.existingFileId;
   expect(fileId).toBeTruthy();
 
-  await expect
-    .poll(
-      async () => {
-        const r = await request.get(`/api/files/${fileId}`);
-        return r.ok() ? (await r.json()).status : 'pending';
-      },
-      { timeout: 60_000, intervals: [1000, 2000] }
-    )
-    .toBe('completed');
+  // Poll until processing finishes; fail fast if the backend marks it 'failed'
+  // instead of waiting out the whole timeout.
+  const deadline = Date.now() + 60_000;
+  let status = 'pending';
+  while (Date.now() < deadline) {
+    const r = await request.get(`/api/files/${fileId}`);
+    if (r.ok()) {
+      status = (await r.json()).status;
+      if (status === 'completed' || status === 'failed') break;
+    }
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  }
+  expect(status, `file processing did not complete (status: ${status})`).toBe('completed');
 
   return fileId;
 }

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,54 @@
+import { APIRequestContext, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PCAP = path.resolve(here, '../../sample-files/ftp.pcap');
+
+/**
+ * Upload a small sample pcap and wait until the backend finishes processing it,
+ * returning the fileId. Used so the analysis pages have real data to render.
+ */
+export async function uploadAndProcessFixture(request: APIRequestContext): Promise<string> {
+  const upload = await request.post('/api/files', {
+    multipart: {
+      file: {
+        name: 'ftp.pcap',
+        mimeType: 'application/octet-stream',
+        buffer: fs.readFileSync(FIXTURE_PCAP),
+      },
+      enableNdpi: 'true',
+      enableFileExtraction: 'true',
+      source: 'ANALYSIS',
+    },
+  });
+  // 409 = this pcap was already uploaded (dedup by hash); reuse the existing one.
+  expect(
+    upload.ok() || upload.status() === 409,
+    `upload failed: ${upload.status()}`
+  ).toBeTruthy();
+  const body = await upload.json();
+  const fileId: string = body.fileId ?? body.existingFileId;
+  expect(fileId).toBeTruthy();
+
+  await expect
+    .poll(
+      async () => {
+        const r = await request.get(`/api/files/${fileId}`);
+        return r.ok() ? (await r.json()).status : 'pending';
+      },
+      { timeout: 60_000, intervals: [1000, 2000] }
+    )
+    .toBe('completed');
+
+  return fileId;
+}
+
+/** The JSON body the backend returns for a 502 when the LLM is unreachable. */
+export const LLM_UNREACHABLE_502 = {
+  status: 502,
+  error: 'Bad Gateway',
+  message: 'LLM server is not reachable: Connection refused',
+  errorCode: 'LLM_UNREACHABLE',
+};

--- a/frontend/e2e/llm-error.spec.ts
+++ b/frontend/e2e/llm-error.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, request as pwRequest } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { uploadAndProcessFixture, LLM_UNREACHABLE_502 } from './helpers';
 
 /**
@@ -9,13 +9,10 @@ import { uploadAndProcessFixture, LLM_UNREACHABLE_502 } from './helpers';
  * is actually visible with its message.
  */
 
-const BASE = process.env.E2E_BASE_URL || 'http://localhost:8888';
 let fileId: string;
 
-test.beforeAll(async () => {
-  const ctx = await pwRequest.newContext({ baseURL: BASE });
-  fileId = await uploadAndProcessFixture(ctx);
-  await ctx.dispose();
+test.beforeAll(async ({ request }) => {
+  fileId = await uploadAndProcessFixture(request);
 });
 
 test('Story tab shows an error alert when story generation returns 502', async ({ page }) => {

--- a/frontend/e2e/llm-error.spec.ts
+++ b/frontend/e2e/llm-error.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, request as pwRequest } from '@playwright/test';
+import { uploadAndProcessFixture, LLM_UNREACHABLE_502 } from './helpers';
+
+/**
+ * Regression guard for #384: when the LLM is unreachable (502), the UI must show
+ * a visible error alert — not a blank/empty container. The blank screen was
+ * caused by React 19 dropping SGDS Alert's `defaultProps` so the Alert rendered
+ * `null`. These tests force the 502 via route interception and assert the alert
+ * is actually visible with its message.
+ */
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8888';
+let fileId: string;
+
+test.beforeAll(async () => {
+  const ctx = await pwRequest.newContext({ baseURL: BASE });
+  fileId = await uploadAndProcessFixture(ctx);
+  await ctx.dispose();
+});
+
+test('Story tab shows an error alert when story generation returns 502', async ({ page }) => {
+  // Force the "no existing story" state so the Generate Story button is shown,
+  // regardless of whether this file already has a story persisted.
+  await page.route('**/api/story/file/**', route =>
+    route.fulfill({ status: 204, body: '' })
+  );
+  await page.route('**/api/story/generate/**', route =>
+    route.fulfill({
+      status: 502,
+      contentType: 'application/json',
+      body: JSON.stringify(LLM_UNREACHABLE_502),
+    })
+  );
+
+  await page.goto(`/analysis/${fileId}/story`);
+  await page.getByRole('button', { name: /Generate Story/i }).click();
+
+  const alert = page.locator('.error-message-container .alert');
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText(/LLM server is not responding/i);
+  await expect(page.getByRole('button', { name: /Retry/i })).toBeVisible();
+});
+
+test('Filter Generator shows an error alert when filter generation returns 502', async ({ page }) => {
+  await page.route('**/api/filter/generate/**', route =>
+    route.fulfill({
+      status: 502,
+      contentType: 'application/json',
+      body: JSON.stringify(LLM_UNREACHABLE_502),
+    })
+  );
+
+  await page.goto(`/analysis/${fileId}/filter-generator`);
+  await page.locator('textarea').first().fill('show me all HTTP traffic');
+  await page.getByRole('button', { name: /Generate Filter/i }).click();
+
+  const alert = page.locator('.alert-danger');
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText(/LLM server is not responding/i);
+});

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('app smoke', () => {
+  test('home/upload page renders', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('TracePcap').first()).toBeVisible();
+    // Primary nav is present
+    await expect(page.getByRole('link', { name: /Analyse/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Monitor/i })).toBeVisible();
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.61.0",
         "@types/color-hash": "^2.0.0",
         "@types/d3": "^7.4.3",
         "@types/node": "^24.10.1",
@@ -1338,6 +1339,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -5312,6 +5329,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,scss,md}\"",
     "lint:css": "stylelint \"src/**/*.css\"",
     "lint:css:fix": "stylelint \"src/**/*.css\" --fix",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@govtechsg/sgds": "^2.3.6",
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.61.0",
     "@types/color-hash": "^2.0.0",
     "@types/d3": "^7.4.3",
     "@types/node": "^24.10.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E smoke tests run against a running TracePcap stack (nginx on :8888).
+ * Bring the stack up first: `docker compose up -d --build`.
+ * Run: `npm run test:e2e` (from frontend/).
+ */
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:8888',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: { args: ['--no-sandbox'] },
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Stacked on #395 (the #384 fix). Base will retarget to `main` once #395 merges.

Adds a small Playwright e2e suite so runtime-only regressions — which type-check and build cleanly — are caught in CI. The motivating case is #384: SGDS `Alert` rendered `null` under React 19, so error states showed a blank container.

## What's added
- **`frontend/playwright.config.ts`** — targets the running stack at `http://localhost:8888` (override via `E2E_BASE_URL`).
- **`e2e/smoke.spec.ts`** — app loads and primary nav renders.
- **`e2e/llm-error.spec.ts`** — Story tab and Filter Generator render a *visible* error alert (not a blank container) when generation returns `502`. The 502 is forced via Playwright route interception, so no (un)reachable LLM is needed; the Story test also stubs the "existing story" lookup to 204 so it's deterministic.
- **`e2e/helpers.ts`** — uploads `sample-files/ftp.pcap` and waits for processing (reuses the existing file on a 409 dedup).
- **`@playwright/test`** devDependency + `test:e2e` script + `e2e/README.md`.
- **`.github/workflows/e2e.yml`** — boots the stack (`docker compose up -d --build`) and runs the suite on PRs touching frontend/backend/compose/nginx.

## Verification
Ran locally against the stack — all green:
```
✓ e2e/llm-error.spec.ts  Story tab shows an error alert when story generation returns 502
✓ e2e/llm-error.spec.ts  Filter Generator shows an error alert when filter generation returns 502
✓ e2e/smoke.spec.ts      app smoke › home/upload page renders
3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)