### PR TITLE
feat: distinguish responding vs non-responding peers in conversation tracer (#387)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
@@ -26,6 +26,14 @@ public interface ConversationRepository
 
   long countByFileId(UUID fileId);
 
+  /** All conversations in a file in which the given IP is either endpoint (initiator or peer). */
+  @Query(
+      "SELECT c FROM ConversationEntity c WHERE c.file.id = :fileId"
+          + " AND (c.srcIp = :ip OR c.dstIp = :ip)"
+          + " ORDER BY c.packetCount DESC")
+  List<ConversationEntity> findByFileIdAndIp(
+      @Param("fileId") UUID fileId, @Param("ip") String ip);
+
   /** Returns the distinct detected file types present in packets for the given file. */
   @Query(
       "SELECT DISTINCT p.detectedFileType FROM PacketEntity p"

--- a/backend/src/main/java/com/tracepcap/analysis/repository/PacketRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/PacketRepository.java
@@ -21,4 +21,15 @@ public interface PacketRepository extends JpaRepository<PacketEntity, UUID> {
       "SELECT p.packetNumber FROM PacketEntity p"
           + " WHERE p.conversation.id IN :ids ORDER BY p.packetNumber ASC")
   List<Long> findPacketNumbersByConversationIds(@Param("ids") List<UUID> ids);
+
+  /**
+   * Of the given conversations, returns the ids that contain at least one packet sent by a host
+   * other than {@code hostIp} — i.e. the peer transmitted back, so it "responded". Used by the
+   * conversation tracer to distinguish responding from silent nodes (e.g. ARP/ICMP/port scans).
+   */
+  @Query(
+      "SELECT DISTINCT p.conversation.id FROM PacketEntity p"
+          + " WHERE p.conversation.id IN :ids AND p.srcIp <> :hostIp")
+  List<UUID> findConversationIdsWithReplyFromPeer(
+      @Param("ids") List<UUID> ids, @Param("hostIp") String hostIp);
 }

--- a/backend/src/main/java/com/tracepcap/analysis/repository/PacketRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/PacketRepository.java
@@ -23,13 +23,17 @@ public interface PacketRepository extends JpaRepository<PacketEntity, UUID> {
   List<Long> findPacketNumbersByConversationIds(@Param("ids") List<UUID> ids);
 
   /**
-   * Of the given conversations, returns the ids that contain at least one packet sent by a host
-   * other than {@code hostIp} — i.e. the peer transmitted back, so it "responded". Used by the
-   * conversation tracer to distinguish responding from silent nodes (e.g. ARP/ICMP/port scans).
+   * For the given file, returns the ids of conversations involving {@code hostIp} that contain at
+   * least one packet sent by the peer (a host other than {@code hostIp}) — i.e. the peer
+   * transmitted back, so it "responded". Used by the conversation tracer to distinguish responding
+   * from silent nodes (e.g. ARP/ICMP/port scans). Joins on file + host directly rather than passing
+   * a list of ids, avoiding large IN clauses and database parameter limits.
    */
   @Query(
       "SELECT DISTINCT p.conversation.id FROM PacketEntity p"
-          + " WHERE p.conversation.id IN :ids AND p.srcIp <> :hostIp")
+          + " WHERE p.conversation.file.id = :fileId"
+          + " AND (p.conversation.srcIp = :hostIp OR p.conversation.dstIp = :hostIp)"
+          + " AND p.srcIp <> :hostIp")
   List<UUID> findConversationIdsWithReplyFromPeer(
-      @Param("ids") List<UUID> ids, @Param("hostIp") String hostIp);
+      @Param("fileId") UUID fileId, @Param("hostIp") String hostIp);
 }

--- a/backend/src/main/java/com/tracepcap/tracer/controller/ConversationTracerController.java
+++ b/backend/src/main/java/com/tracepcap/tracer/controller/ConversationTracerController.java
@@ -1,6 +1,7 @@
 package com.tracepcap.tracer.controller;
 
 import com.tracepcap.tracer.dto.TracerExplainResponse;
