### PR TITLE
fix: e2e fail-fast on file-status error + route error boundary message

### DIFF
--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -41,7 +41,11 @@ export async function uploadAndProcessFixture(request: APIRequestContext): Promi
     if (!r.ok()) {
       throw new Error(`Failed to get file status: ${r.status()} ${r.statusText()}`);
     }
-    status = (await r.json()).status;
+    const body = await r.json();
+    status = body.status;
+    if (!status) {
+      throw new Error(`Response body missing 'status' field: ${JSON.stringify(body)}`);
+    }
     if (status === 'completed' || status === 'failed') break;
     await new Promise(resolve => setTimeout(resolve, 2000));
   }

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -38,10 +38,11 @@ export async function uploadAndProcessFixture(request: APIRequestContext): Promi
   let status = 'pending';
   while (Date.now() < deadline) {
     const r = await request.get(`/api/files/${fileId}`);
-    if (r.ok()) {
-      status = (await r.json()).status;
-      if (status === 'completed' || status === 'failed') break;
+    if (!r.ok()) {
+      throw new Error(`Failed to get file status: ${r.status()} ${r.statusText()}`);
     }
+    status = (await r.json()).status;
+    if (status === 'completed' || status === 'failed') break;
     await new Promise(resolve => setTimeout(resolve, 2000));
   }
   expect(status, `file processing did not complete (status: ${status})`).toBe('completed');

--- a/frontend/src/components/common/RouteErrorBoundary/RouteErrorBoundary.tsx
+++ b/frontend/src/components/common/RouteErrorBoundary/RouteErrorBoundary.tsx
@@ -27,6 +27,8 @@ export const RouteErrorBoundary = () => {
       if (typeof data.message === 'string') message = data.message;
       else if (typeof data.error === 'string') message = data.error;
     }
+  } else if (error instanceof Error) {
+    message = error.message;
   }
 
   const detail =

--- a/frontend/src/components/common/RouteErrorBoundary/RouteErrorBoundary.tsx
+++ b/frontend/src/components/common/RouteErrorBoundary/RouteErrorBoundary.tsx
@@ -29,14 +29,24 @@ export const RouteErrorBoundary = () => {
     }
   } else if (error instanceof Error) {
     message = error.message;
+  } else if (error && typeof error === 'object') {
+    const errObj = error as Record<string, unknown>;
+    if (typeof errObj.message === 'string') message = errObj.message;
+    else if (typeof errObj.error === 'string') message = errObj.error;
   }
 
-  const detail =
-    error instanceof Error
-      ? error.stack || error.message
-      : typeof error === 'string'
-        ? error
-        : undefined;
+  let detail: string | undefined;
+  if (error instanceof Error) {
+    detail = error.stack || error.message;
+  } else if (typeof error === 'string') {
+    detail = error;
+  } else if (error && typeof error === 'object') {
+    try {
+      detail = JSON.stringify(error, null, 2);
+    } catch {
+      detail = String(error);
+    }
+  }
 
   return (
     <Container className="route-error-boundary">


### PR DESCRIPTION
## Summary
Follow-up fixes addressing review feedback from #397. The Playwright e2e suite and route error boundary themselves already landed on `main` via #395; this PR applies the two outstanding review suggestions on top.

- **`e2e/helpers.ts`** — throw immediately on a non-ok file-status response instead of polling until the 60s timeout (fail fast)
- **`RouteErrorBoundary.tsx`** — surface `error.message` for non-route `Error` instances rather than the generic fallback string

## Testing
- `npx tsc --noEmit` passes
- `docker compose up -d --build` rebuilds/restarts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the routing error boundary to display clearer messages when the error is not an `Error` instance, including safe detail rendering in development.

* **Tests**
  * Updated the file upload/process test helper to fail fast on non-OK status during processing polling and to error when the expected `status` field is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->