### PR TITLE
feat: integrate Suricata IDS as an offline threat-detection module (#401)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,10 +18,11 @@ FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 
 # Install runtime dependencies:
-#   tshark  — PCAP/pcapng parser
-#   ndpi    — ndpiReader for application-layer DPI (latest from ntop apt repo)
-#   tzdata  — timezone data
-#   gosu    — privilege-drop helper for entrypoint
+#   tshark    — PCAP/pcapng parser
+#   ndpi      — ndpiReader for application-layer DPI (latest from ntop apt repo)
+#   suricata  — offline IDS engine for signature-based threat detection (eve.json)
+#   tzdata    — timezone data
+#   gosu      — privilege-drop helper for entrypoint
 #
 # The ntop apt repo is required because Ubuntu 22.04's built-in nDPI (4.2-2)
 # lacks H.225/H.245 session tracking and several protocol signatures added in v5.
@@ -49,9 +50,38 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         tshark \
         tzdata \
         gosu \
+        suricata \
         ndpi && \
     dpkg-query -W -f='${Version}' ndpi > /opt/ndpi-version && \
+    dpkg-query -W -f='${Version}' suricata > /opt/suricata-version && \
     apt-get purge -y --auto-remove gnupg curl
+
+# Fetch the Emerging Threats Open ruleset at build time (internet is available during build,
+# same curl pattern as the DB-IP MMDB download below). The jammy `suricata` package does not bundle
+# `suricata-update`, so we download the ET Open tarball directly and concatenate every *.rules file
+# into /etc/suricata/rules/suricata.rules — the path the packaged /etc/suricata/suricata.yaml
+# already references (default-rule-path: /etc/suricata/rules + `rule-files: [suricata.rules]`). ET's
+# classification / reference configs are copied into /etc/suricata so rule classtypes resolve. This keeps
+# signature-based detection fully offline at runtime (per the offline requirement).
+#
+# Rules are made world-readable so the non-root `spring` runtime user can load them.
+#
+# To refresh the ruleset in air-gapped deployments: rebuild the image and redeploy
+# (offline: run pull-and-save-images.sh, transfer tracepcap-backend.tar, load-images.sh) —
+# analogous to the nDPI refresh flow above.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl && \
+    mkdir -p /etc/suricata/rules /tmp/etrules && \
+    curl -fsSL "https://rules.emergingthreats.net/open/suricata/emerging.rules.tar.gz" \
+        | tar -xz -C /tmp/etrules && \
+    cat /tmp/etrules/rules/*.rules > /etc/suricata/rules/suricata.rules && \
+    cp /tmp/etrules/rules/*.config /etc/suricata/ 2>/dev/null || true && \
+    rm -rf /tmp/etrules && \
+    date -u +%Y-%m-%d > /opt/suricata-ruleset-version && \
+    chmod -R a+rX /etc/suricata && \
+    apt-get purge -y --auto-remove curl
 
 # Download DB-IP Lite City MMDB (offline GeoIP).
 # Published monthly at https://db-ip.com/db/download/ip-to-city-lite

--- a/backend/src/main/java/com/tracepcap/analysis/controller/ConversationsController.java
+++ b/backend/src/main/java/com/tracepcap/analysis/controller/ConversationsController.java
@@ -234,13 +234,15 @@ public class ConversationsController {
 
     PrintWriter writer = response.getWriter();
     writer.println(
-        "srcIp,srcPort,dstIp,dstPort,protocol,appName,category,hostname,packetCount,totalBytes,durationMs,startTime,endTime,flowRisks,customSignatures");
+        "srcIp,srcPort,dstIp,dstPort,protocol,appName,category,hostname,packetCount,totalBytes,durationMs,startTime,endTime,flowRisks,customSignatures,suricataAlerts");
     for (ConversationResponse r : rows) {
       String flowRisksValue = r.getFlowRisks() != null ? String.join("; ", r.getFlowRisks()) : "";
       String customSigsValue =
           r.getCustomSignatures() != null ? String.join("; ", r.getCustomSignatures()) : "";
+      String suricataAlertsValue =
+          r.getSuricataAlerts() != null ? String.join("; ", r.getSuricataAlerts()) : "";
       writer.printf(
-          "%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%d,%s,%s,%s,%s%n",
+          "%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%d,%s,%s,%s,%s,%s%n",
           escapeCsv(r.getSrcIp()),
           escapeCsv(r.getSrcPort()),
           escapeCsv(r.getDstIp()),
@@ -255,7 +257,8 @@ public class ConversationsController {
           r.getStartTime() != null ? escapeCsv(CSV_DT.format(r.getStartTime())) : "",
           r.getEndTime() != null ? escapeCsv(CSV_DT.format(r.getEndTime())) : "",
           escapeCsv(flowRisksValue),
-          escapeCsv(customSigsValue));
+          escapeCsv(customSigsValue),
+          escapeCsv(suricataAlertsValue));
     }
     writer.flush();
   }

--- a/backend/src/main/java/com/tracepcap/analysis/controller/ConversationsController.java
+++ b/backend/src/main/java/com/tracepcap/analysis/controller/ConversationsController.java
@@ -72,6 +72,9 @@ public class ConversationsController {
       @Parameter(description = "Comma-separated list of custom signature rule names to include")
           @RequestParam(required = false)
           String customSignatures,
+      @Parameter(description = "Comma-separated list of Suricata IDS alerts to include")
+          @RequestParam(required = false)
+          String suricataAlerts,
       @Parameter(
               description =
                   "Filter conversations whose payload contains this pattern (ASCII or hex, e.g."
@@ -115,6 +118,7 @@ public class ConversationsController {
             fileTypes,
             riskTypes,
             customSignatures,
+            suricataAlerts,
             payloadContains,
             sortBy,
             sortDir,
@@ -163,6 +167,13 @@ public class ConversationsController {
     return ResponseEntity.ok(analysisService.getDistinctCustomSignatures(fileId));
   }
 
+  /** Returns the distinct Suricata IDS alert strings present for this file. */
+  @GetMapping("/{fileId}/suricata-alerts")
+  @Operation(summary = "List distinct Suricata IDS alerts for a file")
+  public ResponseEntity<List<String>> getSuricataAlerts(@PathVariable UUID fileId) {
+    return ResponseEntity.ok(analysisService.getDistinctSuricataAlerts(fileId));
+  }
+
   /**
    * Returns the distinct country codes seen in external IPs for this file, as "CC|Country" strings.
    */
@@ -187,6 +198,7 @@ public class ConversationsController {
       @RequestParam(required = false) String fileTypes,
       @RequestParam(required = false) String riskTypes,
       @RequestParam(required = false) String customSignatures,
+      @RequestParam(required = false) String suricataAlerts,
       @RequestParam(required = false) String payloadContains,
       @RequestParam(required = false) String sortBy,
       @RequestParam(required = false) String sortDir,
@@ -208,6 +220,7 @@ public class ConversationsController {
             fileTypes,
             riskTypes,
             customSignatures,
+            suricataAlerts,
             payloadContains,
             sortBy,
             sortDir,
@@ -262,6 +275,7 @@ public class ConversationsController {
       @RequestParam(required = false) String fileTypes,
       @RequestParam(required = false) String riskTypes,
       @RequestParam(required = false) String customSignatures,
+      @RequestParam(required = false) String suricataAlerts,
       @RequestParam(required = false) String payloadContains,
       @RequestParam(required = false) String sortBy,
       @RequestParam(required = false) String sortDir,
@@ -283,6 +297,7 @@ public class ConversationsController {
             fileTypes,
             riskTypes,
             customSignatures,
+            suricataAlerts,
             payloadContains,
             sortBy,
             sortDir,
@@ -342,6 +357,7 @@ public class ConversationsController {
       String fileTypes,
       String riskTypes,
       String customSignatures,
+      String suricataAlerts,
       String payloadContains,
       String sortBy,
       String sortDir,
@@ -360,6 +376,7 @@ public class ConversationsController {
         .fileTypes(splitComma(fileTypes))
         .riskTypes(splitComma(riskTypes))
         .customSignatures(splitComma(customSignatures))
+        .suricataAlerts(splitComma(suricataAlerts))
         .payloadContains(payloadContains)
         .deviceTypes(splitComma(deviceTypes))
         .countries(splitComma(countries))

--- a/backend/src/main/java/com/tracepcap/analysis/dto/AnalysisSummaryResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/AnalysisSummaryResponse.java
@@ -74,6 +74,7 @@ public class AnalysisSummaryResponse {
     private Long totalBytes;
     private List<String> flowRisks;
     private List<String> customSignatures;
+    private List<String> suricataAlerts;
   }
 
   @Data

--- a/backend/src/main/java/com/tracepcap/analysis/dto/ConversationDetailResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/ConversationDetailResponse.java
@@ -31,6 +31,7 @@ public class ConversationDetailResponse {
   private LocalDateTime tlsNotAfter;
   private List<String> flowRisks;
   private List<String> customSignatures;
+  private List<String> suricataAlerts;
   private List<String> httpUserAgents;
   private Long packetCount;
   private Long totalBytes;

--- a/backend/src/main/java/com/tracepcap/analysis/dto/ConversationFilterParams.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/ConversationFilterParams.java
@@ -49,6 +49,12 @@ public class ConversationFilterParams {
   private final List<String> customSignatures;
 
   /**
+   * Restrict to conversations whose suricata_alerts array contains at least one of the given alert
+   * strings (OR match). Empty = no filter.
+   */
+  private final List<String> suricataAlerts;
+
+  /**
    * Restrict to conversations that contain at least one packet whose payload includes this byte
    * pattern. Accepts ASCII strings (e.g. {@code GET /admin}) or hex sequences (e.g. {@code
    * 0x474554} or {@code 47 45 54}). Null or blank = no filter.

--- a/backend/src/main/java/com/tracepcap/analysis/dto/ConversationResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/ConversationResponse.java
@@ -45,6 +45,7 @@ public class ConversationResponse {
   private LocalDateTime tlsNotAfter;
   private List<String> flowRisks;
   private List<String> customSignatures;
+  private List<String> suricataAlerts;
   private List<String> httpUserAgents;
   private List<String> detectedFileTypes;
   private Long packetCount;

--- a/backend/src/main/java/com/tracepcap/analysis/entity/ConversationEntity.java
+++ b/backend/src/main/java/com/tracepcap/analysis/entity/ConversationEntity.java
@@ -23,6 +23,7 @@ public class ConversationEntity {
   public static final int HOSTNAME_MAX_LENGTH = 255;
   public static final int JA3_HASH_LENGTH = 32;
   public static final int PROTOCOL_MAX_LENGTH = 100;
+  public static final int SURICATA_ALERT_MAX_LENGTH = 512;
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -58,6 +59,9 @@ public class ConversationEntity {
 
   @Column(name = "custom_signatures", columnDefinition = "text[]")
   private String[] customSignatures;
+
+  @Column(name = "suricata_alerts", columnDefinition = "text[]")
+  private String[] suricataAlerts;
 
   @Column(name = "http_user_agents", columnDefinition = "text[]")
   private String[] httpUserAgents;

--- a/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
@@ -41,11 +41,15 @@ public interface ConversationRepository
           + " ORDER BY p.detectedFileType")
   List<String> findDistinctFileTypesByFileId(@Param("fileId") UUID fileId);
 
-  /** Returns only conversations that have at least one nDPI risk flag or Suricata IDS alert. */
+  /**
+   * Returns only conversations that have at least one nDPI risk flag, custom signature match, or
+   * Suricata IDS alert — matching the {@code hasRisks} Specification predicate in {@link #buildSpec}.
+   */
   @Query(
       value =
           "SELECT * FROM conversations WHERE file_id = :fileId"
               + " AND ((flow_risks IS NOT NULL AND array_length(flow_risks, 1) > 0)"
+              + " OR (custom_signatures IS NOT NULL AND array_length(custom_signatures, 1) > 0)"
               + " OR (suricata_alerts IS NOT NULL AND array_length(suricata_alerts, 1) > 0))",
       nativeQuery = true)
   List<ConversationEntity> findByFileIdWithRisks(@Param("fileId") UUID fileId);

--- a/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
@@ -41,11 +41,12 @@ public interface ConversationRepository
           + " ORDER BY p.detectedFileType")
   List<String> findDistinctFileTypesByFileId(@Param("fileId") UUID fileId);
 
-  /** Returns only conversations that have at least one risk flag. */
+  /** Returns only conversations that have at least one nDPI risk flag or Suricata IDS alert. */
   @Query(
       value =
           "SELECT * FROM conversations WHERE file_id = :fileId"
-              + " AND flow_risks IS NOT NULL AND array_length(flow_risks, 1) > 0",
+              + " AND ((flow_risks IS NOT NULL AND array_length(flow_risks, 1) > 0)"
+              + " OR (suricata_alerts IS NOT NULL AND array_length(suricata_alerts, 1) > 0))",
       nativeQuery = true)
   List<ConversationEntity> findByFileIdWithRisks(@Param("fileId") UUID fileId);
 
@@ -254,6 +255,16 @@ public interface ConversationRepository
       nativeQuery = true)
   List<String> findDistinctCustomSignaturesByFileId(@Param("fileId") UUID fileId);
 
+  /** Returns the distinct Suricata IDS alert strings present across a file's conversations. */
+  @Query(
+      value =
+          "SELECT DISTINCT unnest(suricata_alerts) AS alert"
+              + " FROM conversations WHERE file_id = :fileId"
+              + " AND suricata_alerts IS NOT NULL AND array_length(suricata_alerts, 1) > 0"
+              + " ORDER BY alert",
+      nativeQuery = true)
+  List<String> findDistinctSuricataAlertsByFileId(@Param("fileId") UUID fileId);
+
   /**
    * Returns fan-out candidates: source IPs connecting to more than 5 distinct destination IPs.
    * Columns: [src_ip, distinct_dst_ips, total_flows]
@@ -362,10 +373,13 @@ public interface ConversationRepository
         predicates.add(root.get("category").in(params.getCategories()));
       }
 
-      // Has flow risks or custom signature matches
+      // Has flow risks, custom signature, or Suricata IDS alert matches
       if (Boolean.TRUE.equals(params.getHasRisks())) {
         predicates.add(
-            cb.or(cb.isNotNull(root.get("flowRisks")), cb.isNotNull(root.get("customSignatures"))));
+            cb.or(
+                cb.isNotNull(root.get("flowRisks")),
+                cb.isNotNull(root.get("customSignatures")),
+                cb.isNotNull(root.get("suricataAlerts"))));
       }
 
       // Risk type filter (nDPI flow risks)
@@ -400,6 +414,23 @@ public interface ConversationRepository
                             0))
                 .collect(java.util.stream.Collectors.toList());
         predicates.add(cb.or(sigPreds.toArray(new Predicate[0])));
+      }
+
+      // Suricata IDS alert filter
+      if (params.getSuricataAlerts() != null && !params.getSuricataAlerts().isEmpty()) {
+        List<Predicate> alertPreds =
+            params.getSuricataAlerts().stream()
+                .map(
+                    alert ->
+                        cb.greaterThan(
+                            cb.function(
+                                "array_position",
+                                Integer.class,
+                                root.get("suricataAlerts"),
+                                cb.literal(alert)),
+                            0))
+                .collect(java.util.stream.Collectors.toList());
+        predicates.add(cb.or(alertPreds.toArray(new Predicate[0])));
       }
 
       // File type multi-value — EXISTS subquery against packets table

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -69,6 +69,7 @@ public class AnalysisService {
   private final PcapParserService pcapParserService;
   private final NdpiService ndpiService;
   private final TsharkEnrichmentService tsharkEnrichmentService;
+  private final SuricataService suricataService;
   private final CustomSignatureService customSignatureService;
   private final DeviceClassifierService deviceClassifierService;
   private final GeoIpService geoIpService;
@@ -120,11 +121,16 @@ public class AnalysisService {
         if (file.isEnableNdpi()) {
           ndpiService.enrich(tempFile, parseResult.getConversations());
           tsharkEnrichmentService.enrich(tempFile, parseResult.getConversations());
-          log.info(
-              "[{}] [3/7] nDPI + tshark enrichment: {}ms", fileId, System.currentTimeMillis() - t);
-        } else {
-          log.info("[{}] [3/7] nDPI + tshark enrichment: skipped", fileId);
         }
+        if (file.isEnableSuricata()) {
+          suricataService.enrich(tempFile, parseResult.getConversations());
+        }
+        log.info(
+            "[{}] [3/7] Enrichment (nDPI={}, Suricata={}): {}ms",
+            fileId,
+            file.isEnableNdpi(),
+            file.isEnableSuricata(),
+            System.currentTimeMillis() - t);
 
         // Stage 4: Signatures, device classification, geo-IP
         t = System.currentTimeMillis();
@@ -207,6 +213,7 @@ public class AnalysisService {
                   .tlsNotAfter(convInfo.getTlsNotAfter())
                   .flowRisks(toNullableArray(convInfo.getFlowRisks()))
                   .customSignatures(toNullableArray(convInfo.getCustomSignatures()))
+                  .suricataAlerts(toNullableArray(convInfo.getSuricataAlerts()))
                   .httpUserAgents(toNullableArray(convInfo.getHttpUserAgents()))
                   .packetCount(convInfo.getPacketCount())
                   .totalBytes(convInfo.getTotalBytes())
@@ -437,7 +444,9 @@ public class AnalysisService {
                 conv ->
                     (conv.getFlowRisks() != null && conv.getFlowRisks().length > 0)
                         || (conv.getCustomSignatures() != null
-                            && conv.getCustomSignatures().length > 0))
+                            && conv.getCustomSignatures().length > 0)
+                        || (conv.getSuricataAlerts() != null
+                            && conv.getSuricataAlerts().length > 0))
             .count();
 
     List<String> triggeredCustomRules =
@@ -485,6 +494,10 @@ public class AnalysisService {
                         .customSignatures(
                             conv.getCustomSignatures() != null
                                 ? Arrays.asList(conv.getCustomSignatures())
+                                : List.of())
+                        .suricataAlerts(
+                            conv.getSuricataAlerts() != null
+                                ? Arrays.asList(conv.getSuricataAlerts())
                                 : List.of())
                         .build())
             .collect(Collectors.toList());
@@ -605,6 +618,12 @@ public class AnalysisService {
   @Transactional(readOnly = true)
   public List<String> getDistinctCustomSignatures(UUID fileId) {
     return conversationRepository.findDistinctCustomSignaturesByFileId(fileId);
+  }
+
+  /** Returns distinct Suricata IDS alert strings present in this file's conversations. */
+  @Transactional(readOnly = true)
+  public List<String> getDistinctSuricataAlerts(UUID fileId) {
+    return conversationRepository.findDistinctSuricataAlertsByFileId(fileId);
   }
 
   /**
@@ -916,6 +935,7 @@ public class AnalysisService {
         .tlsNotAfter(conv.getTlsNotAfter())
         .flowRisks(toList(conv.getFlowRisks()))
         .customSignatures(toList(conv.getCustomSignatures()))
+        .suricataAlerts(toList(conv.getSuricataAlerts()))
         .httpUserAgents(toList(conv.getHttpUserAgents()))
         .detectedFileTypes(fileTypeMap.getOrDefault(conv.getId(), List.of()))
         .packetCount(conv.getPacketCount())
@@ -977,6 +997,7 @@ public class AnalysisService {
                   .tlsNotAfter(conv.getTlsNotAfter())
                   .flowRisks(toList(conv.getFlowRisks()))
                   .customSignatures(toList(conv.getCustomSignatures()))
+                  .suricataAlerts(toList(conv.getSuricataAlerts()))
                   .httpUserAgents(toList(conv.getHttpUserAgents()))
                   .packetCount(conv.getPacketCount())
                   .totalBytes(conv.getTotalBytes())
@@ -1056,6 +1077,7 @@ public class AnalysisService {
         .tlsNotAfter(conversation.getTlsNotAfter())
         .flowRisks(toList(conversation.getFlowRisks()))
         .customSignatures(toList(conversation.getCustomSignatures()))
+        .suricataAlerts(toList(conversation.getSuricataAlerts()))
         .httpUserAgents(toList(conversation.getHttpUserAgents()))
         .packetCount(conversation.getPacketCount())
         .totalBytes(conversation.getTotalBytes())

--- a/backend/src/main/java/com/tracepcap/analysis/service/PcapParserService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/PcapParserService.java
@@ -365,6 +365,7 @@ public class PcapParserService {
     private String tsharkProtocol;
     private List<String> flowRisks = new ArrayList<>();
     private List<String> customSignatures = new ArrayList<>();
+    private List<String> suricataAlerts = new ArrayList<>();
     private List<String> httpUserAgents = new ArrayList<>();
     private String category;
     private String hostname;

--- a/backend/src/main/java/com/tracepcap/analysis/service/SuricataService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SuricataService.java
@@ -6,6 +6,7 @@ import com.tracepcap.analysis.entity.ConversationEntity;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -106,24 +107,32 @@ public class SuricataService {
               "unix-command.enabled=no");
 
       Process process = pb.start();
+      try {
+        Thread stdoutDrainer = drainAsync(process.getInputStream(), "stdout");
+        Thread stderrDrainer = drainAsync(process.getErrorStream(), "stderr");
+        stdoutDrainer.start();
+        stderrDrainer.start();
 
-      Thread stdoutDrainer = drainAsync(process.getInputStream(), "stdout");
-      Thread stderrDrainer = drainAsync(process.getErrorStream(), "stderr");
-      stdoutDrainer.start();
-      stderrDrainer.start();
+        int exitCode = process.waitFor();
+        stdoutDrainer.join();
+        stderrDrainer.join();
 
-      int exitCode = process.waitFor();
-      stdoutDrainer.join();
-      stderrDrainer.join();
+        if (exitCode != 0) {
+          log.warn("suricata exited with code {} — skipping IDS alerts", exitCode);
+          return result;
+        }
 
-      if (exitCode != 0) {
-        log.warn("suricata exited with code {} — skipping IDS alerts", exitCode);
-        return result;
+        parseEveJson(outDir.resolve(EVE_JSON), result);
+        log.debug("Suricata produced alerts for {} distinct flows", result.size());
+      } finally {
+        // Never leak the subprocess if waitFor was interrupted or parsing threw.
+        if (process.isAlive()) process.destroyForcibly();
       }
 
-      parseEveJson(outDir.resolve(EVE_JSON), result);
-      log.debug("Suricata produced alerts for {} distinct flows", result.size());
-
+    } catch (InterruptedException e) {
+      // Restore the interrupted status so callers up the stack can react.
+      Thread.currentThread().interrupt();
+      log.warn("Suricata process execution was interrupted", e);
     } catch (Exception e) {
       if (isNotFoundError(e)) {
         log.warn(
@@ -242,7 +251,7 @@ public class SuricataService {
    * casing/naming; IP+port pairs are unique enough to map an alert to its conversation.
    */
   private String flowKey(String ip, Integer port, String ip2, Integer port2, String proto) {
-    return String.format("%s:%s->%s:%s", ip, port, ip2, port2);
+    return ip + ":" + port + "->" + ip2 + ":" + port2;
   }
 
   /** Drains a process stream on a daemon thread so the subprocess never blocks on a full pipe. */
@@ -250,7 +259,8 @@ public class SuricataService {
     Thread t =
         new Thread(
             () -> {
-              try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+              try (BufferedReader reader =
+                  new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
                   log.debug("suricata {}: {}", label, line);

--- a/backend/src/main/java/com/tracepcap/analysis/service/SuricataService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SuricataService.java
@@ -1,0 +1,278 @@
+package com.tracepcap.analysis.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tracepcap.analysis.entity.ConversationEntity;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Runs Suricata in offline pcap-read mode as a subprocess to perform signature-based threat
+ * detection over each uploaded PCAP, complementing nDPI: where nDPI answers <em>"what is this
+ * traffic?"</em>, Suricata answers <em>"is this traffic a known threat?"</em>.
+ *
+ * <p>Uses: {@code suricata -r <file> -l <outdir>} with the bundled Emerging Threats Open ruleset.
+ * Suricata writes one JSON object per line to {@code <outdir>/eve.json}; this service reads the
+ * {@code alert} events and maps each back to a {@link PcapParserService.ConversationInfo} by its
+ * 5-tuple.
+ *
+ * <p>Each alert is rendered to a compact string ({@code "<signature> (sid:<id>, sev:<n>)"}) and
+ * stored in the conversation's {@code suricataAlerts} list, mirroring how {@link NdpiService}
+ * populates {@code flowRisks}.
+ *
+ * <p>Gracefully degrades: if the {@code suricata} binary or ruleset is missing or Suricata fails,
+ * {@code suricataAlerts} stays empty and analysis continues normally.
+ */
+@Slf4j
+@Service
+public class SuricataService {
+
+  private static final String SURICATA_BINARY = "suricata";
+
+  /** Suricata writes its JSON event log here, relative to the {@code -l} output directory. */
+  private static final String EVE_JSON = "eve.json";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enrich each ConversationInfo with Suricata IDS alerts. Runs {@code suricata -r} exactly once and
+   * resolves alerts to conversations by 5-tuple. Conversations with no matching alert are left with
+   * an empty suricataAlerts list.
+   */
+  public void enrich(File pcapFile, List<PcapParserService.ConversationInfo> conversations) {
+    if (conversations.isEmpty()) return;
+
+    Map<String, Set<String>> alertMap = runSuricata(pcapFile);
+    if (alertMap.isEmpty()) return;
+
+    for (PcapParserService.ConversationInfo conv : conversations) {
+      Set<String> alerts = resolve(alertMap, conv);
+      if (alerts != null && !alerts.isEmpty()) {
+        conv.setSuricataAlerts(new ArrayList<>(alerts));
+      }
+    }
+
+    long enriched = conversations.stream().filter(c -> !c.getSuricataAlerts().isEmpty()).count();
+    log.info("Suricata flagged {}/{} conversations with IDS alerts", enriched, conversations.size());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Runs {@code suricata -r <file> -l <tmp>} and returns a map of flow key → set of alert strings.
+   * The output directory is created per-run and deleted afterwards.
+   */
+  private Map<String, Set<String>> runSuricata(File pcapFile) {
+    Map<String, Set<String>> result = new HashMap<>();
+    Path outDir = null;
+
+    try {
+      outDir = Files.createTempDirectory("suricata-");
+
+      // --runmode single: one packet-processing thread. Suricata otherwise spawns one worker per
+      //   CPU core, each pre-allocating large stream/flow pools — which exhausts memory and aborts
+      //   on many-core hosts for a one-shot offline read.
+      // --set unix-command.enabled=no: the non-root runtime user cannot bind the root-owned command
+      //   socket, and it is not needed for offline pcap-read mode.
+      ProcessBuilder pb =
+          new ProcessBuilder(
+              SURICATA_BINARY,
+              "-r",
+              pcapFile.getAbsolutePath(),
+              "-l",
+              outDir.toAbsolutePath().toString(),
+              "--runmode",
+              "single",
+              "--set",
+              "unix-command.enabled=no");
+
+      Process process = pb.start();
+
+      Thread stdoutDrainer = drainAsync(process.getInputStream(), "stdout");
+      Thread stderrDrainer = drainAsync(process.getErrorStream(), "stderr");
+      stdoutDrainer.start();
+      stderrDrainer.start();
+
+      int exitCode = process.waitFor();
+      stdoutDrainer.join();
+      stderrDrainer.join();
+
+      if (exitCode != 0) {
+        log.warn("suricata exited with code {} — skipping IDS alerts", exitCode);
+        return result;
+      }
+
+      parseEveJson(outDir.resolve(EVE_JSON), result);
+      log.debug("Suricata produced alerts for {} distinct flows", result.size());
+
+    } catch (Exception e) {
+      if (isNotFoundError(e)) {
+        log.warn(
+            "suricata not found — skipping IDS threat detection. Install suricata to enable.");
+      } else {
+        log.warn("Suricata analysis failed", e);
+      }
+    } finally {
+      if (outDir != null) deleteRecursively(outDir);
+    }
+
+    return result;
+  }
+
+  /**
+   * Parse {@code eve.json} (one JSON object per line), collecting {@code alert} events into the
+   * result map keyed by 5-tuple flow key (indexed in both directions for direction-independent
+   * lookup).
+   */
+  private void parseEveJson(Path eveJson, Map<String, Set<String>> result) {
+    if (!Files.isReadable(eveJson)) {
+      log.warn("Suricata eve.json not found at {} — no alerts parsed", eveJson);
+      return;
+    }
+
+    try (Stream<String> lines = Files.lines(eveJson)) {
+      lines.forEach(line -> parseEveLine(line, result));
+    } catch (Exception e) {
+      log.warn("Failed to read Suricata eve.json: {}", e.getMessage());
+    }
+  }
+
+  /** Parse a single eve.json line; only {@code event_type == "alert"} objects contribute. */
+  private void parseEveLine(String line, Map<String, Set<String>> result) {
+    if (line == null || line.isBlank()) return;
+    try {
+      JsonNode root = objectMapper.readTree(line);
+      if (!"alert".equals(root.path("event_type").asText())) return;
+
+      JsonNode alert = root.path("alert");
+      if (alert.isMissingNode()) return;
+
+      String signature = alert.path("signature").asText("").trim();
+      if (signature.isEmpty()) return;
+      long sid = alert.path("signature_id").asLong(0);
+      int severity = alert.path("severity").asInt(0);
+      String formatted = formatAlert(signature, sid, severity);
+
+      String srcIp = root.path("src_ip").asText(null);
+      String dstIp = root.path("dest_ip").asText(null);
+      if (srcIp == null || dstIp == null) return;
+      Integer srcPort = root.has("src_port") ? root.get("src_port").asInt() : null;
+      Integer dstPort = root.has("dest_port") ? root.get("dest_port").asInt() : null;
+      String proto = root.path("proto").asText(null);
+
+      String key = flowKey(srcIp, srcPort, dstIp, dstPort, proto);
+      result.computeIfAbsent(key, k -> new LinkedHashSet<>()).add(formatted);
+    } catch (Exception e) {
+      log.debug("Skipping unparseable eve.json line: {}", e.getMessage());
+    }
+  }
+
+  /**
+   * Render a compact, length-bounded alert label, e.g. {@code "ET MALWARE X (sid:2014 sev:1)"}.
+   *
+   * <p>Commas are intentionally avoided (and any commas in the ET signature msg are replaced with
+   * semicolons): these alert strings are surfaced as filter tokens that travel through the same
+   * comma-delimited transport as nDPI risk types and custom signatures (both the API query param
+   * and the URL filter state). A literal comma in the value would be mis-split into two bogus
+   * tokens, so the stored label must be comma-free.
+   */
+  private String formatAlert(String signature, long sid, int severity) {
+    StringBuilder sb = new StringBuilder(signature);
+    if (sid > 0 || severity > 0) {
+      sb.append(" (");
+      if (sid > 0) sb.append("sid:").append(sid);
+      if (severity > 0) {
+        if (sid > 0) sb.append(' ');
+        sb.append("sev:").append(severity);
+      }
+      sb.append(')');
+    }
+    String s = sb.toString().replace(',', ';');
+    return s.length() > ConversationEntity.SURICATA_ALERT_MAX_LENGTH
+        ? s.substring(0, ConversationEntity.SURICATA_ALERT_MAX_LENGTH)
+        : s;
+  }
+
+  /** Lookup alerts trying both directions (src→dst and dst→src). */
+  private Set<String> resolve(
+      Map<String, Set<String>> alertMap, PcapParserService.ConversationInfo conv) {
+    String key1 =
+        flowKey(
+            conv.getSrcIp(),
+            conv.getSrcPort(),
+            conv.getDstIp(),
+            conv.getDstPort(),
+            conv.getProtocol());
+    Set<String> alerts = alertMap.get(key1);
+    if (alerts == null) {
+      String key2 =
+          flowKey(
+              conv.getDstIp(),
+              conv.getDstPort(),
+              conv.getSrcIp(),
+              conv.getSrcPort(),
+              conv.getProtocol());
+      alerts = alertMap.get(key2);
+    }
+    return alerts;
+  }
+
+  /**
+   * Canonical 5-tuple key. The transport protocol is intentionally ignored (set to "") because
+   * Suricata's {@code proto} field ("TCP"/"UDP") and pcap4j's {@code protocol} string may differ in
+   * casing/naming; IP+port pairs are unique enough to map an alert to its conversation.
+   */
+  private String flowKey(String ip, Integer port, String ip2, Integer port2, String proto) {
+    return String.format("%s:%s->%s:%s", ip, port, ip2, port2);
+  }
+
+  /** Drains a process stream on a daemon thread so the subprocess never blocks on a full pipe. */
+  private Thread drainAsync(java.io.InputStream stream, String label) {
+    Thread t =
+        new Thread(
+            () -> {
+              try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                  log.debug("suricata {}: {}", label, line);
+                }
+              } catch (Exception ignored) {
+              }
+            });
+    t.setDaemon(true);
+    return t;
+  }
+
+  /** Recursively delete the per-run Suricata output directory; best-effort. */
+  private void deleteRecursively(Path dir) {
+    try (Stream<Path> paths = Files.walk(dir)) {
+      paths.sorted(Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+    } catch (Exception e) {
+      log.debug("Could not clean up Suricata temp dir {}: {}", dir, e.getMessage());
+    }
+  }
+
+  private boolean isNotFoundError(Exception e) {
+    String msg = e.getMessage();
+    return msg != null && (msg.contains("No such file") || msg.contains("error=2"));
+  }
+}

--- a/backend/src/main/java/com/tracepcap/file/controller/FileController.java
+++ b/backend/src/main/java/com/tracepcap/file/controller/FileController.java
@@ -39,17 +39,20 @@ public class FileController {
   public ResponseEntity<FileUploadResponse> uploadFile(
       @RequestParam("file") MultipartFile file,
       @RequestParam(value = "enableNdpi", defaultValue = "true") boolean enableNdpi,
+      @RequestParam(value = "enableSuricata", defaultValue = "true") boolean enableSuricata,
       @RequestParam(value = "enableFileExtraction", defaultValue = "true")
           boolean enableFileExtraction,
       @RequestParam(value = "source", defaultValue = "ANALYSIS") FileSource source) {
     log.info(
-        "Received file upload request: {} (ndpi={}, extraction={}, source={})",
+        "Received file upload request: {} (ndpi={}, suricata={}, extraction={}, source={})",
         file.getOriginalFilename(),
         enableNdpi,
+        enableSuricata,
         enableFileExtraction,
         source);
 
-    FileUploadResponse response = fileService.uploadFile(file, enableNdpi, enableFileExtraction, source);
+    FileUploadResponse response =
+        fileService.uploadFile(file, enableNdpi, enableSuricata, enableFileExtraction, source);
 
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
@@ -115,6 +118,7 @@ public class FileController {
   public ResponseEntity<FileUploadResponse> mergeFiles(
       @Valid @RequestBody MergeFilesRequest request,
       @RequestParam(value = "enableNdpi", defaultValue = "true") boolean enableNdpi,
+      @RequestParam(value = "enableSuricata", defaultValue = "true") boolean enableSuricata,
       @RequestParam(value = "enableFileExtraction", defaultValue = "true")
           boolean enableFileExtraction) {
 
@@ -124,7 +128,11 @@ public class FileController {
 
     FileUploadResponse response =
         fileService.mergeFiles(
-            request.getFileIds(), request.getMergedFileName(), enableNdpi, enableFileExtraction);
+            request.getFileIds(),
+            request.getMergedFileName(),
+            enableNdpi,
+            enableSuricata,
+            enableFileExtraction);
 
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }

--- a/backend/src/main/java/com/tracepcap/file/entity/FileEntity.java
+++ b/backend/src/main/java/com/tracepcap/file/entity/FileEntity.java
@@ -43,6 +43,10 @@ public class FileEntity {
   private boolean enableNdpi = true;
 
   @Builder.Default
+  @Column(name = "enable_suricata", nullable = false)
+  private boolean enableSuricata = true;
+
+  @Builder.Default
   @Column(name = "enable_file_extraction", nullable = false)
   private boolean enableFileExtraction = true;
 

--- a/backend/src/main/java/com/tracepcap/file/service/FileService.java
+++ b/backend/src/main/java/com/tracepcap/file/service/FileService.java
@@ -21,7 +21,11 @@ public interface FileService {
    * @return upload response with file metadata
    */
   FileUploadResponse uploadFile(
-      MultipartFile file, boolean enableNdpi, boolean enableFileExtraction, FileSource source);
+      MultipartFile file,
+      boolean enableNdpi,
+      boolean enableSuricata,
+      boolean enableFileExtraction,
+      FileSource source);
 
   /**
    * Get file metadata by ID
@@ -75,9 +79,14 @@ public interface FileService {
    *
    * @param fileIds ordered list of file IDs to merge
    * @param enableNdpi whether to run nDPI on the merged file
+   * @param enableSuricata whether to run Suricata IDS on the merged file
    * @param enableFileExtraction whether to run file extraction on the merged file
    * @return upload response for the newly created merged file
    */
   FileUploadResponse mergeFiles(
-      List<UUID> fileIds, String mergedFileName, boolean enableNdpi, boolean enableFileExtraction);
+      List<UUID> fileIds,
+      String mergedFileName,
+      boolean enableNdpi,
+      boolean enableSuricata,
+      boolean enableFileExtraction);
 }

--- a/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
+++ b/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
@@ -52,7 +52,11 @@ public class FileServiceImpl implements FileService {
   @Override
   @Transactional
   public FileUploadResponse uploadFile(
-      MultipartFile file, boolean enableNdpi, boolean enableFileExtraction, FileSource source) {
+      MultipartFile file,
+      boolean enableNdpi,
+      boolean enableSuricata,
+      boolean enableFileExtraction,
+      FileSource source) {
     log.info("Starting file upload: {}", file.getOriginalFilename());
 
     // Validate file
@@ -93,6 +97,7 @@ public class FileServiceImpl implements FileService {
               .fileHash(fileHash)
               .source(source != null ? source : FileSource.ANALYSIS)
               .enableNdpi(enableNdpi)
+              .enableSuricata(enableSuricata)
               .enableFileExtraction(enableFileExtraction)
               .build();
 
@@ -228,7 +233,11 @@ public class FileServiceImpl implements FileService {
   @Override
   @Transactional
   public FileUploadResponse mergeFiles(
-      List<UUID> fileIds, String mergedFileName, boolean enableNdpi, boolean enableFileExtraction) {
+      List<UUID> fileIds,
+      String mergedFileName,
+      boolean enableNdpi,
+      boolean enableSuricata,
+      boolean enableFileExtraction) {
     if (fileIds == null || fileIds.size() < 2) {
       throw new InvalidFileException("At least two files are required for merging");
     }
@@ -315,6 +324,7 @@ public class FileServiceImpl implements FileService {
               .status(FileEntity.FileStatus.PROCESSING)
               .fileHash(fileHash)
               .enableNdpi(enableNdpi)
+              .enableSuricata(enableSuricata)
               .enableFileExtraction(enableFileExtraction)
               .build();
 

--- a/backend/src/main/java/com/tracepcap/report/ReportService.java
+++ b/backend/src/main/java/com/tracepcap/report/ReportService.java
@@ -262,6 +262,7 @@ public class ReportService {
       {"Upload Time", formatDt(file.getUploadedAt())},
       {"Status", file.getStatus() != null ? file.getStatus().name() : "—"},
       {"nDPI Enrichment", file.isEnableNdpi() ? "Enabled" : "Disabled"},
+      {"Suricata IDS", file.isEnableSuricata() ? "Enabled" : "Disabled"},
       {"File Extraction", file.isEnableFileExtraction() ? "Enabled" : "Disabled"},
     };
     doc.add(kvTable(rows));

--- a/backend/src/main/resources/db/migration/V17__suricata_alerts.sql
+++ b/backend/src/main/resources/db/migration/V17__suricata_alerts.sql
@@ -1,0 +1,7 @@
+-- Store Suricata IDS alerts per conversation (see #401).
+--
+-- Suricata runs in offline pcap-read mode during Stage 3 enrichment (next to nDPI) and emits
+-- signature-based threat alerts. Each alert is stored as a formatted string, mirroring the existing
+-- flow_risks / custom_signatures text[] columns so the alerts surface in the same security view.
+ALTER TABLE conversations
+    ADD COLUMN suricata_alerts text[];

--- a/backend/src/main/resources/db/migration/V18__enable_suricata_flag.sql
+++ b/backend/src/main/resources/db/migration/V18__enable_suricata_flag.sql
@@ -1,0 +1,7 @@
+-- Dedicated per-file toggle for Suricata IDS analysis (see #401).
+--
+-- Suricata is now gated by its own flag rather than reusing enable_ndpi, so users can run nDPI
+-- protocol identification and Suricata signature-based detection independently. Existing rows
+-- default to enabled, matching the prior behaviour where Suricata ran whenever nDPI was enabled.
+ALTER TABLE files
+    ADD COLUMN enable_suricata BOOLEAN NOT NULL DEFAULT TRUE;

--- a/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
+++ b/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
@@ -11,6 +11,7 @@ import {
   getTextColor,
   getSeverityColor,
   RISK_BADGE,
+  IDS_BADGE,
 } from '@/utils/appColors';
 import { getProtocolColor } from '@/features/network/constants';
 import { deviceTypeLabel, deviceTypeColor } from '@/utils/deviceType';
@@ -366,6 +367,27 @@ export const ConversationDetail = ({
                             </Badge>
                           );
                         })}
+                      </div>
+                    </dd>
+                  </>
+                )}
+                {conversation.suricataAlerts && conversation.suricataAlerts.length > 0 && (
+                  <>
+                    <dt className="col-sm-4">IDS Alerts:</dt>
+                    <dd className="col-sm-8">
+                      <div className="d-flex flex-wrap gap-1">
+                        {conversation.suricataAlerts.map(alert => (
+                          <Badge
+                            key={alert}
+                            style={{
+                              backgroundColor: IDS_BADGE.bg,
+                              color: IDS_BADGE.text,
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {alert}
+                          </Badge>
+                        ))}
                       </div>
                     </dd>
                   </>

--- a/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
+++ b/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
@@ -11,6 +11,7 @@ import {
   getTextColor,
   getSeverityColor,
   RISK_BADGE,
+  IDS_BADGE,
 } from '@/utils/appColors';
 import { getProtocolColor } from '@/features/network/constants';
 import { deviceTypeLabel, deviceTypeColor } from '@/utils/deviceType';
@@ -38,12 +39,14 @@ interface ConversationFilterPanelProps {
   fileTypes: string[];
   riskTypes: string[];
   customSignatureOptions: string[];
+  suricataAlertOptions: string[];
   signatureSeverities?: Record<string, string>;
   countryOptions: string[];
   presentDeviceTypes?: string[];
   activeFilterCount: number;
   visibleColumns: Set<ColumnKey>;
   onToggleColumn: (key: ColumnKey) => void;
+  onResetColumns?: () => void;
   hideColumnToggle?: boolean;
   defaultOpen?: boolean;
 }
@@ -89,12 +92,14 @@ export function ConversationFilterPanel({
   fileTypes,
   riskTypes,
   customSignatureOptions,
+  suricataAlertOptions,
   signatureSeverities = {},
   countryOptions,
   presentDeviceTypes,
   activeFilterCount,
   visibleColumns,
   onToggleColumn,
+  onResetColumns,
   hideColumnToggle = false,
   defaultOpen,
 }: ConversationFilterPanelProps) {
@@ -102,6 +107,7 @@ export function ConversationFilterPanel({
   const [ipInput, setIpInput] = useState(filters.ip);
   const [portInput, setPortInput] = useState(filters.port);
   const [payloadInput, setPayloadInput] = useState(filters.payloadContains);
+  const [idsSearch, setIdsSearch] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const portDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const payloadDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -620,6 +626,61 @@ export function ConversationFilterPanel({
                 </div>
               )}
 
+              {/* Suricata IDS alerts — searchable list (signatures are long and can be many) */}
+              {suricataAlertOptions.length > 0 && (
+                <div className="col-12">
+                  <PillSectionHeader
+                    label="IDS Alerts"
+                    info={
+                      <InfoPopover
+                        id="info-idsalerts"
+                        title="IDS Alerts"
+                        body="Filter by Suricata IDS signature alerts (Emerging Threats Open ruleset). Only signatures that matched at least one conversation in this file are shown."
+                      />
+                    }
+                    onSelectAll={() => onFiltersChange({ suricataAlerts: suricataAlertOptions })}
+                    onDeselectAll={() => onFiltersChange({ suricataAlerts: [] })}
+                  />
+                  {suricataAlertOptions.length > 8 && (
+                    <input
+                      type="text"
+                      className="form-control form-control-sm mb-2"
+                      placeholder="Search IDS alerts…"
+                      value={idsSearch}
+                      onChange={e => setIdsSearch(e.target.value)}
+                    />
+                  )}
+                  <div
+                    className="d-flex flex-column gap-1"
+                    style={{ maxHeight: '180px', overflowY: 'auto' }}
+                  >
+                    {suricataAlertOptions
+                      .filter(a => a.toLowerCase().includes(idsSearch.toLowerCase()))
+                      .map(alert => {
+                        const isActive = filters.suricataAlerts.includes(alert);
+                        return (
+                          <label
+                            key={alert}
+                            className="d-flex align-items-start gap-2"
+                            style={{ cursor: 'pointer', fontSize: '0.8rem' }}
+                          >
+                            <input
+                              type="checkbox"
+                              className="form-check-input mt-1 flex-shrink-0"
+                              style={isActive ? { backgroundColor: IDS_BADGE.bg, borderColor: IDS_BADGE.bg } : undefined}
+                              checked={isActive}
+                              onChange={() =>
+                                toggle('suricataAlerts', alert, filters.suricataAlerts)
+                              }
+                            />
+                            <span>{alert}</span>
+                          </label>
+                        );
+                      })}
+                  </div>
+                </div>
+              )}
+
               {/* Country filter */}
               {countryOptions.length > 0 && (
                 <div className="col-12">
@@ -702,9 +763,22 @@ export function ConversationFilterPanel({
               {/* Column visibility */}
               {!hideColumnToggle && (
                 <div className="col-12 pt-1 border-top mt-3">
-                  <label className="filter-section-label d-block mb-2">
-                    <i className="bi bi-layout-three-columns me-1"></i>Columns
-                  </label>
+                  <div className="d-flex align-items-center justify-content-between mb-2">
+                    <label className="filter-section-label d-block mb-0">
+                      <i className="bi bi-layout-three-columns me-1"></i>Columns
+                    </label>
+                    {onResetColumns && (
+                      <Button
+                        size="sm"
+                        variant="link"
+                        className="p-0 text-decoration-none"
+                        onClick={onResetColumns}
+                        title="Restore the default set of visible columns"
+                      >
+                        <i className="bi bi-arrow-counterclockwise me-1"></i>Reset to default
+                      </Button>
+                    )}
+                  </div>
                   <div className="d-flex flex-wrap gap-2">
                     {COLUMN_DEFS.map(({ key, label }) => (
                       <div key={key} className="form-check form-check-inline mb-0">

--- a/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
+++ b/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
@@ -121,6 +121,11 @@ export function ConversationFilterPanel({
   useEffect(() => {
     setPayloadInput(filters.payloadContains);
   }, [filters.payloadContains]);
+  // Clear the IDS search box when the alert option source changes (e.g. switching files),
+  // otherwise a stale query can silently hide all options for the new dataset.
+  useEffect(() => {
+    setIdsSearch('');
+  }, [suricataAlertOptions]);
 
   const handleIpChange = (value: string) => {
     setIpInput(value);

--- a/frontend/src/components/conversation/ConversationList/ConversationList.tsx
+++ b/frontend/src/components/conversation/ConversationList/ConversationList.tsx
@@ -277,10 +277,14 @@ export const ConversationList = ({
                                 backgroundColor: IDS_BADGE.bg,
                                 color: IDS_BADGE.text,
                                 whiteSpace: 'nowrap',
+                                maxWidth: '24rem',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                display: 'inline-block',
                               }}
                               title={alert}
                             >
-                              {alert}
+                              {alert.length > 96 ? `${alert.slice(0, 96)}…` : alert}
                             </span>
                           ))}
                         </div>

--- a/frontend/src/components/conversation/ConversationList/ConversationList.tsx
+++ b/frontend/src/components/conversation/ConversationList/ConversationList.tsx
@@ -32,6 +32,7 @@ import {
   getTextColor,
   getSeverityColor,
   RISK_BADGE,
+  IDS_BADGE,
 } from '@/utils/appColors';
 import { getProtocolColor } from '@/features/network/constants';
 import './ConversationList.css';
@@ -105,6 +106,7 @@ export const ConversationList = ({
               {col('category') && <th>Category</th>}
               {col('risks') && <th>Risks</th>}
               {col('customRules') && <th>Custom Rules</th>}
+              {col('idsAlerts') && <th>IDS Alerts</th>}
               {col('fileTypes') && (
                 <th style={{ whiteSpace: 'nowrap' }}>File Type</th>
               )}
@@ -257,6 +259,30 @@ export const ConversationList = ({
                               </span>
                             );
                           })}
+                        </div>
+                      ) : (
+                        <span className="text-muted">—</span>
+                      )}
+                    </td>
+                  )}
+                  {col('idsAlerts') && (
+                    <td>
+                      {conversation.suricataAlerts && conversation.suricataAlerts.length > 0 ? (
+                        <div className="d-inline-flex flex-wrap gap-1">
+                          {conversation.suricataAlerts.map(alert => (
+                            <span
+                              key={alert}
+                              className="badge"
+                              style={{
+                                backgroundColor: IDS_BADGE.bg,
+                                color: IDS_BADGE.text,
+                                whiteSpace: 'nowrap',
+                              }}
+                              title={alert}
+                            >
+                              {alert}
+                            </span>
+                          ))}
                         </div>
                       ) : (
                         <span className="text-muted">—</span>

--- a/frontend/src/components/intelligence/ClusterGraph/ClusterGraph.tsx
+++ b/frontend/src/components/intelligence/ClusterGraph/ClusterGraph.tsx
@@ -489,7 +489,7 @@ function ClusterPanel({ cluster, fileId, onClose }: ClusterPanelProps) {
         port: '', payloadContains: '',
         protocols: [], l7Protocols: [], apps: [],
         categories: [], hasRisks: false, fileTypes: [],
-        riskTypes: [], customSignatures: [], deviceTypes: [],
+        riskTypes: [], customSignatures: [], suricataAlerts: [], deviceTypes: [],
         countries: [], sortBy: 'bytes', sortDir: 'desc',
         page: 1, pageSize: 8,
       })

--- a/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
+++ b/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
@@ -134,7 +134,12 @@ export const AddSnapshotModal = ({
           const result = await uploadService.uploadPcap(
             file,
             p => setUploadProgress(p),
-            { enableNdpi: true, enableFileExtraction: true, source: 'MONITOR' },
+            {
+              enableNdpi: true,
+              enableSuricata: true,
+              enableFileExtraction: true,
+              source: 'MONITOR',
+            },
           );
           fileId = result.fileId;
         } catch (uploadErr: any) {

--- a/frontend/src/components/monitor/SubnetDiagramModal/SubnetDiagramModal.tsx
+++ b/frontend/src/components/monitor/SubnetDiagramModal/SubnetDiagramModal.tsx
@@ -65,7 +65,7 @@ export function SubnetDiagramModal({ subnet, snapshots, onHide, defaultSnapId }:
       const filters: ConversationFilters = {
         ip: '', port: '', payloadContains: '', protocols: [], l7Protocols: [],
         apps: [], categories: [], hasRisks: false, fileTypes: [], riskTypes: [],
-        customSignatures: [], deviceTypes: [], countries: [],
+        customSignatures: [], suricataAlerts: [], deviceTypes: [], countries: [],
         sortBy: 'startTime' as ConversationFilters['sortBy'],
         sortDir: 'desc' as ConversationFilters['sortDir'],
         page: 1, pageSize: 10000,

--- a/frontend/src/features/analysis/services/analysisService.ts
+++ b/frontend/src/features/analysis/services/analysisService.ts
@@ -29,6 +29,7 @@ export const analysisService = {
       endTime: conv.endTime || endTime,
       flowRisks: conv.flowRisks ?? [],
       customSignatures: conv.customSignatures ?? [],
+      suricataAlerts: conv.suricataAlerts ?? [],
     }));
 
     const uniqueHosts = (summary.uniqueHosts || []).map((host: any) => ({

--- a/frontend/src/features/conversation/constants.ts
+++ b/frontend/src/features/conversation/constants.ts
@@ -7,6 +7,7 @@ export type ColumnKey =
   | 'category'
   | 'risks'
   | 'customRules'
+  | 'idsAlerts'
   | 'fileTypes'
   | 'srcCountry'
   | 'dstCountry'
@@ -24,6 +25,7 @@ export const COLUMN_DEFS: { key: ColumnKey; label: string; defaultVisible: boole
   { key: 'category', label: 'Category', defaultVisible: true },
   { key: 'risks', label: 'Risks', defaultVisible: true },
   { key: 'customRules', label: 'Custom Rules', defaultVisible: true },
+  { key: 'idsAlerts', label: 'IDS Alerts', defaultVisible: true },
   { key: 'fileTypes', label: 'File Type', defaultVisible: true },
   { key: 'srcCountry', label: 'Src Country', defaultVisible: false },
   { key: 'dstCountry', label: 'Dst Country', defaultVisible: false },
@@ -33,7 +35,12 @@ export const COLUMN_DEFS: { key: ColumnKey; label: string; defaultVisible: boole
   { key: 'startTime', label: 'Start Time', defaultVisible: true },
 ];
 
-export const COLUMN_STORAGE_KEY = 'conv-visible-columns-v5';
+export const COLUMN_STORAGE_KEY = 'conv-visible-columns-v6';
+
+/** The default set of visible columns, ignoring any stored user override. */
+export function defaultVisibleColumns(): Set<ColumnKey> {
+  return new Set(COLUMN_DEFS.filter(c => c.defaultVisible).map(c => c.key));
+}
 
 export function loadVisibleColumns(): Set<ColumnKey> {
   try {
@@ -42,5 +49,5 @@ export function loadVisibleColumns(): Set<ColumnKey> {
   } catch {
     /* ignore */
   }
-  return new Set(COLUMN_DEFS.filter(c => c.defaultVisible).map(c => c.key));
+  return defaultVisibleColumns();
 }

--- a/frontend/src/features/conversation/hooks/useConversationFilters.ts
+++ b/frontend/src/features/conversation/hooks/useConversationFilters.ts
@@ -32,6 +32,7 @@ export function useConversationFilters() {
       fileTypes: splitComma(searchParams.get('fileTypes')),
       riskTypes: splitComma(searchParams.get('riskTypes')),
       customSignatures: splitComma(searchParams.get('customSignatures')),
+      suricataAlerts: splitComma(searchParams.get('suricataAlerts')),
       deviceTypes: splitComma(searchParams.get('deviceTypes')),
       countries: splitComma(searchParams.get('countries')),
       sortBy: (searchParams.get('sortBy') ?? '') as SortField,
@@ -56,6 +57,7 @@ export function useConversationFilters() {
         filters.fileTypes.length > 0,
         filters.riskTypes.length > 0,
         filters.customSignatures.length > 0,
+        filters.suricataAlerts.length > 0,
         filters.deviceTypes.length > 0,
         filters.countries.length > 0,
       ].filter(Boolean).length,
@@ -82,6 +84,7 @@ export function useConversationFilters() {
             fileTypes: splitComma(prev.get('fileTypes')),
             riskTypes: splitComma(prev.get('riskTypes')),
             customSignatures: splitComma(prev.get('customSignatures')),
+            suricataAlerts: splitComma(prev.get('suricataAlerts')),
             deviceTypes: splitComma(prev.get('deviceTypes')),
             countries: splitComma(prev.get('countries')),
             sortBy: (prev.get('sortBy') ?? '') as SortField,
@@ -109,6 +112,7 @@ export function useConversationFilters() {
           set('fileTypes', joinComma(merged.fileTypes));
           set('riskTypes', joinComma(merged.riskTypes));
           set('customSignatures', joinComma(merged.customSignatures));
+          set('suricataAlerts', joinComma(merged.suricataAlerts));
           set('deviceTypes', joinComma(merged.deviceTypes ?? []));
           set('countries', joinComma(merged.countries ?? []));
           set('sortBy', merged.sortBy || undefined);

--- a/frontend/src/features/conversation/services/conversationService.ts
+++ b/frontend/src/features/conversation/services/conversationService.ts
@@ -32,6 +32,7 @@ interface ConversationApiResponse {
   tlsNotAfter?: string | number[] | null;
   flowRisks?: string[] | null;
   customSignatures?: string[] | null;
+  suricataAlerts?: string[] | null;
   httpUserAgents?: string[] | null;
   detectedFileTypes?: string[] | null;
   srcGeo?: ConversationGeoInfo | null;
@@ -111,6 +112,7 @@ function transformConversation(
     tlsNotAfter: apiData.tlsNotAfter != null ? parseDateTime(apiData.tlsNotAfter) : undefined,
     flowRisks: apiData.flowRisks ?? [],
     customSignatures: apiData.customSignatures ?? [],
+    suricataAlerts: apiData.suricataAlerts ?? [],
     httpUserAgents: apiData.httpUserAgents ?? [],
     detectedFileTypes: apiData.detectedFileTypes ?? [],
     srcGeo: apiData.srcGeo ?? undefined,
@@ -220,6 +222,8 @@ export const conversationService = {
     if (filters.riskTypes.length > 0) params.riskTypes = filters.riskTypes.join(',');
     if (filters.customSignatures.length > 0)
       params.customSignatures = filters.customSignatures.join(',');
+    if (filters.suricataAlerts.length > 0)
+      params.suricataAlerts = filters.suricataAlerts.join(',');
     if (filters.deviceTypes && filters.deviceTypes.length > 0)
       params.deviceTypes = filters.deviceTypes.join(',');
     if (filters.countries && filters.countries.length > 0)
@@ -261,6 +265,8 @@ export const conversationService = {
     if (filters.riskTypes.length > 0) params.set('riskTypes', filters.riskTypes.join(','));
     if (filters.customSignatures.length > 0)
       params.set('customSignatures', filters.customSignatures.join(','));
+    if (filters.suricataAlerts.length > 0)
+      params.set('suricataAlerts', filters.suricataAlerts.join(','));
     if (filters.deviceTypes && filters.deviceTypes.length > 0)
       params.set('deviceTypes', filters.deviceTypes.join(','));
     if (filters.countries && filters.countries.length > 0)
@@ -295,6 +301,8 @@ export const conversationService = {
     if (filters.riskTypes.length > 0) params.set('riskTypes', filters.riskTypes.join(','));
     if (filters.customSignatures.length > 0)
       params.set('customSignatures', filters.customSignatures.join(','));
+    if (filters.suricataAlerts.length > 0)
+      params.set('suricataAlerts', filters.suricataAlerts.join(','));
     if (filters.deviceTypes && filters.deviceTypes.length > 0)
       params.set('deviceTypes', filters.deviceTypes.join(','));
     if (filters.countries && filters.countries.length > 0)
@@ -310,6 +318,14 @@ export const conversationService = {
    */
   getCustomSignatures: async (fileId: string): Promise<string[]> => {
     const response = await apiClient.get<string[]>(`/conversations/${fileId}/custom-signatures`);
+    return response.data;
+  },
+
+  /**
+   * Returns distinct Suricata IDS alert strings present in this file's conversations.
+   */
+  getSuricataAlerts: async (fileId: string): Promise<string[]> => {
+    const response = await apiClient.get<string[]>(`/conversations/${fileId}/suricata-alerts`);
     return response.data;
   },
 

--- a/frontend/src/features/conversation/types/index.ts
+++ b/frontend/src/features/conversation/types/index.ts
@@ -14,6 +14,7 @@ export interface ConversationFilters {
   fileTypes: string[];
   riskTypes: string[];
   customSignatures: string[];
+  suricataAlerts: string[];
   deviceTypes: string[];
   countries: string[];
   sortBy: SortField;

--- a/frontend/src/features/network/hooks/useCompareData.ts
+++ b/frontend/src/features/network/hooks/useCompareData.ts
@@ -43,6 +43,7 @@ async function fetchGraphForFile(fileId: string) {
       fileTypes: [],
       riskTypes: [],
       customSignatures: [],
+      suricataAlerts: [],
       deviceTypes: [],
       countries: [],
       sortBy: '',

--- a/frontend/src/features/network/hooks/useNetworkData.ts
+++ b/frontend/src/features/network/hooks/useNetworkData.ts
@@ -108,6 +108,7 @@ export function useNetworkData(
           fileTypes: [],
           riskTypes: [],
           customSignatures: [],
+          suricataAlerts: [],
           deviceTypes: [],
           countries: [],
           sortBy: '',

--- a/frontend/src/features/upload/hooks/useFileUpload.ts
+++ b/frontend/src/features/upload/hooks/useFileUpload.ts
@@ -21,7 +21,11 @@ export const useFileUpload = () => {
   const uploadFiles = useCallback(
     async (
       files: File[],
-      options: AnalysisOptions = { enableNdpi: true, enableFileExtraction: true }
+      options: AnalysisOptions = {
+        enableNdpi: true,
+        enableSuricata: true,
+        enableFileExtraction: true,
+      }
     ) => {
       const entries: UploadEntry[] = files.map((f, i) => ({
         id: `${Date.now()}-${i}`,

--- a/frontend/src/features/upload/services/uploadService.ts
+++ b/frontend/src/features/upload/services/uploadService.ts
@@ -6,6 +6,7 @@ export type FileSource = 'ANALYSIS' | 'MONITOR';
 
 export interface AnalysisOptions {
   enableNdpi: boolean;
+  enableSuricata: boolean;
   enableFileExtraction: boolean;
   source?: FileSource;
 }
@@ -17,11 +18,16 @@ export const uploadService = {
   uploadPcap: async (
     file: File,
     onProgress?: (progress: number) => void,
-    options: AnalysisOptions = { enableNdpi: true, enableFileExtraction: true }
+    options: AnalysisOptions = {
+      enableNdpi: true,
+      enableSuricata: true,
+      enableFileExtraction: true,
+    }
   ): Promise<UploadResponse> => {
     const formData = new FormData();
     formData.append('file', file);
     formData.append('enableNdpi', String(options.enableNdpi));
+    formData.append('enableSuricata', String(options.enableSuricata));
     formData.append('enableFileExtraction', String(options.enableFileExtraction));
     formData.append('source', options.source ?? 'ANALYSIS');
 

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -316,6 +316,7 @@ export const AnalysisPage = () => {
           conversationService.getConversations(fileId, {
             ip: '', port: '', payloadContains: '', protocols: [], l7Protocols: [], apps: [],
             categories: [], hasRisks: false, fileTypes: [], riskTypes: [], customSignatures: [],
+            suricataAlerts: [],
             deviceTypes: [], countries: [], sortBy: '', sortDir: 'asc', page: 1, pageSize: 10000,
           }),
           conversationService.getHostClassifications(fileId).catch(() => undefined),

--- a/frontend/src/pages/Conversation/ConversationPage.tsx
+++ b/frontend/src/pages/Conversation/ConversationPage.tsx
@@ -79,10 +79,15 @@ export const ConversationPage = () => {
       .getCustomSignatures(fileId)
       .then(setCustomSignatureOptions)
       .catch(console.error);
+    // Clear first so stale options from the previous file aren't shown while/if the fetch fails.
+    setSuricataAlertOptions([]);
     conversationService
       .getSuricataAlerts(fileId)
       .then(setSuricataAlertOptions)
-      .catch(console.error);
+      .catch(err => {
+        console.error(err);
+        setSuricataAlertOptions([]);
+      });
     conversationService
       .getSignatureRules()
       .then(rules => {

--- a/frontend/src/pages/Conversation/ConversationPage.tsx
+++ b/frontend/src/pages/Conversation/ConversationPage.tsx
@@ -3,7 +3,11 @@ import { Button, Card, Modal } from '@govtechsg/sgds-react';
 import { useOutletContext, useSearchParams } from 'react-router-dom';
 import type { AnalysisData, Conversation, HostClassification } from '@/types';
 import type { SortField } from '@/features/conversation/types';
-import { loadVisibleColumns, COLUMN_STORAGE_KEY } from '@/features/conversation/constants';
+import {
+  loadVisibleColumns,
+  defaultVisibleColumns,
+  COLUMN_STORAGE_KEY,
+} from '@/features/conversation/constants';
 import type { ColumnKey } from '@/features/conversation/constants';
 import { useConversationFilters } from '@/features/conversation/hooks/useConversationFilters';
 import { conversationService } from '@/features/conversation/services/conversationService';
@@ -43,6 +47,7 @@ export const ConversationPage = () => {
   const [fileTypeOptions, setFileTypeOptions] = useState<string[]>([]);
   const [riskTypeOptions, setRiskTypeOptions] = useState<string[]>([]);
   const [customSignatureOptions, setCustomSignatureOptions] = useState<string[]>([]);
+  const [suricataAlertOptions, setSuricataAlertOptions] = useState<string[]>([]);
   const [countryOptions, setCountryOptions] = useState<string[]>([]);
   const [signatureSeverities, setSignatureSeverities] = useState<Record<string, string>>({});
   const [hostClassMap, setHostClassMap] = useState<Map<string, HostClassification>>(new Map());
@@ -59,6 +64,12 @@ export const ConversationPage = () => {
     });
   }, []);
 
+  // Restore the default visible-column set, clearing any stored override.
+  const resetColumns = useCallback(() => {
+    localStorage.removeItem(COLUMN_STORAGE_KEY);
+    setVisibleColumns(defaultVisibleColumns());
+  }, []);
+
   // Fetch available file types and risk types once per file
   useEffect(() => {
     if (!fileId) return;
@@ -67,6 +78,10 @@ export const ConversationPage = () => {
     conversationService
       .getCustomSignatures(fileId)
       .then(setCustomSignatureOptions)
+      .catch(console.error);
+    conversationService
+      .getSuricataAlerts(fileId)
+      .then(setSuricataAlertOptions)
       .catch(console.error);
     conversationService
       .getSignatureRules()
@@ -351,12 +366,14 @@ export const ConversationPage = () => {
             fileTypes={fileTypeOptions}
             riskTypes={riskTypeOptions}
             customSignatureOptions={customSignatureOptions}
+            suricataAlertOptions={suricataAlertOptions}
             signatureSeverities={signatureSeverities}
             countryOptions={countryOptions}
             presentDeviceTypes={presentDeviceTypes}
             activeFilterCount={activeFilterCount}
             visibleColumns={visibleColumns}
             onToggleColumn={toggleColumn}
+            onResetColumns={resetColumns}
           />
         </div>
       </div>

--- a/frontend/src/pages/Upload/UploadPage.tsx
+++ b/frontend/src/pages/Upload/UploadPage.tsx
@@ -16,6 +16,7 @@ export const UploadPage = () => {
   const [pendingFiles, setPendingFiles] = useState<File[] | null>(null);
   const [analysisOptions, setAnalysisOptions] = useState<AnalysisOptions>({
     enableNdpi: true,
+    enableSuricata: true,
     enableFileExtraction: true,
   });
   const navigate = useNavigate();
@@ -49,7 +50,11 @@ export const UploadPage = () => {
 
   const handleFileSelect = (files: File[]) => {
     if (!analysisOptionsEnabled) {
-      uploadFiles(files, { enableNdpi: true, enableFileExtraction: true });
+      uploadFiles(files, {
+        enableNdpi: true,
+        enableSuricata: true,
+        enableFileExtraction: true,
+      });
     } else {
       setPendingFiles(files);
     }
@@ -116,6 +121,24 @@ export const UploadPage = () => {
                     <div className="text-muted" style={{ fontSize: '0.82rem' }}>
                       Identifies apps (Zoom, Chrome, etc.), traffic categories, and security risks.
                       Adds ~1–2 min for large captures.
+                    </div>
+                  </div>
+                </label>
+
+                <label className="d-flex align-items-start gap-3" style={{ cursor: 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    className="form-check-input mt-1 flex-shrink-0"
+                    checked={analysisOptions.enableSuricata}
+                    onChange={e =>
+                      setAnalysisOptions(o => ({ ...o, enableSuricata: e.target.checked }))
+                    }
+                  />
+                  <div>
+                    <div className="fw-semibold">Suricata IDS threat detection</div>
+                    <div className="text-muted" style={{ fontSize: '0.82rem' }}>
+                      Flags known threats using Emerging Threats Open signatures (IDS alerts). Loads
+                      a large ruleset, adding ~30–60s per capture.
                     </div>
                   </div>
                 </label>

--- a/frontend/src/types/common.types.ts
+++ b/frontend/src/types/common.types.ts
@@ -63,6 +63,7 @@ export interface Conversation {
   tlsNotAfter?: number;
   flowRisks: string[];
   customSignatures: string[];
+  suricataAlerts: string[];
   httpUserAgents: string[];
   detectedFileTypes: string[];
   startTime: number;
@@ -323,6 +324,7 @@ export interface ConversationEvidence {
   startTime?: string | null;
   endTime?: string | null;
   flowRisks?: string[];
+  suricataAlerts?: string[];
   tlsIssuer?: string | null;
   tlsSubject?: string | null;
   ja3Client?: string | null;

--- a/frontend/src/utils/appColors.ts
+++ b/frontend/src/utils/appColors.ts
@@ -22,6 +22,9 @@ const SEVERITY_COLORS: Record<string, { bg: string; text: string }> = {
 /** Distinct colour for nDPI built-in risk flags — clearly different from custom signature severities. */
 export const RISK_BADGE = { bg: '#ffc107', text: '#212529' };
 
+/** Distinct colour for Suricata IDS alerts — clearly different from nDPI risks and custom signatures. */
+export const IDS_BADGE = { bg: '#6f42c1', text: '#ffffff' };
+
 export function getSeverityColor(severity: string): { bg: string; text: string } {
   return SEVERITY_COLORS[severity?.toLowerCase()] ?? SEVERITY_COLORS.low;
 }


### PR DESCRIPTION
Closes #401.

Adds [Suricata](https://suricata.io/) in offline pcap-read mode as a Stage 3 enrichment engine alongside nDPI/tshark. Where nDPI answers *"what is this traffic?"*, Suricata answers *"is this a known threat?"* — its signature-based alerts surface next to the existing nDPI risks and custom signatures.

## Backend
- **`SuricataService`** runs `suricata -r <pcap> -l <out> --runmode single --set unix-command.enabled=no`, parses `eve.json` alert events with Jackson, and maps each to a conversation by 5-tuple. Degrades gracefully (warn + continue) if the binary/ruleset is missing.
- **`suricata_alerts text[]`** column on `conversations` (migration **V17**), wired through the entity/DTOs. Alerts feed the existing security-alerts surface and `securityAlertCount`.
- **Dedicated `enable_suricata` toggle** (migration **V18**) threaded through `FileService`/`FileController` for both upload and merge — Suricata is gated independently of nDPI.
- **Filterable IDS alerts:** distinct-values endpoint (`/api/conversations/{id}/suricata-alerts`) + `suricataAlerts` filter param + `array_position` predicate. Alert labels are kept comma-free so they survive the shared comma-delimited filter transport.
- **`backend/Dockerfile`** installs `suricata` and bundles the **Emerging Threats Open** ruleset at build time into `/etc/suricata/rules/suricata.rules` — fully offline at runtime, refreshed by rebuilding the image (documented inline, mirroring the nDPI/MMDB pattern).

## Frontend
- Purple **IDS Alerts** column + badges in `ConversationList` and `ConversationDetail`.
- Searchable **IDS Alerts** facet in the conversation filter panel.
- **"Suricata IDS threat detection"** checkbox in the upload analysis-options modal.
- **"Reset to default"** button for column visibility.

## Verification
- `docker compose up -d --build` — Suricata 6.0.4 + ~140k ET rules bundled; V17/V18 migrate cleanly.
- Uploaded `demo_all_rules.pcap` → `ET POLICY Spotify P2P Client` alert flows through to the API, `securityAlertCount`, and the UI badge/column.
- Toggle independence confirmed (nDPI-only ≈ 0.2s vs Suricata-on ≈ 44s; each runs independently).
- IDS filter facet verified: distinct endpoint, filter-by-alert (total 1), negative control (total 0), and UI filtering via Playwright.
- Graceful degradation confirmed (binary removed → analysis still completes, warn logged).
- Column reset verified to restore defaults and persist across reload.

## Notes / follow-ups
- Per-file cost: ~40s is dominated by loading the ruleset on every run. A persistent Suricata unix-socket daemon (load rules once) is a natural follow-up optimization.
- Analyses run before the comma-free label change retain comma-containing labels in the DB; re-analysis produces the new form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**New Features**
- Integrated Suricata IDS threat detection with per-file enable/disable control during upload and merge.
- Added Suricata alert filtering in conversation lists (including network/graph/report views).
- Display Suricata “IDS Alerts” in conversation detail pages and as an optional conversation list column.
- Extended conversation exports (CSV and PCAP) to include Suricata alerts, plus a new endpoint to fetch distinct alerts for a file.
- Updated reports to include whether Suricata IDS was enabled for the file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->