### PR TITLE
fix: arrow keys in Conversation Tracer no longer navigate underlying Conversation modal

### DIFF
--- a/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
+++ b/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
@@ -202,8 +202,8 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') { e.stopPropagation(); onClose(); }
-      if (e.key === 'ArrowRight') next();
-      if (e.key === 'ArrowLeft') prev();
+      if (e.key === 'ArrowRight') { e.stopPropagation(); next(); }
+      if (e.key === 'ArrowLeft') { e.stopPropagation(); prev(); }
     };
     document.addEventListener('keydown', onKey, true);
     return () => document.removeEventListener('keydown', onKey, true);


### PR DESCRIPTION
## Summary
Fixes #385. When the **Conversation Tracer** modal is stacked on top of the **Conversation detail** modal, pressing ←/→ stepped the tracer **and** advanced the underlying conversation, because both components attach a `document` `keydown` listener.

The tracer's capture-phase handler already called `stopPropagation()` for `Escape` but not for the arrow keys, so arrow events continued bubbling to `ConversationPage`'s handler.

## Change
Call `e.stopPropagation()` for `ArrowRight`/`ArrowLeft` in the tracer's keydown handler, matching the existing `Escape` behavior. Since the handler runs in the capture phase, this stops the event before it reaches the page-level handler.

```diff
 if (e.key === 'Escape') { e.stopPropagation(); onClose(); }
-if (e.key === 'ArrowRight') next();
-if (e.key === 'ArrowLeft') prev();
+if (e.key === 'ArrowRight') { e.stopPropagation(); next(); }
+if (e.key === 'ArrowLeft') { e.stopPropagation(); prev(); }
```

## Testing
- `npx tsc --noEmit` passes
- `docker compose up -d --build` rebuilds/restarts cleanly
- Manually verified: with both modals stacked, ←/→ now only steps the tracer and the underlying conversation no longer changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* **Fixed keyboard navigation**: Arrow key navigation in the conversation tracer now works correctly without interfering with other interface interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->