### PR TITLE
feat: passive hostname tagging and display for client hosts (#368)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/controller/HostClassificationsController.java
+++ b/backend/src/main/java/com/tracepcap/analysis/controller/HostClassificationsController.java
@@ -31,6 +31,8 @@ public class HostClassificationsController {
                         .ip(e.getIp())
                         .mac(e.getMac())
                         .manufacturer(e.getManufacturer())
+                        .hostname(e.getHostname())
+                        .hostnameSource(e.getHostnameSource())
                         .ttl(e.getTtl())
                         .deviceType(e.getDeviceType())
                         .confidence(e.getConfidence())

--- a/backend/src/main/java/com/tracepcap/analysis/dto/HostClassificationResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/HostClassificationResponse.java
@@ -9,6 +9,8 @@ public class HostClassificationResponse {
   String ip;
   String mac;
   String manufacturer;
+  String hostname;
+  String hostnameSource;
   Integer ttl;
   String deviceType;
   int confidence;

--- a/backend/src/main/java/com/tracepcap/analysis/entity/HostClassificationEntity.java
+++ b/backend/src/main/java/com/tracepcap/analysis/entity/HostClassificationEntity.java
@@ -38,6 +38,20 @@ public class HostClassificationEntity {
   @Column(name = "manufacturer", length = 100)
   private String manufacturer;
 
+  /**
+   * Passively-discovered hostname for this host (e.g. "Johns-MacBook.local", "DESKTOP-AB12"). Null
+   * when no name was observed in the capture.
+   */
+  @Column(name = "hostname", length = 255)
+  private String hostname;
+
+  /**
+   * How {@link #hostname} was discovered. One of: {@code reverse_dns}, {@code mdns}, {@code nbns},
+   * {@code dhcp}, {@code manual}. Null when no hostname is set.
+   */
+  @Column(name = "hostname_source", length = 20)
+  private String hostnameSource;
+
   /** First-seen IP TTL value (may be null for non-IP traffic). */
   @Column(name = "ttl")
   private Integer ttl;

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -72,6 +72,7 @@ public class AnalysisService {
   private final SuricataService suricataService;
   private final CustomSignatureService customSignatureService;
   private final DeviceClassifierService deviceClassifierService;
+  private final HostnameResolverService hostnameResolverService;
   private final GeoIpService geoIpService;
   private final FileExtractionService fileExtractionService;
   private final AnalysisRecordService analysisRecordService;
@@ -137,13 +138,21 @@ public class AnalysisService {
         customSignatureService.applySignatures(parseResult.getConversations());
         Map<String, String> deviceOverrides =
             customSignatureService.getDeviceTypeOverrides(parseResult.getConversations());
+        Map<String, HostnameResolverService.ResolvedHostname> hostnames;
+        try {
+          hostnames = hostnameResolverService.resolve(tempFile);
+        } catch (Exception e) {
+          log.warn("[{}] Hostname resolution failed: {}", fileId, e.getMessage());
+          hostnames = java.util.Map.of();
+        }
         List<HostClassificationEntity> hostClassifications =
             deviceClassifierService.classify(
                 file,
                 parseResult.getConversations(),
                 parseResult.getHostTtls(),
                 parseResult.getHostMacs(),
-                deviceOverrides);
+                deviceOverrides,
+                hostnames);
         hostClassificationRepository.saveAll(hostClassifications);
         try {
           Set<String> allIps =

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -138,13 +138,9 @@ public class AnalysisService {
         customSignatureService.applySignatures(parseResult.getConversations());
         Map<String, String> deviceOverrides =
             customSignatureService.getDeviceTypeOverrides(parseResult.getConversations());
-        Map<String, HostnameResolverService.ResolvedHostname> hostnames;
-        try {
-          hostnames = hostnameResolverService.resolve(tempFile);
-        } catch (Exception e) {
-          log.warn("[{}] Hostname resolution failed: {}", fileId, e.getMessage());
-          hostnames = java.util.Map.of();
-        }
+        // resolve() degrades gracefully and never throws — it returns a (possibly empty) map.
+        Map<String, HostnameResolverService.ResolvedHostname> hostnames =
+            hostnameResolverService.resolve(tempFile);
         List<HostClassificationEntity> hostClassifications =
             deviceClassifierService.classify(
                 file,

--- a/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/DeviceClassifierService.java
@@ -140,6 +140,7 @@ public class DeviceClassifierService {
    * @param hostTtls first-seen TTL per source IP
    * @param hostMacs first-seen MAC per source IP
    * @param deviceOverrides IP → custom device type string set by YAML rules (may be empty)
+   * @param hostnames IP → passively-discovered hostname/source (may be empty)
    * @return one HostClassificationEntity per unique IP
    */
   public List<HostClassificationEntity> classify(
@@ -147,7 +148,8 @@ public class DeviceClassifierService {
       List<PcapParserService.ConversationInfo> conversations,
       Map<String, Integer> hostTtls,
       Map<String, String> hostMacs,
-      Map<String, String> deviceOverrides) {
+      Map<String, String> deviceOverrides,
+      Map<String, HostnameResolverService.ResolvedHostname> hostnames) {
 
     // Build per-host profiles from all conversations
     Map<String, HostProfile> profiles = new LinkedHashMap<>();
@@ -195,6 +197,17 @@ public class DeviceClassifierService {
               .deviceType(deviceType)
               .confidence(confidence)
               .build());
+    }
+
+    // Attach passively-discovered hostnames (DHCP/mDNS/NBNS/reverse DNS) to matching hosts.
+    if (hostnames != null && !hostnames.isEmpty()) {
+      for (HostClassificationEntity host : results) {
+        HostnameResolverService.ResolvedHostname rh = hostnames.get(host.getIp());
+        if (rh != null) {
+          host.setHostname(rh.hostname());
+          host.setHostnameSource(rh.source());
+        }
+      }
     }
 
     log.info("Classified {} hosts", results.size());

--- a/backend/src/main/java/com/tracepcap/analysis/service/HostnameResolverService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/HostnameResolverService.java
@@ -1,0 +1,259 @@
+package com.tracepcap.analysis.service;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves passively-observed hostnames for hosts in a PCAP capture.
+ *
+ * <p>Unlike the nDPI Hostname/SNI field (which records the <em>server</em> name a client connected
+ * to), this service extracts names that identify the local hosts themselves, from four sources:
+ *
+ * <ul>
+ *   <li><b>DHCP option 12</b> — the hostname a client advertises in its DHCP Request.
+ *   <li><b>mDNS</b> — {@code *.local} names announced in multicast DNS A/AAAA responses.
+ *   <li><b>NBNS</b> — NetBIOS names from name-service registrations/responses.
+ *   <li><b>Reverse DNS</b> — PTR responses mapping an IP back to a name.
+ * </ul>
+ *
+ * <p>A single host may be named by several sources; the most authoritative for the host's own
+ * identity wins (see {@link #SOURCE_PRIORITY}). Runs as a single read-only tshark pass and never
+ * throws — on any failure it returns whatever was resolved so far (possibly empty).
+ */
+@Slf4j
+@Service
+public class HostnameResolverService {
+
+  public static final String SOURCE_REVERSE_DNS = "reverse_dns";
+  public static final String SOURCE_MDNS = "mdns";
+  public static final String SOURCE_NBNS = "nbns";
+  public static final String SOURCE_DHCP = "dhcp";
+  public static final String SOURCE_MANUAL = "manual";
+
+  /** Lower value = more authoritative for a host's own identity; the lowest wins per IP. */
+  private static final Map<String, Integer> SOURCE_PRIORITY =
+      Map.of(SOURCE_MANUAL, 0, SOURCE_DHCP, 1, SOURCE_MDNS, 2, SOURCE_NBNS, 3, SOURCE_REVERSE_DNS, 4);
+
+  private static final int HOSTNAME_MAX_LENGTH = 255;
+
+  /** A discovered hostname together with how it was found. */
+  public record ResolvedHostname(String hostname, String source) {}
+
+  /**
+   * Scans the capture and returns a map of IP → resolved hostname for every host whose name could
+   * be derived from DHCP, mDNS, NBNS or reverse DNS.
+   */
+  public Map<String, ResolvedHostname> resolve(File pcapFile) {
+    Map<String, ResolvedHostname> result = new HashMap<>();
+
+    // Fields (pipe-separated, first occurrence only):
+    //   0 _ws.col.Protocol  1 ip.src  2 dhcp.option.hostname
+    //   3 dhcp.option.requested_ip_address  4 dns.resp.name  5 dns.a  6 dns.aaaa
+    //   7 dns.ptr.domain_name  8 dns.qry.name  9 nbns.name  10 nbns.addr
+    ProcessBuilder pb =
+        new ProcessBuilder(
+            "tshark",
+            "-r",
+            pcapFile.getAbsolutePath(),
+            "-Y",
+            "dhcp.option.hostname || (mdns && dns.flags.response==1) || nbns.name"
+                + " || (dns.flags.response==1 && dns.qry.type==12)",
+            "-T",
+            "fields",
+            "-E",
+            "separator=|",
+            "-E",
+            "occurrence=f",
+            "-e",
+            "_ws.col.Protocol",
+            "-e",
+            "ip.src",
+            "-e",
+            "dhcp.option.hostname",
+            "-e",
+            "dhcp.option.requested_ip_address",
+            "-e",
+            "dns.resp.name",
+            "-e",
+            "dns.a",
+            "-e",
+            "dns.aaaa",
+            "-e",
+            "dns.ptr.domain_name",
+            "-e",
+            "dns.qry.name",
+            "-e",
+            "nbns.name",
+            "-e",
+            "nbns.addr");
+    pb.redirectErrorStream(false);
+
+    try {
+      Process process = pb.start();
+
+      // Drain stderr so it can't block stdout.
+      Thread stderrThread =
+          new Thread(
+              () -> {
+                try (BufferedReader err =
+                    new BufferedReader(
+                        new InputStreamReader(
+                            process.getErrorStream(), StandardCharsets.UTF_8))) {
+                  while (err.readLine() != null) {
+                    // discard
+                  }
+                } catch (Exception ignored) {
+                  // best-effort
+                }
+              });
+      stderrThread.setDaemon(true);
+      stderrThread.start();
+
+      try (BufferedReader reader =
+          new BufferedReader(
+              new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          if (line.isEmpty()) continue;
+          parseRow(line.split("\\|", -1), result);
+        }
+      }
+
+      boolean finished = process.waitFor(2, java.util.concurrent.TimeUnit.MINUTES);
+      if (!finished) {
+        process.destroyForcibly();
+        log.warn("Hostname resolution timed out; returning {} partial result(s)", result.size());
+      }
+    } catch (Exception e) {
+      log.warn("Hostname resolution failed: {}", e.getMessage());
+    }
+
+    log.info("Resolved {} host name(s) from DHCP/mDNS/NBNS/reverse-DNS", result.size());
+    return result;
+  }
+
+  // ── Row parsing ─────────────────────────────────────────────────────────────
+
+  private void parseRow(String[] f, Map<String, ResolvedHostname> result) {
+    if (f.length < 11) return;
+    String proto = f[0].toUpperCase();
+
+    if (proto.contains("DHCP") || proto.contains("BOOTP")) {
+      // option 12 hostname; IP is the requested address (option 50) or, failing that, the source.
+      String ip = firstValue(f[3]);
+      if (!isUsableIp(ip)) ip = firstValue(f[1]);
+      record(result, ip, f[2], SOURCE_DHCP);
+    } else if (proto.equals("MDNS")) {
+      String ip = firstValue(f[5]);
+      if (ip == null) ip = firstValue(f[6]);
+      String name = stripTrailingDot(f[4]);
+      // Skip service-discovery records (e.g. "_spotify-connect._tcp.local"); keep host names.
+      if (isPlausibleHostName(name)) record(result, ip, name, SOURCE_MDNS);
+    } else if (proto.contains("NBNS")) {
+      String ip = firstValue(f[10]);
+      if (!isUsableIp(ip)) ip = firstValue(f[1]);
+      record(result, ip, cleanNetbiosName(f[9]), SOURCE_NBNS);
+    } else if (proto.contains("DNS")) {
+      // Reverse PTR: question is "<ip>.in-addr.arpa", answer is the name.
+      String ip = arpaToIp(firstValue(f[8]));
+      record(result, ip, stripTrailingDot(f[7]), SOURCE_REVERSE_DNS);
+    }
+  }
+
+  /** Records ip → (hostname, source), keeping the most authoritative source already seen. */
+  private void record(
+      Map<String, ResolvedHostname> result, String ip, String rawHostname, String source) {
+    if (!isUsableIp(ip)) return;
+    String hostname = cleanHostname(rawHostname);
+    if (hostname == null) return;
+
+    ResolvedHostname existing = result.get(ip);
+    if (existing != null
+        && SOURCE_PRIORITY.getOrDefault(existing.source(), Integer.MAX_VALUE)
+            <= SOURCE_PRIORITY.getOrDefault(source, Integer.MAX_VALUE)) {
+      return; // keep the equal-or-better source already recorded
+    }
+    result.put(ip, new ResolvedHostname(hostname, source));
+  }
+
+  // ── Field helpers ────────────────────────────────────────────────────────────
+
+  /** tshark may join multiple occurrences with ','; take the first non-blank token. */
+  private String firstValue(String field) {
+    if (field == null) return null;
+    String trimmed = field.trim();
+    if (trimmed.isEmpty()) return null;
+    int comma = trimmed.indexOf(',');
+    return comma >= 0 ? trimmed.substring(0, comma).trim() : trimmed;
+  }
+
+  private String cleanHostname(String raw) {
+    if (raw == null) return null;
+    String h = raw.trim();
+    if (h.isEmpty()) return null;
+    if (h.length() > HOSTNAME_MAX_LENGTH) h = h.substring(0, HOSTNAME_MAX_LENGTH);
+    return h;
+  }
+
+  private String stripTrailingDot(String raw) {
+    if (raw == null) return null;
+    String h = raw.trim();
+    return h.endsWith(".") ? h.substring(0, h.length() - 1) : h;
+  }
+
+  /**
+   * NetBIOS names are space-padded and carry a "&lt;XX&gt;" suffix type byte. Only the machine-name
+   * suffixes (00 = Workstation, 20 = Server service) identify the host itself; group/browser
+   * suffixes (1b/1c/1d/1e = domain-master/browser, etc.) name the workgroup, not the host, so they
+   * are dropped to avoid labelling every member with the workgroup name.
+   */
+  private String cleanNetbiosName(String raw) {
+    if (raw == null) return null;
+    String h = firstValue(raw);
+    if (h == null) return null;
+    int lt = h.indexOf('<');
+    String suffix = null;
+    if (lt >= 0) {
+      int gt = h.indexOf('>', lt);
+      suffix = (gt > lt ? h.substring(lt + 1, gt) : h.substring(lt + 1)).trim().toLowerCase();
+      h = h.substring(0, lt);
+    }
+    if (suffix != null && !suffix.equals("00") && !suffix.equals("20")) return null;
+    h = h.trim();
+    return h.isEmpty() ? null : h;
+  }
+
+  /** Rejects mDNS service-discovery names ("_http._tcp.local") and keeps real host names. */
+  private boolean isPlausibleHostName(String name) {
+    if (name == null || name.isBlank()) return false;
+    String lower = name.toLowerCase();
+    return !lower.startsWith("_") && !lower.contains("._tcp") && !lower.contains("._udp")
+        && !lower.contains("._sub");
+  }
+
+  /** Converts a reverse-DNS "4.3.2.1.in-addr.arpa" question to the IPv4 "1.2.3.4". */
+  private String arpaToIp(String qryName) {
+    if (qryName == null) return null;
+    String name = qryName.trim().toLowerCase();
+    if (!name.endsWith(".in-addr.arpa")) return null; // IPv6 ip6.arpa not supported
+    String labels = name.substring(0, name.length() - ".in-addr.arpa".length());
+    String[] octets = labels.split("\\.");
+    if (octets.length != 4) return null;
+    StringBuilder sb = new StringBuilder();
+    for (int i = octets.length - 1; i >= 0; i--) {
+      sb.append(octets[i]);
+      if (i > 0) sb.append('.');
+    }
+    return sb.toString();
+  }
+
+  private boolean isUsableIp(String ip) {
+    return ip != null && !ip.isBlank() && !ip.equals("0.0.0.0") && !ip.equals("::");
+  }
+}

--- a/backend/src/main/java/com/tracepcap/analysis/service/HostnameResolverService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/HostnameResolverService.java
@@ -4,8 +4,12 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -50,7 +54,8 @@ public class HostnameResolverService {
    * be derived from DHCP, mDNS, NBNS or reverse DNS.
    */
   public Map<String, ResolvedHostname> resolve(File pcapFile) {
-    Map<String, ResolvedHostname> result = new HashMap<>();
+    // Concurrent: the stdout reader (background thread) writes while the main thread reads size().
+    Map<String, ResolvedHostname> result = new ConcurrentHashMap<>();
 
     // Fields (pipe-separated, first occurrence only):
     //   0 _ws.col.Protocol  1 ip.src  2 dhcp.option.hostname
@@ -94,8 +99,11 @@ public class HostnameResolverService {
             "nbns.addr");
     pb.redirectErrorStream(false);
 
+    Process process = null;
+    ExecutorService ioExecutor = null;
     try {
-      Process process = pb.start();
+      process = pb.start();
+      final Process proc = process;
 
       // Drain stderr so it can't block stdout.
       Thread stderrThread =
@@ -103,8 +111,7 @@ public class HostnameResolverService {
               () -> {
                 try (BufferedReader err =
                     new BufferedReader(
-                        new InputStreamReader(
-                            process.getErrorStream(), StandardCharsets.UTF_8))) {
+                        new InputStreamReader(proc.getErrorStream(), StandardCharsets.UTF_8))) {
                   while (err.readLine() != null) {
                     // discard
                   }
@@ -115,23 +122,47 @@ public class HostnameResolverService {
       stderrThread.setDaemon(true);
       stderrThread.start();
 
-      try (BufferedReader reader =
-          new BufferedReader(
-              new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-        String line;
-        while ((line = reader.readLine()) != null) {
-          if (line.isEmpty()) continue;
-          parseRow(line.split("\\|", -1), result);
+      // Read stdout on a separate thread so a tshark that hangs while holding stdout open
+      // can't block the waitFor timeout below indefinitely.
+      ioExecutor = Executors.newSingleThreadExecutor();
+      Future<?> stdoutTask =
+          ioExecutor.submit(
+              () -> {
+                try (BufferedReader reader =
+                    new BufferedReader(
+                        new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
+                  String line;
+                  while ((line = reader.readLine()) != null) {
+                    if (!line.isEmpty()) parseRow(line.split("\\|", -1), result);
+                  }
+                } catch (Exception ignored) {
+                  // best-effort
+                }
+              });
+
+      boolean finished = process.waitFor(2, TimeUnit.MINUTES);
+      if (!finished) {
+        log.warn("Hostname resolution timed out; returning {} partial result(s)", result.size());
+      } else {
+        int exit = process.exitValue();
+        if (exit != 0) {
+          log.warn("Hostname resolution: tshark exited with code {}; results may be partial", exit);
+        }
+        // Let the reader drain any output still buffered after the process exited.
+        try {
+          stdoutTask.get(5, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+          // best-effort
         }
       }
-
-      boolean finished = process.waitFor(2, java.util.concurrent.TimeUnit.MINUTES);
-      if (!finished) {
-        process.destroyForcibly();
-        log.warn("Hostname resolution timed out; returning {} partial result(s)", result.size());
-      }
+    } catch (InterruptedException e) {
+      log.warn("Hostname resolution interrupted");
+      Thread.currentThread().interrupt();
     } catch (Exception e) {
       log.warn("Hostname resolution failed: {}", e.getMessage());
+    } finally {
+      if (process != null) process.destroyForcibly();
+      if (ioExecutor != null) ioExecutor.shutdownNow();
     }
 
     log.info("Resolved {} host name(s) from DHCP/mDNS/NBNS/reverse-DNS", result.size());
@@ -240,7 +271,8 @@ public class HostnameResolverService {
   /** Converts a reverse-DNS "4.3.2.1.in-addr.arpa" question to the IPv4 "1.2.3.4". */
   private String arpaToIp(String qryName) {
     if (qryName == null) return null;
-    String name = qryName.trim().toLowerCase();
+    // DNS query names may carry a trailing dot ("4.3.2.1.in-addr.arpa."); strip it first.
+    String name = stripTrailingDot(qryName).toLowerCase();
     if (!name.endsWith(".in-addr.arpa")) return null; // IPv6 ip6.arpa not supported
     String labels = name.substring(0, name.length() - ".in-addr.arpa".length());
     String[] octets = labels.split("\\.");

--- a/backend/src/main/java/com/tracepcap/intelligence/dto/HostSummaryDto.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/dto/HostSummaryDto.java
@@ -8,6 +8,7 @@ import lombok.Data;
 public class HostSummaryDto {
   private String ip;
   private String hostname;
+  private String hostnameSource;
   private long totalBytes;
   private long packetCount;
   private long conversationCount;

--- a/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
@@ -340,9 +340,15 @@ public class NetworkIntelligenceService {
           String role = acc.clientConversations > acc.serverConversations * 2 ? "client"
               : acc.serverConversations > acc.clientConversations * 2 ? "server"
               : "both";
+          // Prefer the host's own discovered name (DHCP/mDNS/NBNS/reverse DNS) over the
+          // nDPI SNI, which records the server a client connected to rather than the host itself.
+          String hostname = device != null && device.getHostname() != null
+              ? device.getHostname() : acc.hostname;
+          String hostnameSource = device != null ? device.getHostnameSource() : null;
           return HostSummaryDto.builder()
               .ip(ip)
-              .hostname(acc.hostname)
+              .hostname(hostname)
+              .hostnameSource(hostnameSource)
               .totalBytes(acc.totalBytes)
               .packetCount(acc.packetCount)
               .conversationCount(acc.conversationCount)

--- a/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
@@ -342,9 +342,10 @@ public class NetworkIntelligenceService {
               : "both";
           // Prefer the host's own discovered name (DHCP/mDNS/NBNS/reverse DNS) over the
           // nDPI SNI, which records the server a client connected to rather than the host itself.
-          String hostname = device != null && device.getHostname() != null
-              ? device.getHostname() : acc.hostname;
-          String hostnameSource = device != null ? device.getHostnameSource() : null;
+          boolean useDeviceHostname = device != null && device.getHostname() != null;
+          String hostname = useDeviceHostname ? device.getHostname() : acc.hostname;
+          // Only attach a discovery-source badge when the passively-discovered name is the one shown.
+          String hostnameSource = useDeviceHostname ? device.getHostnameSource() : null;
           return HostSummaryDto.builder()
               .ip(ip)
               .hostname(hostname)

--- a/backend/src/main/resources/db/migration/V19__host_hostname.sql
+++ b/backend/src/main/resources/db/migration/V19__host_hostname.sql
@@ -1,0 +1,7 @@
+-- Surface passively-observed client hostnames in the Network Intelligence view (#368).
+-- `hostname`        — the discovered name for the host (e.g. "Johns-MacBook.local", "DESKTOP-AB12").
+-- `hostname_source` — how it was discovered, one of:
+--                     reverse_dns, mdns, nbns, dhcp, manual.
+ALTER TABLE host_classifications
+    ADD COLUMN hostname        VARCHAR(255),
+    ADD COLUMN hostname_source VARCHAR(20);

--- a/frontend/src/components/common/HostnameSourceBadge/HostnameSourceBadge.tsx
+++ b/frontend/src/components/common/HostnameSourceBadge/HostnameSourceBadge.tsx
@@ -1,0 +1,58 @@
+import type { HostnameSource } from '@/types';
+
+const SOURCE_INFO: Record<HostnameSource, { label: string; tooltip: string; color: string }> = {
+  dhcp: {
+    label: 'DHCP',
+    tooltip: 'Hostname advertised by the host in a DHCP request (option 12).',
+    color: '#0072c6',
+  },
+  mdns: {
+    label: 'mDNS',
+    tooltip: 'Hostname announced via multicast DNS (e.g. a *.local Bonjour/Avahi name).',
+    color: '#5c2d91',
+  },
+  nbns: {
+    label: 'NBNS',
+    tooltip: 'NetBIOS name observed from a NetBIOS Name Service registration or response.',
+    color: '#b35900',
+  },
+  reverse_dns: {
+    label: 'rDNS',
+    tooltip: 'Name resolved from a reverse DNS (PTR) lookup of the IP address.',
+    color: '#107c10',
+  },
+  manual: {
+    label: 'Manual',
+    tooltip: 'Hostname set manually by an analyst.',
+    color: '#6c757d',
+  },
+};
+
+interface HostnameSourceBadgeProps {
+  source?: HostnameSource | string | null;
+}
+
+/** Small coloured chip showing how a host's name was discovered (DHCP, mDNS, NBNS, rDNS). */
+export const HostnameSourceBadge = ({ source }: HostnameSourceBadgeProps) => {
+  if (!source) return null;
+  const info = SOURCE_INFO[source as HostnameSource];
+  if (!info) return null;
+  return (
+    <span
+      title={info.tooltip}
+      style={{
+        fontSize: 9,
+        fontWeight: 600,
+        color: '#fff',
+        background: info.color,
+        borderRadius: 3,
+        padding: '1px 4px',
+        cursor: 'help',
+        whiteSpace: 'nowrap',
+        flexShrink: 0,
+      }}
+    >
+      {info.label}
+    </span>
+  );
+};

--- a/frontend/src/components/intelligence/TopHostsTable/TopHostsTable.tsx
+++ b/frontend/src/components/intelligence/TopHostsTable/TopHostsTable.tsx
@@ -2,6 +2,7 @@ import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState } from 'react';
 import { Badge, Button } from '@govtechsg/sgds-react';
 import { formatBytes } from '@/utils/formatters';
+import { HostnameSourceBadge } from '@components/common/HostnameSourceBadge/HostnameSourceBadge';
 import type { HostSummary, SortBy } from '@/features/intelligence/services/intelligenceService';
 
 const GEO_SOURCE_INFO = {
@@ -100,11 +101,20 @@ export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHos
               <tr key={host.ip}>
                 <td className="text-muted">{page * pageSize + i + 1}</td>
                 <td>
-                  <span className="fw-semibold" style={{ fontFamily: 'monospace', fontSize: 11 }}>
-                    {host.ip}
-                  </span>
-                  {host.hostname && (
-                    <div className="text-info" style={{ fontSize: 10 }}>{host.hostname}</div>
+                  {host.hostname ? (
+                    <>
+                      <div className="d-flex align-items-center gap-1">
+                        <span className="fw-semibold" style={{ fontSize: 11 }}>{host.hostname}</span>
+                        <HostnameSourceBadge source={host.hostnameSource} />
+                      </div>
+                      <div className="text-muted" style={{ fontFamily: 'monospace', fontSize: 10 }}>
+                        {host.ip}
+                      </div>
+                    </>
+                  ) : (
+                    <span className="fw-semibold" style={{ fontFamily: 'monospace', fontSize: 11 }}>
+                      {host.ip}
+                    </span>
                   )}
                 </td>
                 <td>{formatBytes(host.totalBytes)}</td>

--- a/frontend/src/components/monitor/MonitorNetworkDiagram/MonitorNetworkDiagram.tsx
+++ b/frontend/src/components/monitor/MonitorNetworkDiagram/MonitorNetworkDiagram.tsx
@@ -6,6 +6,7 @@ import type { NodeHighlight } from '@/components/network/NetworkGraph/NetworkGra
 import { NetworkGraph } from '@/components/network/NetworkGraph';
 import { NetworkControls } from '@/components/network/NetworkControls';
 import { NodeDetails } from '@/components/network/NodeDetails';
+import { NodeLabelSettingsModal } from '@/components/network/NodeLabelSettingsModal';
 import type { GraphNode } from '@/features/network/types';
 import { useNetworkData } from '@/features/network/hooks/useNetworkData';
 import { toggleSet } from '@/features/network/constants';
@@ -119,6 +120,7 @@ export const MonitorNetworkDiagram = ({
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showFilterModal, setShowFilterModal] = useState(false);
+  const [showLabelModal, setShowLabelModal] = useState(false);
 
   // ── Filter state ──────────────────────────────────────────────────────────
   const [ipFilter, setIpFilter] = useState('');
@@ -164,6 +166,7 @@ export const MonitorNetworkDiagram = ({
     if (!show) {
       setSelectedNode(null);
       setShowFilterModal(false);
+      setShowLabelModal(false);
       return;
     }
     if (initialSnapshotId) {
@@ -390,7 +393,16 @@ export const MonitorNetworkDiagram = ({
           <Button
             variant="link"
             size="sm"
-            className="ms-auto p-0 text-muted"
+            className="ms-auto p-0 text-muted me-3"
+            onClick={() => setShowLabelModal(true)}
+            title="Customize node labels"
+          >
+            <i className="bi bi-tags" />
+          </Button>
+          <Button
+            variant="link"
+            size="sm"
+            className="p-0 text-muted"
             onClick={() => setIsFullscreen(f => !f)}
             title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
           >
@@ -567,6 +579,9 @@ export const MonitorNetworkDiagram = ({
         <Button variant="secondary" onClick={() => setShowFilterModal(false)}>Close</Button>
       </Modal.Footer>
     </Modal>
+
+    {/* Node-label settings — separate modal so it stacks above the diagram */}
+    <NodeLabelSettingsModal show={showLabelModal} onHide={() => setShowLabelModal(false)} />
     </>
   );
 };

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -9,6 +9,7 @@ import { NetworkInsightsPanel } from '@/components/monitor/NetworkInsightsPanel/
 import { NetworkGraph } from '@/components/network/NetworkGraph';
 import { NetworkControls } from '@/components/network/NetworkControls';
 import { NodeDetails } from '@/components/network/NodeDetails';
+import { NodeLabelSettingsModal } from '@/components/network/NodeLabelSettingsModal';
 import { useNetworkData } from '@/features/network/hooks/useNetworkData';
 import { toggleSet } from '@/features/network/constants';
 import { edgeMatchesLegendKey, applyNetworkFilters } from '@/features/network/services/networkService';
@@ -126,6 +127,7 @@ export const SnapshotDetailModal = ({
   const [layoutType, setLayoutType] = useState<'circular' | 'hierarchicalTd'>('circular');
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
   const [showFilterModal, setShowFilterModal] = useState(false);
+  const [showLabelModal, setShowLabelModal] = useState(false);
 
   // Filter state
   const [ipFilter, setIpFilter] = useState('');
@@ -476,6 +478,15 @@ export const SnapshotDetailModal = ({
                   ))}
                 </div>
               )}
+              <Button
+                variant="link"
+                size="sm"
+                className="p-0 text-muted ms-auto"
+                onClick={() => setShowLabelModal(true)}
+                title="Customize node labels"
+              >
+                <i className="bi bi-tags" />
+              </Button>
             </div>
             <div className="monitor-diagram-graph" style={{ height: 460 }}>
               {graphLoading ? (
@@ -775,6 +786,9 @@ export const SnapshotDetailModal = ({
         <Button variant="secondary" onClick={() => setShowFilterModal(false)}>Close</Button>
       </Modal.Footer>
     </Modal>
+
+    {/* Node-label settings — separate modal so it stacks above the diagram */}
+    <NodeLabelSettingsModal show={showLabelModal} onHide={() => setShowLabelModal(false)} />
     </>
   );
 };

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -10,6 +10,7 @@ import type { GraphNode, GraphEdge } from '@/features/network/types';
 import { getProtocolColor, NODE_TYPE_CONFIG } from '@/features/network/constants';
 import { deviceTypeColor, deviceTypeIcon, deviceTypeLabel, DEVICE_TYPES } from '@/utils/deviceType';
 import { useStore } from '@/store';
+import type { NodeLabelConfig } from '@/store/slices/nodeLabelSlice';
 import './NetworkGraph.css';
 
 // ---------------------------------------------------------------------------
@@ -103,6 +104,47 @@ function getNodeIcon(nodeType: string, deviceType: string): string {
  *   3. Accent-colored Bootstrap Icon centered inside
  *   4. Text label below
  */
+/**
+ * Builds the ordered list of text lines drawn under a node, from the user's label
+ * configuration. Cluster nodes ignore the config and keep their descriptive label.
+ * Always returns at least one line so a node is never left unlabelled.
+ */
+function buildNodeLines(node: GraphNode, cfg: NodeLabelConfig): string[] {
+  if (node.data.isCluster) return node.label ? [node.label] : [];
+
+  const lines: string[] = [];
+  for (const opt of cfg.fields) {
+    if (!opt.enabled) continue;
+    let value: string | undefined;
+    switch (opt.field) {
+      case 'ip':
+        value = node.data.ip;
+        break;
+      case 'hostname':
+        value = node.data.hostname;
+        break;
+      case 'mac':
+        value = node.data.mac;
+        break;
+      case 'deviceType':
+        value =
+          node.data.deviceType && node.data.deviceType !== 'UNKNOWN'
+            ? deviceTypeLabel(node.data.deviceType)
+            : undefined;
+        break;
+      case 'manufacturer':
+        value = node.data.manufacturer;
+        break;
+    }
+    if (value) lines.push(value);
+  }
+  const custom = cfg.customText.trim();
+  if (custom) lines.push(custom);
+  // Never render an unlabelled node — fall back to IP (or the node's display label).
+  if (lines.length === 0) lines.push(node.data.ip || node.label || '');
+  return lines.filter(Boolean);
+}
+
 function drawNodeLabel(
   ctx: CanvasRenderingContext2D,
   data: { x: number; y: number; size: number; label: string | null; color: string },
@@ -110,6 +152,7 @@ function drawNodeLabel(
   nodeFill: string,
   ntMap: Map<string, string>,
   dtMap: Map<string, string>,
+  linesMap: Map<string, string[]>,
   hlMap?: Map<string, NodeHighlight>,
 ): void {
   const { x, y, size, label, color: accentColor } = data;
@@ -149,13 +192,19 @@ function drawNodeLabel(
   ctx.textBaseline = 'middle';
   ctx.fillText(cp, x, y);
 
-  // Text label below
-  if (label) {
+  // Text label(s) below — one line per configured field.
+  // An empty label means the node is dimmed (hover) and should draw no text.
+  const lines = label ? linesMap.get(label) ?? [label] : [];
+  if (lines.length > 0) {
     ctx.font = `500 11px Inter, system-ui, sans-serif`;
     ctx.fillStyle = labelColor;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
-    ctx.fillText(label, x, y + size + 3);
+    let lineY = y + size + 3;
+    for (const line of lines) {
+      ctx.fillText(line, x, lineY);
+      lineY += 13;
+    }
   }
 }
 
@@ -356,6 +405,9 @@ export const NetworkGraph = memo(function NetworkGraph({
   const graphRef = useRef<Graph | null>(null);
   const nodeTypeByLabel = useRef<Map<string, string>>(new Map());
   const deviceTypeByLabel = useRef<Map<string, string>>(new Map());
+  // Per-node text lines (keyed by the node's label), derived from the user's label config.
+  const nodeLinesByLabel = useRef<Map<string, string[]>>(new Map());
+  const nodeLabelConfig = useStore(s => s.nodeLabelConfig);
   const elkRef = useRef<InstanceType<typeof ELK> | null>(null);
   if (!elkRef.current) {
     elkRef.current = new ELK({
@@ -378,6 +430,14 @@ export const NetworkGraph = memo(function NetworkGraph({
     highlightedNodesRef.current = highlightedNodes;
     sigmaRef.current?.refresh();
   }, [highlightedNodes]);
+
+  // Recompute node text lines when the label config changes, then redraw (no relayout).
+  useEffect(() => {
+    const lines = new Map<string, string[]>();
+    for (const n of nodesRef.current) lines.set(n.label, buildNodeLines(n, nodeLabelConfig));
+    nodeLinesByLabel.current = lines;
+    sigmaRef.current?.refresh();
+  }, [nodeLabelConfig]);
 
   // Hidden neighbor lookup
   const hiddenNodeMap = useMemo(
@@ -423,6 +483,13 @@ export const NetworkGraph = memo(function NetworkGraph({
     const graph = buildGraph(nodes, edges, primarySource);
     graphRef.current = graph;
 
+    // Seed the per-node text lines before the first paint. Read config fresh so a
+    // config change alone doesn't force a full graph rebuild + relayout (handled below).
+    const initialCfg = useStore.getState().nodeLabelConfig;
+    const initialLines = new Map<string, string[]>();
+    for (const n of nodes) initialLines.set(n.label, buildNodeLines(n, initialCfg));
+    nodeLinesByLabel.current = initialLines;
+
     const bgColor = darkMode ? DARK_BG : LIGHT_BG;
     const nodeFill = darkMode ? DARK_SURFACE : '#ffffff';
     const labelColor = darkMode ? '#c9d1d9' : '#212529';
@@ -438,10 +505,10 @@ export const NetworkGraph = memo(function NetworkGraph({
       minEdgeThickness: 0.5,
       zIndex: true,
       defaultDrawNodeLabel: (ctx, data) => {
-        drawNodeLabel(ctx, data, labelColor, nodeFill, nodeTypeByLabel.current, deviceTypeByLabel.current, highlightedNodesRef.current);
+        drawNodeLabel(ctx, data, labelColor, nodeFill, nodeTypeByLabel.current, deviceTypeByLabel.current, nodeLinesByLabel.current, highlightedNodesRef.current);
       },
       defaultDrawNodeHover: (ctx, data) => {
-        drawNodeLabel(ctx, data, labelColor, nodeFill, nodeTypeByLabel.current, deviceTypeByLabel.current, highlightedNodesRef.current);
+        drawNodeLabel(ctx, data, labelColor, nodeFill, nodeTypeByLabel.current, deviceTypeByLabel.current, nodeLinesByLabel.current, highlightedNodesRef.current);
       },
       nodeReducer: (node, data) => {
         const res = { ...data };

--- a/frontend/src/components/network/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/components/network/NodeDetails/NodeDetails.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import type { GraphNode, GraphEdge } from '@/features/network/types';
 import { NODE_TYPE_CONFIG, getProtocolColor } from '@/features/network/constants';
 import { deviceTypeLabel, deviceTypeColor } from '@/utils/deviceType';
+import { HostnameSourceBadge } from '@components/common/HostnameSourceBadge/HostnameSourceBadge';
 import { NodeClassificationPopup } from '@components/common/NodeClassificationPopup/NodeClassificationPopup';
 import { EntityDetailModal } from '@components/common/EntityDetailModal';
 import type { NodeHighlight } from '@/components/network/NetworkGraph/NetworkGraph';
@@ -287,7 +288,10 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                       {node.data.hostname && (
                         <>
                           <dt className="col-5 text-muted">Hostname</dt>
-                          <dd className="col-7 mb-1">{node.data.hostname}</dd>
+                          <dd className="col-7 mb-1 d-flex align-items-center gap-1">
+                            <span>{node.data.hostname}</span>
+                            <HostnameSourceBadge source={node.data.hostnameSource} />
+                          </dd>
                         </>
                       )}
 

--- a/frontend/src/components/network/NodeLabelSettingsModal/NodeLabelSettingsModal.tsx
+++ b/frontend/src/components/network/NodeLabelSettingsModal/NodeLabelSettingsModal.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import { Button, Form, Modal } from '@govtechsg/sgds-react';
+import { useStore } from '@/store';
+import {
+  NODE_LABEL_FIELD_META,
+  type NodeLabelConfig,
+  type NodeLabelFieldOption,
+} from '@/store/slices/nodeLabelSlice';
+
+interface NodeLabelSettingsModalProps {
+  show: boolean;
+  onHide: () => void;
+  /** Render target so the modal stays inside the (possibly fullscreen) graph card. */
+  container?: HTMLElement;
+}
+
+/** Example values used to render a live preview of the chosen label layout. */
+const PREVIEW_VALUES: Record<string, string> = {
+  ip: '192.168.1.42',
+  hostname: 'Johns-MacBook.local',
+  mac: 'a4:83:e7:1a:2b:3c',
+  deviceType: 'Laptop / Desktop',
+  manufacturer: 'Apple',
+};
+
+/**
+ * Lets the analyst choose which host attributes (and optional custom text) are drawn
+ * as lines of text beneath each node in the network topology graph.
+ */
+export const NodeLabelSettingsModal = ({ show, onHide, container }: NodeLabelSettingsModalProps) => {
+  const config = useStore(s => s.nodeLabelConfig);
+  const setNodeLabelConfig = useStore(s => s.setNodeLabelConfig);
+  const resetNodeLabelConfig = useStore(s => s.resetNodeLabelConfig);
+
+  // Draft state so changes only apply on Save.
+  const [fields, setFields] = useState<NodeLabelFieldOption[]>(config.fields);
+  const [customText, setCustomText] = useState(config.customText);
+
+  // Re-seed the draft from the live config each time the modal opens.
+  useEffect(() => {
+    if (show) {
+      setFields(config.fields);
+      setCustomText(config.customText);
+    }
+  }, [show, config]);
+
+  const toggleField = (index: number) =>
+    setFields(prev => prev.map((f, i) => (i === index ? { ...f, enabled: !f.enabled } : f)));
+
+  const moveField = (index: number, dir: -1 | 1) =>
+    setFields(prev => {
+      const target = index + dir;
+      if (target < 0 || target >= prev.length) return prev;
+      const next = [...prev];
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+
+  const handleSave = () => {
+    const newConfig: NodeLabelConfig = { fields, customText };
+    setNodeLabelConfig(newConfig);
+    onHide();
+  };
+
+  const handleReset = () => {
+    resetNodeLabelConfig();
+    onHide();
+  };
+
+  const previewLines = [
+    ...fields.filter(f => f.enabled).map(f => PREVIEW_VALUES[f.field]),
+    ...(customText.trim() ? [customText.trim()] : []),
+  ];
+
+  return (
+    <Modal show={show} onHide={onHide} centered container={container}>
+      <Modal.Header closeButton>
+        <Modal.Title>Customize node labels</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p className="text-muted small mb-3">
+          Choose which details appear as text beneath each node, and the order they stack in. Fields
+          with no value for a given host are skipped automatically.
+        </p>
+
+        <div className="d-flex flex-column gap-1 mb-3">
+          {fields.map((f, i) => (
+            <div
+              key={f.field}
+              className="d-flex align-items-center gap-2 border rounded px-2 py-1"
+            >
+              <Form.Check
+                type="checkbox"
+                id={`node-label-${f.field}`}
+                checked={f.enabled}
+                onChange={() => toggleField(i)}
+              />
+              <i className={`bi ${NODE_LABEL_FIELD_META[f.field].icon} text-muted`} />
+              <span className="flex-grow-1">{NODE_LABEL_FIELD_META[f.field].label}</span>
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                className="py-0 px-1"
+                title="Move up"
+                disabled={i === 0}
+                onClick={() => moveField(i, -1)}
+              >
+                <i className="bi bi-arrow-up" />
+              </Button>
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                className="py-0 px-1"
+                title="Move down"
+                disabled={i === fields.length - 1}
+                onClick={() => moveField(i, 1)}
+              >
+                <i className="bi bi-arrow-down" />
+              </Button>
+            </div>
+          ))}
+        </div>
+
+        <Form.Group className="mb-3">
+          <Form.Label className="small fw-semibold mb-1">Custom text (optional)</Form.Label>
+          <Form.Control
+            type="text"
+            placeholder="e.g. Lab segment"
+            value={customText}
+            maxLength={40}
+            onChange={e => setCustomText(e.target.value)}
+          />
+          <Form.Text className="text-muted">
+            Shown as the last line under every node.
+          </Form.Text>
+        </Form.Group>
+
+        <div className="border rounded p-3 text-center" style={{ background: 'var(--sgds-light, #f8f9fa)' }}>
+          <div className="text-muted small mb-2">Preview</div>
+          <i className="bi bi-pc-display-horizontal" style={{ fontSize: 24 }} />
+          {previewLines.length > 0 ? (
+            previewLines.map((line, i) => (
+              <div key={i} style={{ fontSize: 11, fontWeight: 500, lineHeight: '13px' }}>
+                {line}
+              </div>
+            ))
+          ) : (
+            <div className="text-muted fst-italic" style={{ fontSize: 11 }}>
+              No fields selected — IP address will be shown as a fallback.
+            </div>
+          )}
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="outline-secondary" className="me-auto" onClick={handleReset}>
+          Reset to default
+        </Button>
+        <Button variant="secondary" onClick={onHide}>
+          Cancel
+        </Button>
+        <Button variant="primary" onClick={handleSave}>
+          Apply
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};

--- a/frontend/src/components/network/NodeLabelSettingsModal/NodeLabelSettingsModal.tsx
+++ b/frontend/src/components/network/NodeLabelSettingsModal/NodeLabelSettingsModal.tsx
@@ -135,7 +135,10 @@ export const NodeLabelSettingsModal = ({ show, onHide, container }: NodeLabelSet
           </Form.Text>
         </Form.Group>
 
-        <div className="border rounded p-3 text-center" style={{ background: 'var(--sgds-light, #f8f9fa)' }}>
+        <div
+          className="border rounded p-3 text-center"
+          style={{ background: 'var(--tp-bg-subtle)', color: 'var(--tp-text)' }}
+        >
           <div className="text-muted small mb-2">Preview</div>
           <i className="bi bi-pc-display-horizontal" style={{ fontSize: 24 }} />
           {previewLines.length > 0 ? (

--- a/frontend/src/components/network/NodeLabelSettingsModal/index.ts
+++ b/frontend/src/components/network/NodeLabelSettingsModal/index.ts
@@ -1,0 +1,1 @@
+export { NodeLabelSettingsModal } from './NodeLabelSettingsModal';

--- a/frontend/src/features/intelligence/services/intelligenceService.ts
+++ b/frontend/src/features/intelligence/services/intelligenceService.ts
@@ -59,6 +59,7 @@ export interface ClusterGraphResponse {
 export interface HostSummary {
   ip: string;
   hostname: string | null;
+  hostnameSource: string | null;
   totalBytes: number;
   packetCount: number;
   conversationCount: number;

--- a/frontend/src/features/network/services/networkService.ts
+++ b/frontend/src/features/network/services/networkService.ts
@@ -540,6 +540,13 @@ export function buildNetworkGraph(
         nodeMap[ip].data.manufacturer = c.manufacturer;
         nodeMap[ip].data.ttl = c.ttl;
         if (c.mac && !nodeMap[ip].data.mac) nodeMap[ip].data.mac = c.mac;
+        // The classifier's hostname identifies the host itself (DHCP/mDNS/NBNS/reverse
+        // DNS) and is more authoritative than the SNI-derived conversation hostname.
+        if (c.hostname) {
+          nodeMap[ip].data.hostname = c.hostname;
+          nodeMap[ip].data.hostnameSource = c.hostnameSource;
+          if (nodeMap[ip].label === ip) nodeMap[ip].label = c.hostname;
+        }
       }
     });
   }

--- a/frontend/src/features/network/types/index.ts
+++ b/frontend/src/features/network/types/index.ts
@@ -35,6 +35,8 @@ export interface NodeData {
   /** True when this node is identified by a MAC address (pure L2 device with no IP). */
   isL2?: boolean;
   hostname?: string;
+  /** How `hostname` was discovered: reverse_dns | mdns | nbns | dhcp | manual. */
+  hostnameSource?: string;
   packetsSent: number;
   packetsReceived: number;
   bytesSent: number;

--- a/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
+++ b/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
@@ -14,6 +14,7 @@ import { formatBytes } from '@/utils/formatters';
 import { NetworkGraph } from '@components/network/NetworkGraph';
 import { NetworkControls } from '@components/network/NetworkControls';
 import { NodeDetails } from '@components/network/NodeDetails';
+import { NodeLabelSettingsModal } from '@components/network/NodeLabelSettingsModal';
 import { LoadingSpinner } from '@components/common/LoadingSpinner';
 import { ErrorMessage } from '@components/common/ErrorMessage';
 import type { AnalysisOutletContext } from '@/pages/Analysis/AnalysisPage';
@@ -44,6 +45,7 @@ export const NetworkDiagramPage = () => {
   const [customInput, setCustomInput] = useState('');
   const [showSignificanceModal, setShowSignificanceModal] = useState(false);
   const [showFilterModal, setShowFilterModal] = useState(false);
+  const [showLabelModal, setShowLabelModal] = useState(false);
   const { nodes, edges, stats, loading, error, refetch, hiddenNodes, hiddenNodesList, crossEdges } =
     useNetworkData(fileId, data, nodeLimit);
 
@@ -93,13 +95,14 @@ export const NetworkDiagramPage = () => {
     if (!isFullscreen) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
+      if (showLabelModal) { setShowLabelModal(false); return; }
       if (showFilterModal) { setShowFilterModal(false); return; }
       if (selectedNode) { setSelectedNode(null); return; }
       setIsFullscreen(false);
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [isFullscreen, showFilterModal, selectedNode]);
+  }, [isFullscreen, showFilterModal, showLabelModal, selectedNode]);
 
   // ─── "Present" sets: only show options that exist in the data ───────────────
 
@@ -527,15 +530,26 @@ export const NetworkDiagramPage = () => {
           <Card className={isFullscreen ? 'nd-css-fullscreen' : ''} ref={graphCardRef}>
             <Card.Header className="d-flex justify-content-between align-items-center">
               <strong>Topology Diagram</strong>
-              <Button
-                variant="link"
-                size="sm"
-                className="p-0 text-muted"
-                onClick={toggleFullscreen}
-                title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-              >
-                <i className={`bi ${isFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'}`} />
-              </Button>
+              <div className="d-flex align-items-center gap-3">
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="p-0 text-muted"
+                  onClick={() => setShowLabelModal(true)}
+                  title="Customize node labels"
+                >
+                  <i className="bi bi-tags" />
+                </Button>
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="p-0 text-muted"
+                  onClick={toggleFullscreen}
+                  title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                >
+                  <i className={`bi ${isFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'}`} />
+                </Button>
+              </div>
             </Card.Header>
             <Card.Body className="p-0 network-diagram-graph-body">
               <NetworkGraph
@@ -563,6 +577,12 @@ export const NetworkDiagramPage = () => {
           onClose={() => setSelectedNode(null)}
         />
       )}
+
+      <NodeLabelSettingsModal
+        show={showLabelModal}
+        onHide={() => setShowLabelModal(false)}
+        container={graphCardRef.current ?? undefined}
+      />
 
       <Modal
         show={showFilterModal}

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -6,10 +6,12 @@ import { createAnalysisSlice } from './slices/analysisSlice';
 import type { AnalysisSlice } from './slices/analysisSlice';
 import { createThemeSlice } from './slices/themeSlice';
 import type { ThemeSlice, ThemeMode } from './slices/themeSlice';
+import { createNodeLabelSlice } from './slices/nodeLabelSlice';
+import type { NodeLabelSlice } from './slices/nodeLabelSlice';
 
 export type { ThemeMode };
 
-type StoreState = UploadSlice & AnalysisSlice & ThemeSlice;
+type StoreState = UploadSlice & AnalysisSlice & ThemeSlice & NodeLabelSlice;
 
 export const useStore = create<StoreState>()(
   devtools(
@@ -18,6 +20,7 @@ export const useStore = create<StoreState>()(
         ...createUploadSlice(...a),
         ...createAnalysisSlice(...a),
         ...createThemeSlice(...a),
+        ...createNodeLabelSlice(...a),
       }),
       {
         name: 'tracepcap-storage',
@@ -26,6 +29,7 @@ export const useStore = create<StoreState>()(
           recentFiles: state.recentFiles,
           analysisSummaries: state.analysisSummaries,
           themeMode: state.themeMode,
+          nodeLabelConfig: state.nodeLabelConfig,
         }),
       }
     ),

--- a/frontend/src/store/slices/nodeLabelSlice.ts
+++ b/frontend/src/store/slices/nodeLabelSlice.ts
@@ -1,0 +1,49 @@
+import type { StateCreator } from 'zustand';
+
+/** A field on a host that can be shown as a line of text below its graph node. */
+export type NodeLabelField = 'ip' | 'hostname' | 'mac' | 'deviceType' | 'manufacturer';
+
+/** Human-readable name for each selectable field (shown in the settings modal). */
+export const NODE_LABEL_FIELD_META: Record<NodeLabelField, { label: string; icon: string }> = {
+  ip: { label: 'IP address', icon: 'bi-hdd-network' },
+  hostname: { label: 'Hostname', icon: 'bi-tag' },
+  mac: { label: 'MAC address', icon: 'bi-ethernet' },
+  deviceType: { label: 'Device type', icon: 'bi-pc-display' },
+  manufacturer: { label: 'Manufacturer', icon: 'bi-building' },
+};
+
+/** One field together with whether it is currently shown. Order matters: it is the draw order. */
+export interface NodeLabelFieldOption {
+  field: NodeLabelField;
+  enabled: boolean;
+}
+
+export interface NodeLabelConfig {
+  /** Ordered list of every field with its enabled flag; enabled ones render top-to-bottom. */
+  fields: NodeLabelFieldOption[];
+  /** Optional static text drawn as the final line under every node. */
+  customText: string;
+}
+
+export const DEFAULT_NODE_LABEL_CONFIG: NodeLabelConfig = {
+  fields: [
+    { field: 'hostname', enabled: true },
+    { field: 'ip', enabled: true },
+    { field: 'mac', enabled: false },
+    { field: 'deviceType', enabled: false },
+    { field: 'manufacturer', enabled: false },
+  ],
+  customText: '',
+};
+
+export interface NodeLabelSlice {
+  nodeLabelConfig: NodeLabelConfig;
+  setNodeLabelConfig: (config: NodeLabelConfig) => void;
+  resetNodeLabelConfig: () => void;
+}
+
+export const createNodeLabelSlice: StateCreator<NodeLabelSlice> = set => ({
+  nodeLabelConfig: DEFAULT_NODE_LABEL_CONFIG,
+  setNodeLabelConfig: config => set({ nodeLabelConfig: config }),
+  resetNodeLabelConfig: () => set({ nodeLabelConfig: DEFAULT_NODE_LABEL_CONFIG }),
+});

--- a/frontend/src/types/common.types.ts
+++ b/frontend/src/types/common.types.ts
@@ -414,10 +414,17 @@ export interface HostClassification {
   ip: string;
   mac?: string;
   manufacturer?: string;
+  /** Passively-discovered hostname for the host (DHCP/mDNS/NBNS/reverse DNS). */
+  hostname?: string;
+  /** How `hostname` was discovered: reverse_dns | mdns | nbns | dhcp | manual. */
+  hostnameSource?: HostnameSource;
   ttl?: number;
   deviceType: DeviceType;
   confidence: number;
 }
+
+/** How a host's name was discovered from passive traffic. */
+export type HostnameSource = 'reverse_dns' | 'mdns' | 'nbns' | 'dhcp' | 'manual';
 
 // Filter Generator Types
 export interface FilterGenerationRequest {


### PR DESCRIPTION
Closes #368.

## Summary

Discovers each host's **own** name from passive traffic and surfaces it across the intelligence views. Previously the only "hostname" was the nDPI Hostname/SNI — which names the *server* a client connected to (e.g. `zoom.us`), not the client itself — and `HostClassificationEntity` had no hostname field at all.

Hostnames are now derived from four sources, with the most authoritative for client identity winning per IP (`dhcp > mdns > nbns > reverse_dns`):

- **DHCP option 12** — the name a client advertises in its DHCP request
- **mDNS** — `*.local` names from multicast DNS A/AAAA responses
- **NBNS** — NetBIOS machine names (workgroup/browser group names filtered out)
- **Reverse DNS** — PTR responses (IPv4 `in-addr.arpa`)

## Backend
- `V19__host_hostname.sql` — adds `hostname` + `hostname_source` to `host_classifications`
- `HostnameResolverService` (new) — single read-only tshark pass; filters mDNS service-discovery records (`_x._tcp.local`) and NBNS group suffixes (`<1b>`–`<1e>`); never throws (degrades to no hostnames)
- Wired into `DeviceClassifierService` + `AnalysisService`
- Exposed via `HostClassificationResponse` and `HostSummaryDto`; top-hosts now prefers the host's own name over SNI

## Frontend
- `HostnameSourceBadge` (new) — coloured DHCP/mDNS/NBNS/rDNS chip
- Graph nodes label with the discovered hostname (fallback to IP); `NodeDetails` shows the source badge
- `TopHostsTable` shows hostname primary, IP secondary, with badge

## Verification
- `tsc --noEmit` clean; `docker compose build` (backend + nginx) succeeds; V19 applied; backend healthy
- Uploaded a real capture → host-classifications and top-hosts APIs both return `192.168.0.1 → TL-SG116E [dhcp]` and `192.168.1.75 → Gabrieles-iPad.local [mdns]`; noise filters confirmed (NBNS `WORKGROUP<1d>` and mDNS `_spotify-connect._tcp.local` correctly excluded)
- Playwright: network-diagram renders with 0 console errors; nodes display `TL-SG116E` and `Gabrieles-iPad.local` as labels instead of raw IPs

## Notes
- IPv6 `ip6.arpa` reverse lookups are skipped (IPv4 only)
- `manual` source enum is reserved for a future manual-rename UI (not in scope)
- `TopHostsTable` is currently not mounted in any page (pre-existing); its changes are covered by the API + type-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added passive hostname discovery for PCAP uploads and now store/distribute each discovered hostname with a discovery source (reverse DNS, DHCP, mDNS, NBNS, or manual).
  * Added hostname source badges across intelligence and network views (node details, top hosts, and the IP/Hostname table).
  * Introduced customizable, multi-line node labels via a “Customize node labels” modal, persisted in your settings.
* **Database / Data Updates**
  * Added nullable `hostname` and `hostnameSource` fields to host classification records and exposed them through the related UI models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Added: customizable node labels

Follow-up that builds on the hostname work — a **Customize node labels** modal (tag icon on the Topology Diagram card) lets the analyst choose what text renders beneath each node:

- Toggle and reorder **IP address, hostname, MAC address, device type, manufacturer**, plus an optional static **custom text** line
- Live preview in the modal; each enabled field becomes one stacked line under the node (empty fields skipped; a node is never left unlabelled)
- Config is persisted (zustand `nodeLabelSlice`) and read directly by `NetworkGraph`, so it also applies to the Compare view; changing it redraws without a relayout

Verified with Playwright: enabling MAC + custom text restacks every node label live with 0 console errors.