+import com.tracepcap.tracer.dto.TracerPeersResponse;
 import com.tracepcap.tracer.dto.TracerStepsResponse;
 import com.tracepcap.tracer.service.ConversationTracerService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,6 +28,15 @@ public class ConversationTracerController {
   public ResponseEntity<TracerStepsResponse> getSteps(@PathVariable UUID conversationId) {
     log.info("GET /api/tracer/{}/steps", conversationId);
     return ResponseEntity.ok(tracerService.getSteps(conversationId));
+  }
+
+  @GetMapping("/{conversationId}/peers")
+  @Operation(
+      summary = "Get traced host's peers with response status",
+      description = "Returns every peer the traced host exchanged packets with, each flagged as responding or silent — for scan-style visualisation (e.g. ARP scans).")
+  public ResponseEntity<TracerPeersResponse> getPeers(@PathVariable UUID conversationId) {
+    log.info("GET /api/tracer/{}/peers", conversationId);
+    return ResponseEntity.ok(tracerService.getPeers(conversationId));
   }
 
   @PostMapping("/{conversationId}/explain")

--- a/backend/src/main/java/com/tracepcap/tracer/dto/TracerPeer.java
+++ b/backend/src/main/java/com/tracepcap/tracer/dto/TracerPeer.java
@@ -1,0 +1,15 @@
+package com.tracepcap.tracer.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/** A peer that the traced host exchanged packets with, plus whether it responded. */
+@Data
+@Builder
+public class TracerPeer {
+  private String ip;
+  private String conversationId; // representative conversation between host and this peer
+  private String protocol;
+  private long packetCount;
+  private boolean responded; // true if the peer sent at least one packet back to the host
+}

--- a/backend/src/main/java/com/tracepcap/tracer/dto/TracerPeersResponse.java
+++ b/backend/src/main/java/com/tracepcap/tracer/dto/TracerPeersResponse.java
@@ -1,0 +1,17 @@
+package com.tracepcap.tracer.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Peers reached by the traced host, each flagged as responding or silent. Powers the tracer's
+ * scan-style visualisation (e.g. ARP scan) where only a subset of probed targets reply.
+ */
+@Data
+@Builder
+public class TracerPeersResponse {
+  private String conversationId; // the conversation that was queried
+  private String hostIp; // the traced host (initiator) all peers are relative to
+  private List<TracerPeer> peers;
+}

--- a/backend/src/main/java/com/tracepcap/tracer/service/ConversationTracerService.java
+++ b/backend/src/main/java/com/tracepcap/tracer/service/ConversationTracerService.java
@@ -87,8 +87,7 @@ public class ConversationTracerService {
     List<ConversationEntity> hostConvs = conversationRepository.findByFileIdAndIp(fileId, hostIp);
 
     Set<UUID> respondedConvIds = new HashSet<>(
-        packetRepository.findConversationIdsWithReplyFromPeer(
-            hostConvs.stream().map(ConversationEntity::getId).toList(), hostIp));
+        packetRepository.findConversationIdsWithReplyFromPeer(fileId, hostIp));
 
     // Aggregate per peer IP: a peer counts as responding if any of its conversations had a reply.
     // Preserve packetCount-desc ordering from the query via a LinkedHashMap.
@@ -97,7 +96,7 @@ public class ConversationTracerService {
     Map<String, Boolean> respondedByPeer = new HashMap<>();
 
     for (ConversationEntity c : hostConvs) {
-      String peerIp = c.getSrcIp().equals(hostIp) ? c.getDstIp() : c.getSrcIp();
+      String peerIp = hostIp.equals(c.getSrcIp()) ? c.getDstIp() : c.getSrcIp();
       if (peerIp == null || peerIp.equals(hostIp)) continue;
       boolean replied = respondedConvIds.contains(c.getId());
       respondedByPeer.merge(peerIp, replied, Boolean::logicalOr);

--- a/backend/src/main/java/com/tracepcap/tracer/service/ConversationTracerService.java
+++ b/backend/src/main/java/com/tracepcap/tracer/service/ConversationTracerService.java
@@ -71,6 +71,59 @@ public class ConversationTracerService {
         .build();
   }
 
+  /**
+   * Returns the peers the traced host exchanged packets with, each flagged as responding or silent.
+   * The host is the initiator (srcIp) of the given conversation. "Responded" is determined directly
+   * from packet directions — a peer responded if it sent at least one packet back to the host —
+   * which is reliable across protocols (ARP, ICMP, TCP/UDP port scans) regardless of nDPI risks.
+   */
+  public TracerPeersResponse getPeers(UUID conversationId) {
+    ConversationEntity conv = conversationRepository.findById(conversationId)
+        .orElseThrow(() -> new NoSuchElementException("Conversation not found: " + conversationId));
+
+    String hostIp = conv.getSrcIp();
+    UUID fileId = conv.getFile().getId();
+
+    List<ConversationEntity> hostConvs = conversationRepository.findByFileIdAndIp(fileId, hostIp);
+
+    Set<UUID> respondedConvIds = new HashSet<>(
+        packetRepository.findConversationIdsWithReplyFromPeer(
+            hostConvs.stream().map(ConversationEntity::getId).toList(), hostIp));
+
+    // Aggregate per peer IP: a peer counts as responding if any of its conversations had a reply.
+    // Preserve packetCount-desc ordering from the query via a LinkedHashMap.
+    Map<String, TracerPeer.TracerPeerBuilder> byPeer = new LinkedHashMap<>();
+    Map<String, Long> packetTotals = new HashMap<>();
+    Map<String, Boolean> respondedByPeer = new HashMap<>();
+
+    for (ConversationEntity c : hostConvs) {
+      String peerIp = c.getSrcIp().equals(hostIp) ? c.getDstIp() : c.getSrcIp();
+      if (peerIp == null || peerIp.equals(hostIp)) continue;
+      boolean replied = respondedConvIds.contains(c.getId());
+      respondedByPeer.merge(peerIp, replied, Boolean::logicalOr);
+      packetTotals.merge(peerIp, c.getPacketCount() != null ? c.getPacketCount() : 0L, Long::sum);
+      byPeer.computeIfAbsent(
+          peerIp,
+          ip -> TracerPeer.builder()
+              .ip(ip)
+              .conversationId(c.getId().toString())
+              .protocol(c.getProtocol()));
+    }
+
+    List<TracerPeer> peers = byPeer.entrySet().stream()
+        .map(e -> e.getValue()
+            .packetCount(packetTotals.getOrDefault(e.getKey(), 0L))
+            .responded(Boolean.TRUE.equals(respondedByPeer.get(e.getKey())))
+            .build())
+        .toList();
+
+    return TracerPeersResponse.builder()
+        .conversationId(conversationId.toString())
+        .hostIp(hostIp)
+        .peers(peers)
+        .build();
+  }
+
   public TracerExplainResponse explainSteps(UUID conversationId) {
     // Return from cache if available
     List<StepExplanation> cached = explanationCache.get(conversationId);

--- a/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
+++ b/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
@@ -2,8 +2,7 @@ import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Badge, Button, OverlayTrigger, Popover } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
-import { tracerService, type TracerStep, type TracerStepsResponse } from '@/features/tracer/tracerService';
-import { conversationService } from '@/features/conversation/services/conversationService';
+import { tracerService, type TracerStep, type TracerStepsResponse, type TracerPeer } from '@/features/tracer/tracerService';
 
 function AiExplanationInfoPopover() {
   const popover = (
@@ -42,7 +41,6 @@ function AiExplanationInfoPopover() {
 
 interface ConversationTracerModalProps {
   conversationId: string;
-  fileId: string;
   onClose: () => void;
 }
 
@@ -54,6 +52,11 @@ const CX = SVG_W / 2;
 const CY = SVG_H / 2;
 const PEER_R = 150; // radius of the peer ring
 const NODE_R = 26;  // node circle radius
+
+// Node state colors
+const COLOR_ACTIVE = '#0072c6';   // traced peer (blue)
+const COLOR_RESPONDED = '#107c10'; // peer that replied (green)
+const COLOR_SILENT = '#9aa0a6';    // peer that never replied (muted gray)
 
 function peerPos(index: number, total: number): { x: number; y: number } {
   // Start from top (−π/2) so single peer appears directly above center
@@ -74,11 +77,11 @@ function shortIp(ip: string): string {
 
 // ── Main modal ────────────────────────────────────────────────────────────────
 
-export const ConversationTracerModal = ({ conversationId, fileId, onClose }: ConversationTracerModalProps) => {
+export const ConversationTracerModal = ({ conversationId, onClose }: ConversationTracerModalProps) => {
   const [tracer, setTracer] = useState<TracerStepsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [peers, setPeers] = useState<string[]>([]);
+  const [peers, setPeers] = useState<TracerPeer[]>([]);
 
   const [currentStep, setCurrentStep] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -105,31 +108,23 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
       .finally(() => setLoading(false));
   }, [conversationId]);
 
-  // Fetch all conversations for srcIp → build peer list
+  // Fetch the host's peers with response status → build peer ring
   useEffect(() => {
-    if (!tracer || !fileId) return;
-    const srcIp = tracer.srcIp;
-    conversationService.getConversations(fileId, {
-      ip: srcIp,
-      port: '', payloadContains: '',
-      protocols: [], l7Protocols: [], apps: [], categories: [],
-      hasRisks: false, fileTypes: [], riskTypes: [], customSignatures: [],
-      deviceTypes: [], countries: [],
-      sortBy: '', sortDir: 'desc',
-      page: 1, pageSize: 50,
-    }).then(result => {
-      const peerSet = new Set<string>();
-      result.data.forEach(c => {
-        const [src, dst] = c.endpoints;
-        peerSet.add(src.ip === srcIp ? dst.ip : src.ip);
+    if (!tracer) return;
+    tracerService.getPeers(conversationId)
+      .then(result => {
+        // Keep the ring readable: always include the traced peer, then fill up to 12.
+        const traced = result.peers.filter(p => p.ip === tracer.dstIp);
+        const others = result.peers.filter(p => p.ip !== tracer.dstIp);
+        const ordered = [...traced, ...others].slice(0, 12);
+        setPeers(ordered.length > 0
+          ? ordered
+          : [{ ip: tracer.dstIp, conversationId, protocol: tracer.protocol, packetCount: 0, responded: false }]);
+      })
+      .catch(() => {
+        setPeers([{ ip: tracer.dstIp, conversationId, protocol: tracer.protocol, packetCount: 0, responded: false }]);
       });
-      // Always include the traced conversation's peer
-      peerSet.add(tracer.dstIp);
-      setPeers([...peerSet].slice(0, 12));
-    }).catch(() => {
-      setPeers([tracer.dstIp]);
-    });
-  }, [tracer, fileId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [tracer, conversationId]);
 
   // Fetch LLM explanations after steps load
   useEffect(() => {
@@ -218,7 +213,7 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
 
   // Compute dot position for the current step
   const activePeerIp = tracer?.dstIp ?? null;
-  const activePeerIdx = peers.indexOf(activePeerIp ?? '');
+  const activePeerIdx = peers.findIndex(p => p.ip === activePeerIp);
   const dotPos = useMemo(() => {
     if (!step || activePeerIdx < 0) return null;
     const pos = peerPos(activePeerIdx, peers.length);
@@ -284,17 +279,22 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
                   style={{ width: '100%', height: 'auto', maxHeight: 260, display: 'block' }}
                 >
                   {/* Edges */}
-                  {peers.map((ip, i) => {
+                  {peers.map((peer, i) => {
                     const pos = peerPos(i, peers.length);
-                    const isActive = ip === activePeerIp;
+                    const isActive = peer.ip === activePeerIp;
+                    const color = isActive
+                      ? COLOR_ACTIVE
+                      : peer.responded ? COLOR_RESPONDED : COLOR_SILENT;
+                    // Silent peers: dashed + dimmed; responded/active: solid edge.
                     return (
                       <line
-                        key={ip}
+                        key={peer.ip}
                         x1={CX} y1={CY}
                         x2={pos.x} y2={pos.y}
-                        stroke={isActive ? '#0072c6' : 'var(--tp-border)'}
+                        stroke={color}
                         strokeWidth={isActive ? 2.5 : 1.5}
-                        strokeDasharray={isActive ? undefined : '5 4'}
+                        strokeDasharray={peer.responded || isActive ? undefined : '5 4'}
+                        opacity={peer.responded || isActive ? 1 : 0.5}
                       />
                     );
                   })}
@@ -325,41 +325,71 @@ export const ConversationTracerModal = ({ conversationId, fileId, onClose }: Con
                   </text>
 
                   {/* Peer nodes */}
-                  {peers.map((ip, i) => {
+                  {peers.map((peer, i) => {
                     const pos = peerPos(i, peers.length);
-                    const isActive = ip === activePeerIp;
+                    const isActive = peer.ip === activePeerIp;
+                    const silent = !peer.responded && !isActive;
+                    const color = isActive
+                      ? COLOR_ACTIVE
+                      : peer.responded ? COLOR_RESPONDED : COLOR_SILENT;
+                    const label = isActive
+                      ? 'Traced'
+                      : peer.responded ? 'Responded' : 'No response';
                     // Place label above or below based on y position
                     const labelY = pos.y < CY
                       ? pos.y - NODE_R - 6
                       : pos.y + NODE_R + 13;
                     return (
-                      <g key={ip}>
+                      <g key={peer.ip} opacity={silent ? 0.55 : 1}>
                         <circle
                           cx={pos.x} cy={pos.y} r={NODE_R}
                           fill={isActive ? 'var(--tp-surface-hover)' : 'var(--tp-bg-subtle)'}
-                          stroke={isActive ? '#0072c6' : 'var(--tp-text-muted)'}
+                          stroke={color}
                           strokeWidth={isActive ? 2 : 1.5}
+                          strokeDasharray={silent ? '4 3' : undefined}
                         />
                         <text
                           x={pos.x} y={pos.y + 4}
                           textAnchor="middle" dominantBaseline="middle"
                           fontSize={8} fontFamily="monospace"
-                          fill={isActive ? '#0050a0' : 'var(--tp-text-muted)'}
+                          fill={color}
                         >
-                          {shortIp(ip)}
+                          {shortIp(peer.ip)}
                         </text>
                         <text
                           x={pos.x} y={labelY}
                           textAnchor="middle" fontSize={10}
-                          fill={isActive ? '#0072c6' : 'var(--tp-text-muted)'}
+                          fill={color}
                           fontWeight={isActive ? 600 : 400}
                         >
-                          {isActive ? 'Traced' : 'Peer'}
+                          {label}
                         </text>
                       </g>
                     );
                   })}
                 </svg>
+
+                {/* Legend + scan summary — only meaningful when probing multiple peers */}
+                {peers.length > 1 && (() => {
+                  const respondedCount = peers.filter(p => p.responded).length;
+                  const silentCount = peers.length - respondedCount;
+                  const Swatch = ({ color, dashed, text }: { color: string; dashed?: boolean; text: string }) => (
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                      <svg width={16} height={10} aria-hidden="true">
+                        <circle cx={5} cy={5} r={4} fill="none" stroke={color} strokeWidth={1.5}
+                          strokeDasharray={dashed ? '2 2' : undefined} opacity={dashed ? 0.7 : 1} />
+                      </svg>
+                      {text}
+                    </span>
+                  );
+                  return (
+                    <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center', gap: 12, fontSize: 10, color: 'var(--tp-text-muted)', marginBottom: 4 }}>
+                      <Swatch color={COLOR_RESPONDED} text={`Responded (${respondedCount})`} />
+                      <Swatch color={COLOR_SILENT} dashed text={`No response (${silentCount})`} />
+                      <Swatch color={COLOR_ACTIVE} text="Traced" />
+                    </div>
+                  );
+                })()}
 
                 {/* Step info */}
                 {step?.info && (

--- a/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
+++ b/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
@@ -58,6 +58,19 @@ const COLOR_ACTIVE = '#0072c6';   // traced peer (blue)
 const COLOR_RESPONDED = '#107c10'; // peer that replied (green)
 const COLOR_SILENT = '#9aa0a6';    // peer that never replied (muted gray)
 
+/** Legend swatch — defined at module scope to avoid recreating the component each render. */
+function Swatch({ color, dashed, text }: { color: string; dashed?: boolean; text: string }) {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <svg width={16} height={10} aria-hidden="true">
+        <circle cx={5} cy={5} r={4} fill="none" stroke={color} strokeWidth={1.5}
+          strokeDasharray={dashed ? '2 2' : undefined} opacity={dashed ? 0.7 : 1} />
+      </svg>
+      {text}
+    </span>
+  );
+}
+
 function peerPos(index: number, total: number): { x: number; y: number } {
   // Start from top (−π/2) so single peer appears directly above center
   const angle = (2 * Math.PI * index) / total - Math.PI / 2;
@@ -373,15 +386,6 @@ export const ConversationTracerModal = ({ conversationId, onClose }: Conversatio
                 {peers.length > 1 && (() => {
                   const respondedCount = peers.filter(p => p.responded).length;
                   const silentCount = peers.length - respondedCount;
-                  const Swatch = ({ color, dashed, text }: { color: string; dashed?: boolean; text: string }) => (
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                      <svg width={16} height={10} aria-hidden="true">
-                        <circle cx={5} cy={5} r={4} fill="none" stroke={color} strokeWidth={1.5}
-                          strokeDasharray={dashed ? '2 2' : undefined} opacity={dashed ? 0.7 : 1} />
-                      </svg>
-                      {text}
-                    </span>
-                  );
                   return (
                     <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center', gap: 12, fontSize: 10, color: 'var(--tp-text-muted)', marginBottom: 4 }}>
                       <Swatch color={COLOR_RESPONDED} text={`Responded (${respondedCount})`} />

--- a/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
+++ b/frontend/src/components/conversation/ConversationTracer/ConversationTracerModal.tsx
@@ -124,19 +124,22 @@ export const ConversationTracerModal = ({ conversationId, onClose }: Conversatio
   // Fetch the host's peers with response status → build peer ring
   useEffect(() => {
     if (!tracer) return;
+    let cancelled = false;
+    const fallback = [{ ip: tracer.dstIp, conversationId, protocol: tracer.protocol, packetCount: 0, responded: false }];
     tracerService.getPeers(conversationId)
       .then(result => {
+        if (cancelled) return;
         // Keep the ring readable: always include the traced peer, then fill up to 12.
         const traced = result.peers.filter(p => p.ip === tracer.dstIp);
         const others = result.peers.filter(p => p.ip !== tracer.dstIp);
         const ordered = [...traced, ...others].slice(0, 12);
-        setPeers(ordered.length > 0
-          ? ordered
-          : [{ ip: tracer.dstIp, conversationId, protocol: tracer.protocol, packetCount: 0, responded: false }]);
+        setPeers(ordered.length > 0 ? ordered : fallback);
       })
       .catch(() => {
-        setPeers([{ ip: tracer.dstIp, conversationId, protocol: tracer.protocol, packetCount: 0, responded: false }]);
+        if (cancelled) return;
+        setPeers(fallback);
       });
+    return () => { cancelled = true; };
   }, [tracer, conversationId]);
 
   // Fetch LLM explanations after steps load
@@ -384,8 +387,10 @@ export const ConversationTracerModal = ({ conversationId, onClose }: Conversatio
 
                 {/* Legend + scan summary — only meaningful when probing multiple peers */}
                 {peers.length > 1 && (() => {
-                  const respondedCount = peers.filter(p => p.responded).length;
-                  const silentCount = peers.length - respondedCount;
+                  // Counts exclude the traced peer, which is shown as its own state.
+                  const nonTraced = peers.filter(p => p.ip !== activePeerIp);
+                  const respondedCount = nonTraced.filter(p => p.responded).length;
+                  const silentCount = nonTraced.length - respondedCount;
                   return (
                     <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center', gap: 12, fontSize: 10, color: 'var(--tp-text-muted)', marginBottom: 4 }}>
                       <Swatch color={COLOR_RESPONDED} text={`Responded (${respondedCount})`} />

--- a/frontend/src/features/tracer/tracerService.ts
+++ b/frontend/src/features/tracer/tracerService.ts
@@ -23,6 +23,20 @@ export interface TracerStepsResponse {
   steps: TracerStep[];
 }
 
+export interface TracerPeer {
+  ip: string;
+  conversationId: string;
+  protocol: string;
+  packetCount: number;
+  responded: boolean;
+}
+
+export interface TracerPeersResponse {
+  conversationId: string;
+  hostIp: string;
+  peers: TracerPeer[];
+}
+
 export interface StepExplanation {
   stepIndex: number;
   explanation: string;
@@ -38,6 +52,13 @@ export const tracerService = {
   async getSteps(conversationId: string): Promise<TracerStepsResponse> {
     const res = await apiClient.get<TracerStepsResponse>(
       API_ENDPOINTS.TRACER_STEPS(conversationId)
+    );
+    return res.data;
+  },
+
+  async getPeers(conversationId: string): Promise<TracerPeersResponse> {
+    const res = await apiClient.get<TracerPeersResponse>(
+      API_ENDPOINTS.TRACER_PEERS(conversationId)
     );
     return res.data;
   },

--- a/frontend/src/pages/Conversation/ConversationPage.tsx
+++ b/frontend/src/pages/Conversation/ConversationPage.tsx
@@ -498,7 +498,6 @@ export const ConversationPage = () => {
       {tracerConversationId && (
         <ConversationTracerModal
           conversationId={tracerConversationId}
-          fileId={fileId}
           onClose={() => setTracerConversationId(null)}
         />
       )}

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -50,6 +50,7 @@ export const API_ENDPOINTS = {
 
   // Conversation Tracer
   TRACER_STEPS: (conversationId: string) => `/tracer/${conversationId}/steps`,
+  TRACER_PEERS: (conversationId: string) => `/tracer/${conversationId}/peers`,
   TRACER_EXPLAIN: (conversationId: string) => `/tracer/${conversationId}/explain`,
 
   // IP Org Rules (Network Labels)

--- a/sample-files/gen_arp_scan.py
+++ b/sample-files/gen_arp_scan.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Generate arp_scan.pcap — one host ARP-scanning a /24, only some hosts reply.
+
+Demonstrates issue #387: the conversation tracer should distinguish responding
+from silent nodes. Scanner 192.168.1.10 sends "who-has" for .1 .. .12;
+a subset reply with their MAC, the rest stay silent.
+"""
+import os
+from scapy.all import wrpcap
+from scapy.layers.l2 import Ether, ARP
+
+SCANNER_IP = "192.168.1.10"
+SCANNER_MAC = "aa:bb:cc:00:00:10"
+
+# .ip -> mac for hosts that ARE alive (will reply); others are silent.
+ALIVE = {
+    1: "aa:bb:cc:00:00:01",
+    5: "aa:bb:cc:00:00:05",
+    7: "aa:bb:cc:00:00:07",
+    11: "aa:bb:cc:00:00:0b",
+}
+TARGETS = range(1, 13)  # probe .1 .. .12
+
+pkts = []
+for n in TARGETS:
+    target_ip = f"192.168.1.{n}"
+    # Broadcast ARP request "who has target_ip, tell SCANNER_IP"
+    req = Ether(src=SCANNER_MAC, dst="ff:ff:ff:ff:ff:ff") / ARP(
+        op=1, hwsrc=SCANNER_MAC, psrc=SCANNER_IP, hwdst="00:00:00:00:00:00", pdst=target_ip
+    )
+    pkts.append(req)
+    if n in ALIVE:
+        # ARP reply: target_ip is-at its MAC, unicast back to scanner
+        reply = Ether(src=ALIVE[n], dst=SCANNER_MAC) / ARP(
+            op=2, hwsrc=ALIVE[n], psrc=target_ip, hwdst=SCANNER_MAC, pdst=SCANNER_IP
+        )
+        pkts.append(reply)
+
+out = os.path.join(os.path.dirname(__file__), "arp_scan.pcap")
+wrpcap(out, pkts)
+print(f"Wrote {out}: {len(pkts)} packets, {len(ALIVE)} of {len(list(TARGETS))} targets alive")

--- a/sample-files/gen_arp_scan.py
+++ b/sample-files/gen_arp_scan.py
@@ -19,7 +19,8 @@ ALIVE = {
     7: "aa:bb:cc:00:00:07",
     11: "aa:bb:cc:00:00:0b",
 }
-TARGETS = range(1, 13)  # probe .1 .. .12
+SCANNER_LAST_OCTET = int(SCANNER_IP.rsplit(".", 1)[1])
+TARGETS = [n for n in range(1, 13) if n != SCANNER_LAST_OCTET]  # probe .1 .. .12 (skip scanner)
 
 pkts = []
 for n in TARGETS:


### PR DESCRIPTION
## Summary

Closes #387. Enhances the conversation tracer to visually distinguish **nodes that respond** from **nodes that stay silent** — making one-to-many probe patterns like ARP scans immediately legible.

Each peer the traced host probed is now rendered in one of three states:

- **Responded** — green, solid node + edge (the peer sent traffic back)
- **No response** — dimmed, dashed gray node + edge (silent target)
- **Traced** — blue, the conversation currently being stepped through

A legend with live counts sits under the graph.

## How response status is determined

Resolving the issue's open question on data source: it's computed **on the backend, directly from packet directions** — a peer "responded" iff it sent at least one packet back to the host. This is reliable across protocols (ARP, ICMP, TCP/UDP port scans) and does **not** depend on nDPI flow risks; verified that nDPI's `unidirectional_traffic` flag is not set for ARP traffic, so the existing frontend `direction` field would not have worked.

## Changes

**Backend**
- New `GET /api/tracer/{conversationId}/peers` → every peer of the traced host with a `responded` flag
- `ConversationRepository.findByFileIdAndIp`, `PacketRepository.findConversationIdsWithReplyFromPeer`
- `TracerPeer` / `TracerPeersResponse` DTOs, `ConversationTracerService.getPeers`

**Frontend**
- `tracerService.getPeers` + `TRACER_PEERS` endpoint
- `ConversationTracerModal` derives the peer ring from the new endpoint and renders responded/silent/traced node + edge states with a legend
- Removed the now-unused `fileId` prop / `conversationService` dependency from the modal

## Testing

- `docker compose up -d --build` — builds clean
- Added `sample-files/gen_arp_scan.py` to reproduce a one-to-many ARP scan capture (one host probes `.1`–`.12`; `.1/.5/.7/.11` reply)
- Verified end-to-end: `/peers` returns 4 responders + 7 silent (self-IP excluded); the modal renders the ring as expected (confirmed via Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added peer discovery to Conversation Tracer: the modal now lists all peers the traced host exchanged packets with, including whether each peer responded.
  * Implemented a new backend peers endpoint to aggregate per-peer metadata across the conversation set.
* **UI Improvements**
  * Updated the star-graph visualization to use richer peer data (responded vs no-response vs traced), with muted/dashed styling for silent peers.
  * Added a conditional legend showing counts for responded and no-response peers.
* **Chores**
  * Added a sample ARP-scan script to generate a demo capture (`arp_scan.pcap`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->