### PR TITLE
feat: configurable file extraction limits + UI limit warnings (#324)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,19 @@ OVERVIEW_APPS_LIMITED=true
 # Applications are ranked alphabetically. Increase if your captures regularly identify many distinct apps.
 OVERVIEW_APPS_MAX=100
 
+# File Extraction Configuration
+# Tunes the limits applied when extracting embedded files from captures. When any limit is hit,
+# a warning is shown on the Extracted Files tab so you know results may be incomplete.
+# EXTRACTION_MAX_MATCHES_PER_STREAM: Max files extracted from a single raw TCP/UDP stream.
+# Guards against runaway extraction on streams with many magic-byte sequences. Increase to extract more.
+EXTRACTION_MAX_MATCHES_PER_STREAM=20
+# EXTRACTION_MAX_STREAM_CONVERSATIONS: Max number of non-HTTP streams scanned for embedded files per PCAP.
+# Increase if large captures have many distinct file-bearing conversations.
+EXTRACTION_MAX_STREAM_CONVERSATIONS=50
+# EXTRACTION_MAX_FILE_SIZE_MB: Max size (in MB) of a single extracted file that will be stored.
+# Larger files are detected but skipped (shown with a "Too large" badge). Increase to store bigger files.
+EXTRACTION_MAX_FILE_SIZE_MB=50
+
 # Frontend Configuration
 # VITE_MAP_RESOLUTION: Controls the polygon fidelity of the world map at build time.
 # Allowed values: 110m (low fidelity, ~170 KB), 50m (medium — default, ~760 KB), 10m (high fidelity, ~1 MB)

--- a/backend/src/main/java/com/tracepcap/analysis/controller/ExtractedFilesController.java
+++ b/backend/src/main/java/com/tracepcap/analysis/controller/ExtractedFilesController.java
@@ -29,6 +29,9 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 @RequiredArgsConstructor
 public class ExtractedFilesController {
 
+  /** Upper bound on size-skipped files returned in the warnings response. */
+  private static final int MAX_SIZE_LIMIT_FILES = 100;
+
   private final ExtractedFileRepository extractedFileRepository;
   private final FileRepository fileRepository;
   private final StorageService storageService;
@@ -59,10 +62,13 @@ public class ExtractedFilesController {
             .findById(fileId)
             .orElseThrow(() -> new ResourceNotFoundException("File not found: " + fileId));
 
-    // Size-limit skips are persisted as extracted_files rows — list them from there.
+    // Size-limit skips are persisted as extracted_files rows — query just those, capped to
+    // keep the response bounded on captures with very many skipped files.
     List<ExtractionWarningsResponse.SkippedFile> sizeLimitFiles =
-        extractedFileRepository.findByFileIdOrderByCreatedAtAsc(fileId).stream()
-            .filter(e -> "exceeds_size_limit".equals(e.getSkippedReason()))
+        extractedFileRepository
+            .findByFileIdAndSkippedReasonOrderByCreatedAtAsc(fileId, "exceeds_size_limit")
+            .stream()
+            .limit(MAX_SIZE_LIMIT_FILES)
             .map(
                 e ->
                     ExtractionWarningsResponse.SkippedFile.builder()
@@ -87,14 +93,23 @@ public class ExtractedFilesController {
             .build());
   }
 
-  /** Parses a comma-separated list of conversation UUIDs into a list (empty when null/blank). */
+  /**
+   * Parses a comma-separated list of conversation UUIDs into a list (empty when null/blank).
+   * Malformed tokens are skipped rather than failing the whole request.
+   */
   private static List<UUID> parseConvIds(String csv) {
     if (csv == null || csv.isBlank()) return List.of();
-    return java.util.Arrays.stream(csv.split(","))
-        .map(String::trim)
-        .filter(s -> !s.isEmpty())
-        .map(UUID::fromString)
-        .collect(Collectors.toList());
+    List<UUID> ids = new java.util.ArrayList<>();
+    for (String token : csv.split(",")) {
+      String s = token.trim();
+      if (s.isEmpty()) continue;
+      try {
+        ids.add(UUID.fromString(s));
+      } catch (IllegalArgumentException e) {
+        log.warn("Skipping malformed conversation id in extraction warning: {}", s);
+      }
+    }
+    return ids;
   }
 
   /** MIME types the browser can safely render inline without a plugin. */

--- a/backend/src/main/java/com/tracepcap/analysis/controller/ExtractedFilesController.java
+++ b/backend/src/main/java/com/tracepcap/analysis/controller/ExtractedFilesController.java
@@ -1,9 +1,13 @@
 package com.tracepcap.analysis.controller;
 
 import com.tracepcap.analysis.dto.ExtractedFileResponse;
+import com.tracepcap.analysis.dto.ExtractionWarningsResponse;
 import com.tracepcap.analysis.entity.ExtractedFileEntity;
 import com.tracepcap.analysis.repository.ExtractedFileRepository;
+import com.tracepcap.analysis.service.ExtractionLimits;
 import com.tracepcap.common.exception.ResourceNotFoundException;
+import com.tracepcap.file.entity.FileEntity;
+import com.tracepcap.file.repository.FileRepository;
 import com.tracepcap.file.service.StorageService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.io.InputStream;
@@ -26,7 +30,9 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 public class ExtractedFilesController {
 
   private final ExtractedFileRepository extractedFileRepository;
+  private final FileRepository fileRepository;
   private final StorageService storageService;
+  private final ExtractionLimits extractionLimits;
 
   @GetMapping
   @Operation(summary = "List all files extracted from a PCAP capture")
@@ -42,6 +48,53 @@ public class ExtractedFilesController {
         entities.stream().map(this::toResponse).collect(Collectors.toList());
 
     return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/warnings")
+  @Operation(summary = "Report which file-extraction limits were hit for a PCAP capture")
+  public ResponseEntity<ExtractionWarningsResponse> extractionWarnings(@PathVariable UUID fileId) {
+
+    FileEntity file =
+        fileRepository
+            .findById(fileId)
+            .orElseThrow(() -> new ResourceNotFoundException("File not found: " + fileId));
+
+    // Size-limit skips are persisted as extracted_files rows — list them from there.
+    List<ExtractionWarningsResponse.SkippedFile> sizeLimitFiles =
+        extractedFileRepository.findByFileIdOrderByCreatedAtAsc(fileId).stream()
+            .filter(e -> "exceeds_size_limit".equals(e.getSkippedReason()))
+            .map(
+                e ->
+                    ExtractionWarningsResponse.SkippedFile.builder()
+                        .id(e.getId())
+                        .conversationId(
+                            e.getConversation() != null ? e.getConversation().getId() : null)
+                        .filename(e.getFilename())
+                        .fileSize(e.getFileSize())
+                        .build())
+            .collect(Collectors.toList());
+
+    return ResponseEntity.ok(
+        ExtractionWarningsResponse.builder()
+            .matchLimitConversationIds(parseConvIds(file.getExtractionMatchLimitConvIds()))
+            .conversationLimitSkippedCount(file.getExtractionConversationLimitSkippedCount())
+            .conversationLimitSkippedIds(
+                parseConvIds(file.getExtractionConversationLimitSkippedIds()))
+            .sizeLimitFiles(sizeLimitFiles)
+            .maxMatchesPerStream(extractionLimits.getMaxMatchesPerStream())
+            .maxStreamConversations(extractionLimits.getMaxStreamConversations())
+            .maxFileSizeMb(extractionLimits.getMaxFileSizeMb())
+            .build());
+  }
+
+  /** Parses a comma-separated list of conversation UUIDs into a list (empty when null/blank). */
+  private static List<UUID> parseConvIds(String csv) {
+    if (csv == null || csv.isBlank()) return List.of();
+    return java.util.Arrays.stream(csv.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(UUID::fromString)
+        .collect(Collectors.toList());
   }
 
   /** MIME types the browser can safely render inline without a plugin. */

--- a/backend/src/main/java/com/tracepcap/analysis/dto/ExtractionWarningsResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/ExtractionWarningsResponse.java
@@ -1,0 +1,53 @@
+package com.tracepcap.analysis.dto;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Reports which configurable file-extraction limits were hit while processing a PCAP, with enough
+ * detail (specific streams and files) for the UI to point users at what was truncated, alongside the
+ * limit values in effect.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExtractionWarningsResponse {
+
+  /** Conversation IDs whose raw stream hit the per-stream file cap; more files may exist. */
+  private List<UUID> matchLimitConversationIds;
+
+  /** Total non-HTTP file-bearing streams that were not scanned because of the conversation cap. */
+  private int conversationLimitSkippedCount;
+
+  /** Conversation IDs (capped) of the non-HTTP streams that were skipped. */
+  private List<UUID> conversationLimitSkippedIds;
+
+  /** Files detected but not stored because they exceeded the per-file size limit. */
+  private List<SkippedFile> sizeLimitFiles;
+
+  /** Configured maximum files extracted per raw stream. */
+  private int maxMatchesPerStream;
+
+  /** Configured maximum non-HTTP streams scanned per PCAP. */
+  private int maxStreamConversations;
+
+  /** Configured maximum size, in MB, of a single extracted file. */
+  private int maxFileSizeMb;
+
+  /** A single file that was detected but skipped for exceeding the size limit. */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class SkippedFile {
+    private UUID id;
+    private UUID conversationId;
+    private String filename;
+    private Long fileSize;
+  }
+}

--- a/backend/src/main/java/com/tracepcap/analysis/repository/ExtractedFileRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/ExtractedFileRepository.java
@@ -11,6 +11,9 @@ public interface ExtractedFileRepository extends JpaRepository<ExtractedFileEnti
 
   List<ExtractedFileEntity> findByFileIdOrderByCreatedAtAsc(UUID fileId);
 
+  List<ExtractedFileEntity> findByFileIdAndSkippedReasonOrderByCreatedAtAsc(
+      UUID fileId, String skippedReason);
+
   List<ExtractedFileEntity> findByConversationId(UUID conversationId);
 
   long countByConversationId(UUID conversationId);

--- a/backend/src/main/java/com/tracepcap/analysis/service/ExtractionLimits.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/ExtractionLimits.java
@@ -1,5 +1,6 @@
 package com.tracepcap.analysis.service;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -31,5 +32,26 @@ public class ExtractionLimits {
   /** Convenience accessor returning the per-file size limit in bytes. */
   public long maxFileSizeBytes() {
     return (long) maxFileSizeMb * 1024 * 1024;
+  }
+
+  /**
+   * Fail fast on misconfiguration so a bad value is caught at startup rather than crashing
+   * mid-analysis. {@code maxMatchesPerStream} must be at least 1 (0 would still extract one file
+   * yet report the cap as hit). The other two may be 0 — meaning "scan no raw streams" / "store no
+   * extracted files" respectively — but never negative (which would break {@code subList}/{@code
+   * limit} and size comparisons downstream).
+   */
+  @PostConstruct
+  void validate() {
+    if (maxMatchesPerStream < 1 || maxStreamConversations < 0 || maxFileSizeMb < 0) {
+      throw new IllegalStateException(
+          "Invalid extraction limits (maxMatchesPerStream must be >= 1; the others >= 0): "
+              + "maxMatchesPerStream="
+              + maxMatchesPerStream
+              + ", maxStreamConversations="
+              + maxStreamConversations
+              + ", maxFileSizeMb="
+              + maxFileSizeMb);
+    }
   }
 }

--- a/backend/src/main/java/com/tracepcap/analysis/service/ExtractionLimits.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/ExtractionLimits.java
@@ -1,0 +1,35 @@
+package com.tracepcap.analysis.service;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Runtime-tunable limits for the file extraction pipeline.
+ *
+ * <p>Each value defaults to its historical compile-time constant and can be overridden via an
+ * environment variable (wired through {@code application.yml}) without rebuilding the image. Shared
+ * by {@link FileExtractionService} (enforcement) and the extractions controller (surfacing the
+ * configured values in UI warnings).
+ */
+@Component
+@Getter
+public class ExtractionLimits {
+
+  /** Maximum embedded files extracted per raw TCP/UDP stream. */
+  @Value("${tracepcap.extraction.max-matches-per-stream:20}")
+  private int maxMatchesPerStream;
+
+  /** Maximum number of non-HTTP conversations scanned for embedded files per PCAP. */
+  @Value("${tracepcap.extraction.max-stream-conversations:50}")
+  private int maxStreamConversations;
+
+  /** Maximum size, in megabytes, of a single extracted file stored in MinIO. */
+  @Value("${tracepcap.extraction.max-file-size-mb:50}")
+  private int maxFileSizeMb;
+
+  /** Convenience accessor returning the per-file size limit in bytes. */
+  public long maxFileSizeBytes() {
+    return (long) maxFileSizeMb * 1024 * 1024;
+  }
+}

--- a/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
@@ -458,6 +458,11 @@ public class FileExtractionService {
   // Raw stream extraction
   // -------------------------------------------------------------------------
 
+  /**
+   * Reconstructs non-HTTP TCP/UDP streams whose packets had file-type detections and scans them for
+   * embedded files via magic-byte matching. Records on {@code file} which conversations hit the
+   * per-stream match cap and how many streams were skipped by the conversation cap.
+   */
   private void extractFromRawStreams(
       FileEntity file, File tempPcapFile, List<ConversationEntity> allConvs) {
 

--- a/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
@@ -41,12 +41,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FileExtractionService {
 
-  /** Maximum size of a single extracted file stored in MinIO (50 MB). */
-  private static final int MAX_EXTRACTED_FILE_BYTES = 50 * 1024 * 1024;
-
   /**
    * Maximum bytes buffered per raw stream during reassembly (200 MB). This is intentionally larger
-   * than {@link #MAX_EXTRACTED_FILE_BYTES} so that magic-byte scanning can still find files near
+   * than the configurable per-file size limit so that magic-byte scanning can still find files near
    * the end of a large stream, while preventing a single runaway stream from exhausting heap.
    */
   private static final int MAX_STREAM_BUFFER_BYTES = 200 * 1024 * 1024;
@@ -54,14 +51,11 @@ public class FileExtractionService {
   /** Skipped-reason value written to DB when a file exceeds the per-file size limit. */
   private static final String REASON_EXCEEDS_SIZE_LIMIT = "exceeds_size_limit";
 
-  /** Maximum number of non-HTTP conversations to scan for embedded files. */
-  private static final int MAX_RAW_STREAM_CONVERSATIONS = 50;
-
   /**
-   * Maximum embedded files extracted per raw stream. Prevents runaway extraction on streams that
-   * contain many magic-byte sequences (e.g. synthetic test data or binary protocols).
+   * Maximum conversation IDs recorded per limit-hit warning. Bounds the size of the warning detail
+   * stored on the file row (and rendered in the UI) when very large captures hit a limit.
    */
-  private static final int MAX_MATCHES_PER_STREAM = 20;
+  private static final int MAX_RECORDED_CONV_IDS = 100;
 
   private static final Tika TIKA = new Tika();
 
@@ -168,6 +162,7 @@ public class FileExtractionService {
   private final ConversationRepository conversationRepository;
   private final PacketRepository packetRepository;
   private final StorageService storageService;
+  private final ExtractionLimits limits;
 
   // -------------------------------------------------------------------------
   // Public entry point
@@ -471,7 +466,7 @@ public class FileExtractionService {
 
     if (convIdsWithFiles.isEmpty()) return;
 
-    List<ConversationEntity> candidates =
+    List<ConversationEntity> eligible =
         allConvs.stream()
             .filter(c -> convIdsWithFiles.contains(c.getId()))
             .filter(
@@ -479,8 +474,23 @@ public class FileExtractionService {
                   String tp = c.getTsharkProtocol();
                   return tp == null || !tp.toUpperCase().contains("HTTP");
                 })
-            .limit(MAX_RAW_STREAM_CONVERSATIONS)
             .toList();
+
+    if (eligible.size() > limits.getMaxStreamConversations()) {
+      List<ConversationEntity> skipped =
+          eligible.subList(limits.getMaxStreamConversations(), eligible.size());
+      log.warn(
+          "PCAP {} has {} non-HTTP streams with file-type hits — scanning only the first {} "
+              + "(raise EXTRACTION_MAX_STREAM_CONVERSATIONS to scan more)",
+          file.getId(),
+          eligible.size(),
+          limits.getMaxStreamConversations());
+      file.setExtractionConversationLimitSkippedCount(skipped.size());
+      file.setExtractionConversationLimitSkippedIds(joinConvIds(skipped));
+    }
+
+    List<ConversationEntity> candidates =
+        eligible.stream().limit(limits.getMaxStreamConversations()).toList();
 
     if (candidates.isEmpty()) return;
 
@@ -512,22 +522,40 @@ public class FileExtractionService {
     // Single tshark pass to read all required streams at once.
     Map<String, byte[]> streamData = readAllStreams(tempPcapFile, tcpIds, udpIds);
 
+    List<ConversationEntity> matchCapped = new ArrayList<>();
     for (Map.Entry<ConversationEntity, StreamInfo> entry : convStreamMap.entrySet()) {
       ConversationEntity conv = entry.getKey();
       StreamInfo info = entry.getValue();
       byte[] streamBytes = streamData.get(info.transport() + ":" + info.index());
       if (streamBytes == null || streamBytes.length == 0) continue;
       try {
-        processMagicMatches(file, conv, streamBytes);
+        if (processMagicMatches(file, conv, streamBytes)) matchCapped.add(conv);
       } catch (Exception e) {
         log.debug(
             "Stream extraction skipped for conversation {}: {}", conv.getId(), e.getMessage());
       }
     }
+    if (!matchCapped.isEmpty()) {
+      file.setExtractionMatchLimitConvIds(joinConvIds(matchCapped));
+    }
   }
 
-  private void processMagicMatches(FileEntity file, ConversationEntity conv, byte[] streamBytes) {
+  /**
+   * Scans a single reassembled stream for embedded files.
+   *
+   * @return {@code true} if the per-stream match cap was reached (more files may exist)
+   */
+  private boolean processMagicMatches(
+      FileEntity file, ConversationEntity conv, byte[] streamBytes) {
     List<MagicMatch> segments = findMagicMatches(streamBytes);
+    boolean capReached = segments.size() >= limits.getMaxMatchesPerStream();
+    if (capReached) {
+      log.warn(
+          "Raw stream for conversation {} hit the {}-file extraction cap — additional embedded "
+              + "files may exist (raise EXTRACTION_MAX_MATCHES_PER_STREAM to extract more)",
+          conv.getId(),
+          limits.getMaxMatchesPerStream());
+    }
     for (MagicMatch seg : segments) {
       int start = seg.start();
       int end = seg.end();
@@ -535,12 +563,12 @@ public class FileExtractionService {
       long segSize = (long) end - start;
       String ext = seg.ext();
       String name = "stream-" + conv.getId().toString().substring(0, 8) + "-" + start + "." + ext;
-      if (segSize > MAX_EXTRACTED_FILE_BYTES) {
+      if (segSize > limits.maxFileSizeBytes()) {
         log.warn(
             "Skipping magic-byte extracted file {} ({} bytes) — exceeds {} MB limit",
             name,
             segSize,
-            MAX_EXTRACTED_FILE_BYTES / 1024 / 1024);
+            limits.getMaxFileSizeMb());
         recordSkippedFile(file, conv.getId(), name, segSize, "magic_bytes");
         continue;
       }
@@ -552,6 +580,15 @@ public class FileExtractionService {
       String mime = detectMime(fileData);
       storeExtractedFile(file, conv.getId(), fileData, name, mime, sha256, "magic_bytes");
     }
+    return capReached;
+  }
+
+  /** Joins conversation IDs into a comma-separated string, capped to limit DB/UI bloat. */
+  private static String joinConvIds(List<ConversationEntity> convs) {
+    return convs.stream()
+        .limit(MAX_RECORDED_CONV_IDS)
+        .map(c -> c.getId().toString())
+        .collect(Collectors.joining(","));
   }
 
   // -------------------------------------------------------------------------
@@ -785,7 +822,7 @@ public class FileExtractionService {
       if (ext.isEmpty()) ext = "bin";
 
       results.add(new MagicMatch(start, data.length, mime, ext));
-      if (results.size() >= MAX_MATCHES_PER_STREAM) break;
+      if (results.size() >= limits.getMaxMatchesPerStream()) break;
       // Jump past this match's signature region to avoid re-detecting the same file body,
       // then reset the automaton so it starts fresh from the new position.
       i = start + 256;
@@ -889,12 +926,12 @@ public class FileExtractionService {
       throws Exception {
     long rawSize = localFile.length();
     if (rawSize == 0) return;
-    if (rawSize > MAX_EXTRACTED_FILE_BYTES) {
+    if (rawSize > limits.maxFileSizeBytes()) {
       log.warn(
           "Skipping extracted file {} ({} bytes) — exceeds {} MB limit",
           localFile.getName(),
           rawSize,
-          MAX_EXTRACTED_FILE_BYTES / 1024 / 1024);
+          limits.getMaxFileSizeMb());
       recordSkippedFile(file, conversationId, localFile.getName(), rawSize, method);
       return;
     }

--- a/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/FileExtractionService.java
@@ -183,6 +183,12 @@ public class FileExtractionService {
 
     log.info("Starting file extraction for PCAP {}", file.getId());
 
+    // Clear any limit-hit warnings from a previous extraction of this file so a fresh run that
+    // no longer hits the limits doesn't leave stale warnings on the record.
+    file.setExtractionMatchLimitConvIds(null);
+    file.setExtractionConversationLimitSkippedCount(0);
+    file.setExtractionConversationLimitSkippedIds(null);
+
     // Load all conversations once — shared by both extraction strategies
     List<ConversationEntity> allConvs =
         (savedConversationIds == null || savedConversationIds.isEmpty())

--- a/backend/src/main/java/com/tracepcap/file/entity/FileEntity.java
+++ b/backend/src/main/java/com/tracepcap/file/entity/FileEntity.java
@@ -46,6 +46,22 @@ public class FileEntity {
   @Column(name = "enable_file_extraction", nullable = false)
   private boolean enableFileExtraction = true;
 
+  /**
+   * Comma-separated conversation IDs whose raw stream hit the per-stream match cap during
+   * extraction (more embedded files may exist). Null/empty when the cap was never reached.
+   */
+  @Column(name = "extraction_match_limit_conv_ids", columnDefinition = "text")
+  private String extractionMatchLimitConvIds;
+
+  /** Total non-HTTP file-bearing streams that were not scanned because of the conversation cap. */
+  @Builder.Default
+  @Column(name = "extraction_conversation_limit_skipped_count", nullable = false)
+  private int extractionConversationLimitSkippedCount = 0;
+
+  /** Comma-separated (capped) conversation IDs of streams skipped by the conversation cap. */
+  @Column(name = "extraction_conversation_limit_skipped_ids", columnDefinition = "text")
+  private String extractionConversationLimitSkippedIds;
+
   @Column(name = "uploaded_at", nullable = false)
   private LocalDateTime uploadedAt;
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -162,6 +162,11 @@ tracepcap:
   overview:
     apps-limited: ${OVERVIEW_APPS_LIMITED:true}   # true = cap detected apps list; false = show all
     apps-max: ${OVERVIEW_APPS_MAX:100}            # Max apps shown when apps-limited=true
+  extraction:
+    # File-extraction limits. Raise these to extract more from large/synthetic captures.
+    max-matches-per-stream: ${EXTRACTION_MAX_MATCHES_PER_STREAM:20}   # Max files per raw TCP/UDP stream
+    max-stream-conversations: ${EXTRACTION_MAX_STREAM_CONVERSATIONS:50} # Max non-HTTP streams scanned per PCAP
+    max-file-size-mb: ${EXTRACTION_MAX_FILE_SIZE_MB:50}              # Max size of a single extracted file (MB)
   signatures:
     path: ${SIGNATURES_PATH:/app/config/signatures.yml}  # Path to the custom signatures YAML file
   geo:

--- a/backend/src/main/resources/db/migration/V16__extraction_limit_warnings.sql
+++ b/backend/src/main/resources/db/migration/V16__extraction_limit_warnings.sql
@@ -1,0 +1,9 @@
+-- Record details of when configurable file-extraction limits were hit so the UI can warn that
+-- extraction results may be incomplete and point users at the specific streams/files (see #324).
+--
+-- The per-file size limit needs no column here: skipped files are already persisted in
+-- extracted_files with skipped_reason = 'exceeds_size_limit', and are listed from there.
+ALTER TABLE files
+    ADD COLUMN extraction_match_limit_conv_ids             TEXT,
+    ADD COLUMN extraction_conversation_limit_skipped_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN extraction_conversation_limit_skipped_ids   TEXT;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,10 @@ services:
       # Network Intelligence cluster limits
       INTELLIGENCE_MAX_CLUSTERS: ${INTELLIGENCE_MAX_CLUSTERS:-60}
       INTELLIGENCE_MAX_EDGES: ${INTELLIGENCE_MAX_EDGES:-200}
+      # File extraction limits (see .env.example)
+      EXTRACTION_MAX_MATCHES_PER_STREAM: ${EXTRACTION_MAX_MATCHES_PER_STREAM:-20}
+      EXTRACTION_MAX_STREAM_CONVERSATIONS: ${EXTRACTION_MAX_STREAM_CONVERSATIONS:-50}
+      EXTRACTION_MAX_FILE_SIZE_MB: ${EXTRACTION_MAX_FILE_SIZE_MB:-50}
       # Timezone Configuration
       TZ: Asia/Singapore
     volumes:

--- a/frontend/src/features/extractedFiles/services/extractedFilesService.ts
+++ b/frontend/src/features/extractedFiles/services/extractedFilesService.ts
@@ -13,8 +13,32 @@ export interface ExtractedFile {
   createdAt: string;
 }
 
+export interface SkippedFile {
+  id: string;
+  conversationId: string | null;
+  filename: string | null;
+  fileSize: number | null;
+}
+
+export interface ExtractionWarnings {
+  matchLimitConversationIds: string[];
+  conversationLimitSkippedCount: number;
+  conversationLimitSkippedIds: string[];
+  sizeLimitFiles: SkippedFile[];
+  maxMatchesPerStream: number;
+  maxStreamConversations: number;
+  maxFileSizeMb: number;
+}
+
 export async function getExtractedFiles(fileId: string): Promise<ExtractedFile[]> {
   const response = await apiClient.get<ExtractedFile[]>(API_ENDPOINTS.EXTRACTED_FILES(fileId));
+  return response.data;
+}
+
+export async function getExtractionWarnings(fileId: string): Promise<ExtractionWarnings> {
+  const response = await apiClient.get<ExtractionWarnings>(
+    API_ENDPOINTS.EXTRACTED_FILES_WARNINGS(fileId)
+  );
   return response.data;
 }
 

--- a/frontend/src/features/extractedFiles/services/extractedFilesService.ts
+++ b/frontend/src/features/extractedFiles/services/extractedFilesService.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '@/services/api/client';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
 
+/** A file extracted from a PCAP, or one detected but skipped (when `skippedReason` is set). */
 export interface ExtractedFile {
   id: string;
   conversationId: string | null;
@@ -13,6 +14,7 @@ export interface ExtractedFile {
   createdAt: string;
 }
 
+/** A file that was detected but not stored because it exceeded the per-file size limit. */
 export interface SkippedFile {
   id: string;
   conversationId: string | null;
@@ -20,6 +22,10 @@ export interface SkippedFile {
   fileSize: number | null;
 }
 
+/**
+ * Which extraction limits were hit for a capture (so results may be incomplete), plus the limit
+ * values in effect. Empty lists / zero counts mean the corresponding limit was not reached.
+ */
 export interface ExtractionWarnings {
   matchLimitConversationIds: string[];
   conversationLimitSkippedCount: number;
@@ -30,11 +36,13 @@ export interface ExtractionWarnings {
   maxFileSizeMb: number;
 }
 
+/** Fetches all files extracted from the given PCAP. */
 export async function getExtractedFiles(fileId: string): Promise<ExtractedFile[]> {
   const response = await apiClient.get<ExtractedFile[]>(API_ENDPOINTS.EXTRACTED_FILES(fileId));
   return response.data;
 }
 
+/** Fetches which extraction limits (if any) were hit while processing the given PCAP. */
 export async function getExtractionWarnings(fileId: string): Promise<ExtractionWarnings> {
   const response = await apiClient.get<ExtractionWarnings>(
     API_ENDPOINTS.EXTRACTED_FILES_WARNINGS(fileId)
@@ -42,6 +50,7 @@ export async function getExtractionWarnings(fileId: string): Promise<ExtractionW
   return response.data;
 }
 
+/** Fetches the files extracted from a single conversation within a PCAP. */
 export async function getExtractionsByConversation(
   fileId: string,
   conversationId: string
@@ -52,10 +61,12 @@ export async function getExtractionsByConversation(
   return response.data;
 }
 
+/** Builds the download URL for an extracted file (triggers an attachment download). */
 export function getDownloadUrl(fileId: string, extractionId: string): string {
   return `/api${API_ENDPOINTS.EXTRACTED_FILE_DOWNLOAD(fileId, extractionId)}`;
 }
 
+/** Builds the inline-preview URL for an extracted file (browser-renderable types only). */
 export function getPreviewUrl(fileId: string, extractionId: string): string {
   return `/api/files/${fileId}/extractions/${extractionId}/preview`;
 }

--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -167,6 +167,7 @@ function sortFiles(files: ExtractedFile[], by: SortField | '', dir: SortDir): Ex
 /** Renders a truncated SHA-256 with a click-to-copy button. */
 const CopyHash = ({ hash }: { hash: string }) => {
   const [copied, setCopied] = useState(false);
+  /** Copies the full hash to the clipboard and briefly shows a confirmation state. */
   const copy = useCallback(() => {
     navigator.clipboard.writeText(hash).then(() => {
       setCopied(true);
@@ -228,6 +229,7 @@ export const ExtractedFilesPage = () => {
       .catch(() => setWarnings(null));
   }, [fileId]);
 
+  /** Cycles a column's sort state on header click: asc → desc → unsorted. */
   const handleSort = (field: SortField) => {
     if (sortBy !== field) {
       setSortBy(field);
@@ -240,6 +242,7 @@ export const ExtractedFilesPage = () => {
     }
   };
 
+  /** A clickable table header cell that sorts by `field` and shows the current sort direction. */
   const SortableHeader = ({ field, label }: { field: SortField; label: string }) => {
     const isActive = sortBy === field;
     const icon = !isActive
@@ -257,8 +260,10 @@ export const ExtractedFilesPage = () => {
     );
   };
 
+  /** Opens the safety-disclaimer modal before a file is downloaded. */
   const handleDownloadRequest = (file: ExtractedFile) => setPendingDownload(file);
 
+  /** Performs the actual download of the pending file once the disclaimer is accepted. */
   const confirmDownload = () => {
     if (!pendingDownload) return;
     const url = getDownloadUrl(fileId, pendingDownload.id);

--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -26,6 +26,7 @@ interface AnalysisOutletContext {
 type SortField = 'filename' | 'mimeType' | 'fileSize' | 'extractionMethod';
 type SortDir = 'asc' | 'desc';
 
+/** Collapsible explainer card describing how files are extracted and the per-file size limit. */
 const ExtractionInfoCard = ({ maxFileSizeMb }: { maxFileSizeMb?: number }) => {
   const [collapsed, setCollapsed] = useState(true);
   return (
@@ -79,6 +80,7 @@ const ExtractionInfoCard = ({ maxFileSizeMb }: { maxFileSizeMb?: number }) => {
   );
 };
 
+/** Maps a MIME type to a Bootstrap icon class for the filename column. */
 function mimeIcon(mimeType: string | null): string {
   if (!mimeType) return 'bi-file-earmark';
   if (mimeType.startsWith('image/')) return 'bi-file-earmark-image';
@@ -141,12 +143,14 @@ const ConvLinks = ({
   );
 };
 
+/** Renders a colored badge for the extraction method (HTTP vs raw stream). */
 function methodBadge(method: string | null) {
   if (method === 'tshark_http') return <Badge bg="primary">HTTP</Badge>;
   if (method === 'magic_bytes') return <Badge bg="secondary">Raw stream</Badge>;
   return <Badge bg="light" text="dark">{method ?? '—'}</Badge>;
 }
 
+/** Returns a copy of `files` sorted by the given field/direction (unchanged when no field). */
 function sortFiles(files: ExtractedFile[], by: SortField | '', dir: SortDir): ExtractedFile[] {
   if (!by) return files;
   return [...files].sort((a, b) => {
@@ -160,6 +164,7 @@ function sortFiles(files: ExtractedFile[], by: SortField | '', dir: SortDir): Ex
   });
 }
 
+/** Renders a truncated SHA-256 with a click-to-copy button. */
 const CopyHash = ({ hash }: { hash: string }) => {
   const [copied, setCopied] = useState(false);
   const copy = useCallback(() => {
@@ -187,6 +192,10 @@ const CopyHash = ({ hash }: { hash: string }) => {
   );
 };
 
+/**
+ * Extracted Files tab: lists files carved from a capture, with sorting, MIME filtering, inline
+ * preview/download, and an "extraction may be incomplete" banner when any limit was hit.
+ */
 export const ExtractedFilesPage = () => {
   const { fileId } = useOutletContext<AnalysisOutletContext>();
   const navigate = useNavigate();

--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -3,9 +3,11 @@ import { useOutletContext, useNavigate } from 'react-router-dom';
 import type { AnalysisData } from '@/types';
 import {
   getExtractedFiles,
+  getExtractionWarnings,
   getDownloadUrl,
   getPreviewUrl,
   type ExtractedFile,
+  type ExtractionWarnings,
 } from '@features/extractedFiles/services/extractedFilesService';
 import { LoadingSpinner } from '@components/common/LoadingSpinner';
 import { ErrorMessage } from '@components/common/ErrorMessage';
@@ -24,7 +26,7 @@ interface AnalysisOutletContext {
 type SortField = 'filename' | 'mimeType' | 'fileSize' | 'extractionMethod';
 type SortDir = 'asc' | 'desc';
 
-const ExtractionInfoCard = () => {
+const ExtractionInfoCard = ({ maxFileSizeMb }: { maxFileSizeMb: number }) => {
   const [collapsed, setCollapsed] = useState(true);
   return (
     <Card className="mb-3" style={{ overflow: 'hidden' }}>
@@ -66,7 +68,7 @@ const ExtractionInfoCard = () => {
           <p className="mb-0">
             All extracted files are stored as raw bytes only — no execution or active-content
             rendering occurs. A safety disclaimer is shown before each download. Individual files
-            larger than 50 MB are not stored; they appear in this list with a{' '}
+            larger than {maxFileSizeMb} MB are not stored; they appear in this list with a{' '}
             <Badge bg="warning" text="dark" style={{ fontSize: '0.85em' }}>Too large</Badge>{' '}
             badge so you can see they were detected but skipped.
           </p>
@@ -104,6 +106,39 @@ function nativePreviewMode(mimeType: string | null): 'audio' | 'video' | 'image'
   if (mimeType === 'video/mp4' || mimeType === 'video/webm' || mimeType === 'video/ogg') return 'video';
   return null;
 }
+
+/** Renders a capped, comma-separated list of conversation links (by short id) for a warning. */
+const ConvLinks = ({
+  ids,
+  fileId,
+  navigate,
+}: {
+  ids: string[];
+  fileId: string;
+  navigate: ReturnType<typeof useNavigate>;
+}) => {
+  const MAX = 10;
+  const shown = ids.slice(0, MAX);
+  return (
+    <>
+      {shown.map((cid, i) => (
+        <span key={cid}>
+          <Button
+            variant="link"
+            size="sm"
+            className="p-0 align-baseline font-monospace"
+            style={{ fontSize: 'inherit' }}
+            onClick={() => navigate(`/analysis/${fileId}/conversations?highlight=${cid}`)}
+          >
+            {cid.slice(0, 8)}
+          </Button>
+          {i < shown.length - 1 ? ', ' : ''}
+        </span>
+      ))}
+      {ids.length > MAX && <span> and {ids.length - MAX} more</span>}
+    </>
+  );
+};
 
 function methodBadge(method: string | null) {
   if (method === 'tshark_http') return <Badge bg="primary">HTTP</Badge>;
@@ -155,6 +190,7 @@ export const ExtractedFilesPage = () => {
   const { fileId } = useOutletContext<AnalysisOutletContext>();
   const navigate = useNavigate();
   const [files, setFiles] = useState<ExtractedFile[]>([]);
+  const [warnings, setWarnings] = useState<ExtractionWarnings | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pendingDownload, setPendingDownload] = useState<ExtractedFile | null>(null);
@@ -176,6 +212,10 @@ export const ExtractedFilesPage = () => {
       .then(setFiles)
       .catch(err => setError(err?.message ?? 'Failed to load extracted files'))
       .finally(() => setLoading(false));
+    // Warnings are non-critical — failure here should not block the file list.
+    getExtractionWarnings(fileId)
+      .then(setWarnings)
+      .catch(() => setWarnings(null));
   }, [fileId]);
 
   const handleSort = (field: SortField) => {
@@ -247,7 +287,98 @@ export const ExtractedFilesPage = () => {
         </Badge>
       </div>
 
-      <ExtractionInfoCard />
+      {warnings &&
+        (warnings.matchLimitConversationIds.length > 0 ||
+          warnings.conversationLimitSkippedCount > 0 ||
+          warnings.sizeLimitFiles.length > 0) && (
+          <Alert variant="warning" className="mb-3">
+            <Alert.Heading className="h6 mb-2">
+              <i className="bi bi-exclamation-triangle-fill me-2"></i>
+              Extraction may be incomplete
+            </Alert.Heading>
+            <p className="mb-2 small">
+              One or more extraction limits were reached for this capture, so some files may be
+              missing from the list below. Raise the relevant environment variable and re-run the
+              analysis to extract more. Conversation links are shown by short stream id.
+            </p>
+            <ul className="mb-0 small">
+              {warnings.matchLimitConversationIds.length > 0 && (
+                <li>
+                  <strong>{warnings.matchLimitConversationIds.length}</strong> raw stream(s) hit the
+                  per-stream cap of <strong>{warnings.maxMatchesPerStream}</strong> file(s) —
+                  additional embedded files may exist. Raise{' '}
+                  <code>EXTRACTION_MAX_MATCHES_PER_STREAM</code>. Affected:{' '}
+                  <ConvLinks
+                    ids={warnings.matchLimitConversationIds}
+                    fileId={fileId}
+                    navigate={navigate}
+                  />
+                  .
+                </li>
+              )}
+              {warnings.conversationLimitSkippedCount > 0 && (
+                <li>
+                  <strong>{warnings.conversationLimitSkippedCount}</strong> non-HTTP stream(s) with
+                  detected files were not scanned (only the first{' '}
+                  <strong>{warnings.maxStreamConversations}</strong> are). Raise{' '}
+                  <code>EXTRACTION_MAX_STREAM_CONVERSATIONS</code>.
+                  {warnings.conversationLimitSkippedIds.length > 0 && (
+                    <>
+                      {' '}
+                      Skipped:{' '}
+                      <ConvLinks
+                        ids={warnings.conversationLimitSkippedIds}
+                        fileId={fileId}
+                        navigate={navigate}
+                      />
+                      .
+                    </>
+                  )}
+                </li>
+              )}
+              {warnings.sizeLimitFiles.length > 0 && (
+                <li>
+                  <strong>{warnings.sizeLimitFiles.length}</strong> file(s) exceeded the{' '}
+                  <strong>{warnings.maxFileSizeMb} MB</strong> per-file limit and were not stored
+                  (shown with a “Too large” badge below). Raise{' '}
+                  <code>EXTRACTION_MAX_FILE_SIZE_MB</code>.
+                  <ul className="mb-0">
+                    {warnings.sizeLimitFiles.slice(0, 10).map(f => (
+                      <li key={f.id}>
+                        <span className="font-monospace">{f.filename ?? '(unnamed)'}</span>
+                        {f.fileSize != null && <> ({formatBytes(f.fileSize)})</>}
+                        {f.conversationId && (
+                          <>
+                            {' '}
+                            —{' '}
+                            <Button
+                              variant="link"
+                              size="sm"
+                              className="p-0 align-baseline"
+                              style={{ fontSize: 'inherit' }}
+                              onClick={() =>
+                                navigate(
+                                  `/analysis/${fileId}/conversations?highlight=${f.conversationId}`
+                                )
+                              }
+                            >
+                              view conversation
+                            </Button>
+                          </>
+                        )}
+                      </li>
+                    ))}
+                    {warnings.sizeLimitFiles.length > 10 && (
+                      <li>and {warnings.sizeLimitFiles.length - 10} more</li>
+                    )}
+                  </ul>
+                </li>
+              )}
+            </ul>
+          </Alert>
+        )}
+
+      <ExtractionInfoCard maxFileSizeMb={warnings?.maxFileSizeMb ?? 50} />
 
       {/* Filter panel */}
       {allMimeTypes.length > 0 && (
@@ -397,7 +528,7 @@ export const ExtractedFilesPage = () => {
                           <Badge
                             bg="warning"
                             text="dark"
-                            title="File exceeds the 50 MB size limit and was not stored"
+                            title={`File exceeds the ${warnings?.maxFileSizeMb ?? 50} MB size limit and was not stored`}
                           >
                             <i className="bi bi-slash-circle me-1"></i>
                             Too large

--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -26,7 +26,7 @@ interface AnalysisOutletContext {
 type SortField = 'filename' | 'mimeType' | 'fileSize' | 'extractionMethod';
 type SortDir = 'asc' | 'desc';
 
-const ExtractionInfoCard = ({ maxFileSizeMb }: { maxFileSizeMb: number }) => {
+const ExtractionInfoCard = ({ maxFileSizeMb }: { maxFileSizeMb?: number }) => {
   const [collapsed, setCollapsed] = useState(true);
   return (
     <Card className="mb-3" style={{ overflow: 'hidden' }}>
@@ -68,7 +68,8 @@ const ExtractionInfoCard = ({ maxFileSizeMb }: { maxFileSizeMb: number }) => {
           <p className="mb-0">
             All extracted files are stored as raw bytes only — no execution or active-content
             rendering occurs. A safety disclaimer is shown before each download. Individual files
-            larger than {maxFileSizeMb} MB are not stored; they appear in this list with a{' '}
+            larger than {maxFileSizeMb != null ? `${maxFileSizeMb} MB` : 'the configured limit'} are
+            not stored; they appear in this list with a{' '}
             <Badge bg="warning" text="dark" style={{ fontSize: '0.85em' }}>Too large</Badge>{' '}
             badge so you can see they were detected but skipped.
           </p>
@@ -378,7 +379,7 @@ export const ExtractedFilesPage = () => {
           </Alert>
         )}
 
-      <ExtractionInfoCard maxFileSizeMb={warnings?.maxFileSizeMb ?? 50} />
+      <ExtractionInfoCard maxFileSizeMb={warnings?.maxFileSizeMb} />
 
       {/* Filter panel */}
       {allMimeTypes.length > 0 && (
@@ -528,7 +529,11 @@ export const ExtractedFilesPage = () => {
                           <Badge
                             bg="warning"
                             text="dark"
-                            title={`File exceeds the ${warnings?.maxFileSizeMb ?? 50} MB size limit and was not stored`}
+                            title={
+                              warnings?.maxFileSizeMb != null
+                                ? `File exceeds the ${warnings.maxFileSizeMb} MB size limit and was not stored`
+                                : 'File exceeds the configured size limit and was not stored'
+                            }
                           >
                             <i className="bi bi-slash-circle me-1"></i>
                             Too large

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -39,6 +39,7 @@ export const API_ENDPOINTS = {
 
   // Extracted Files
   EXTRACTED_FILES: (fileId: string) => `/files/${fileId}/extractions`,
+  EXTRACTED_FILES_WARNINGS: (fileId: string) => `/files/${fileId}/extractions/warnings`,
   EXTRACTED_FILE_DOWNLOAD: (fileId: string, extractionId: string) =>
     `/files/${fileId}/extractions/${extractionId}/download`,
 


### PR DESCRIPTION
Closes #324.

## What
Makes the three hard-coded file-extraction limits configurable via environment variables, and surfaces a detailed warning on the **Extracted Files** tab when any limit is hit so users know results may be incomplete and which limit to raise.

## Configurable limits
All default to the previous compile-time values — existing deployments behave identically.

| Env var | Default | Effect |
|---|---|---|
| `EXTRACTION_MAX_MATCHES_PER_STREAM` | 20 | Max files extracted per raw TCP/UDP stream |
| `EXTRACTION_MAX_STREAM_CONVERSATIONS` | 50 | Max non-HTTP streams scanned per PCAP |
| `EXTRACTION_MAX_FILE_SIZE_MB` | 50 | Max size of a single extracted file |

Wired through a shared `ExtractionLimits` bean (`application.yml` → `tracepcap.extraction.*`), documented in `docker-compose.yml` and `.env.example`.

## UI warnings (with specifics)
- **Backend** tracks which conversations hit the per-stream match cap and which non-HTTP streams were skipped by the conversation cap (new columns via migration `V16`). Size-skipped files are listed from the existing `extracted_files` skip rows.
- New endpoint `GET /api/files/{fileId}/extractions/warnings` returns the details plus the effective limit values.
- **Frontend** renders an "Extraction may be incomplete" banner listing the affected streams (clickable conversation links) and skipped files (name + size + link). Lists are capped (10 in UI, 100 stored) to stay manageable on large captures.

## Testing
Verified end-to-end with `docker compose up -d --build`:
- Migration `V16` applies cleanly.
- With limits minimized, `demo_all_rules.pcap` triggers all three warnings; the banner lists the correct streams and files, and links navigate to the highlighted conversation.
- With defaults restored, the endpoint reports 20/50/50 and no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-capture extraction-limit warnings to the extracted files UI, including alerts, conversation links for affected conversations, and a list of files skipped due to size limits.
  * Added a new endpoint to retrieve extraction warnings by file ID.
  * Updated the UI “too large” messaging/tooltips to use the configured max extracted file size.
* **Chores**
  * Introduced configurable extraction limits (matches per stream, max conversations scanned, max extracted file size) via environment variables and app configuration.
  * Added a database migration and persistence for warning details when limits are reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->