### PR TITLE
feat(monitor): demo UX improvements for subnets, roles, events, dates

### DIFF
--- a/backend/src/main/java/com/tracepcap/insights/controller/NetworkExternalEventController.java
+++ b/backend/src/main/java/com/tracepcap/insights/controller/NetworkExternalEventController.java
@@ -39,7 +39,7 @@ public class NetworkExternalEventController {
 
   @PutMapping("/{eventId}")
   @Operation(summary = "Update an external event")
-  public ResponseEntity<NetworkExternalEventDto> update(
+  public ResponseEntity<NetworkExternalEventDto> updateExternalEvent(
       @PathVariable UUID networkId,
       @PathVariable UUID eventId,
       @Valid @RequestBody CreateExternalEventRequest req) {

--- a/backend/src/main/java/com/tracepcap/insights/controller/NetworkExternalEventController.java
+++ b/backend/src/main/java/com/tracepcap/insights/controller/NetworkExternalEventController.java
@@ -5,6 +5,7 @@ import com.tracepcap.insights.dto.NetworkExternalEventDto;
 import com.tracepcap.insights.service.NetworkExternalEventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -32,13 +33,7 @@ public class NetworkExternalEventController {
   @Operation(summary = "Create an external event")
   public ResponseEntity<NetworkExternalEventDto> create(
       @PathVariable UUID networkId,
-      @RequestBody CreateExternalEventRequest req) {
-    if (req.getTitle() == null || req.getTitle().isBlank()) {
-      return ResponseEntity.badRequest().build();
-    }
-    if (req.getEventTime() == null) {
-      return ResponseEntity.badRequest().build();
-    }
+      @Valid @RequestBody CreateExternalEventRequest req) {
     return ResponseEntity.status(HttpStatus.CREATED).body(service.createEvent(networkId, req));
   }
 
@@ -47,13 +42,7 @@ public class NetworkExternalEventController {
   public ResponseEntity<NetworkExternalEventDto> update(
       @PathVariable UUID networkId,
       @PathVariable UUID eventId,
-      @RequestBody CreateExternalEventRequest req) {
-    if (req.getTitle() == null || req.getTitle().isBlank()) {
-      return ResponseEntity.badRequest().build();
-    }
-    if (req.getEventTime() == null) {
-      return ResponseEntity.badRequest().build();
-    }
+      @Valid @RequestBody CreateExternalEventRequest req) {
     return ResponseEntity.ok(service.updateEvent(networkId, eventId, req));
   }
 

--- a/backend/src/main/java/com/tracepcap/insights/controller/NetworkExternalEventController.java
+++ b/backend/src/main/java/com/tracepcap/insights/controller/NetworkExternalEventController.java
@@ -42,6 +42,21 @@ public class NetworkExternalEventController {
     return ResponseEntity.status(HttpStatus.CREATED).body(service.createEvent(networkId, req));
   }
 
+  @PutMapping("/{eventId}")
+  @Operation(summary = "Update an external event")
+  public ResponseEntity<NetworkExternalEventDto> update(
+      @PathVariable UUID networkId,
+      @PathVariable UUID eventId,
+      @RequestBody CreateExternalEventRequest req) {
+    if (req.getTitle() == null || req.getTitle().isBlank()) {
+      return ResponseEntity.badRequest().build();
+    }
+    if (req.getEventTime() == null) {
+      return ResponseEntity.badRequest().build();
+    }
+    return ResponseEntity.ok(service.updateEvent(networkId, eventId, req));
+  }
+
   @DeleteMapping("/{eventId}")
   @Operation(summary = "Delete an external event")
   public ResponseEntity<Void> delete(

--- a/backend/src/main/java/com/tracepcap/insights/dto/CreateExternalEventRequest.java
+++ b/backend/src/main/java/com/tracepcap/insights/dto/CreateExternalEventRequest.java
@@ -1,11 +1,13 @@
 package com.tracepcap.insights.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.Data;
 
 @Data
 public class CreateExternalEventRequest {
-  private LocalDateTime eventTime;
-  private String title;
+  @NotNull private LocalDateTime eventTime;
+  @NotBlank private String title;
   private String description;
 }

--- a/backend/src/main/java/com/tracepcap/insights/service/NetworkExternalEventService.java
+++ b/backend/src/main/java/com/tracepcap/insights/service/NetworkExternalEventService.java
@@ -41,6 +41,20 @@ public class NetworkExternalEventService {
   }
 
   @Transactional
+  public NetworkExternalEventDto updateEvent(
+      UUID networkId, UUID eventId, CreateExternalEventRequest req) {
+    NetworkExternalEventEntity event = eventRepository.findById(eventId)
+        .orElseThrow(() -> new ResourceNotFoundException("Event not found: " + eventId));
+    if (!event.getNetwork().getId().equals(networkId)) {
+      throw new ResourceNotFoundException("Event not found in network: " + eventId);
+    }
+    event.setEventTime(req.getEventTime());
+    event.setTitle(req.getTitle());
+    event.setDescription(req.getDescription());
+    return toDto(eventRepository.save(event));
+  }
+
+  @Transactional
   public void deleteEvent(UUID networkId, UUID eventId) {
     NetworkExternalEventEntity event = eventRepository.findById(eventId)
         .orElseThrow(() -> new ResourceNotFoundException("Event not found: " + eventId));

--- a/docs/features/network-monitor.rst
+++ b/docs/features/network-monitor.rst
@@ -399,9 +399,15 @@ use the **Role** section at the top of the Details tab:
 - **Suggest with AI** — the LLM analyses the device's traffic signals
   (manufacturer, device type, observed applications, protocols) and suggests a
   label. The suggestion is shown with an "AI suggested" badge.
-- **Accept** — confirms the AI suggestion; the label is saved as
-  human-confirmed.
+- **Accept** — keeps the AI suggestion; the label is saved as a
+  **Manual label** (an analyst-assigned label).
 - **Discard** — removes the unconfirmed suggestion.
+
+A label saved by an analyst (typed directly or by accepting a suggestion) carries
+a **Manual label** badge. This records *what the host is* — its identity. It is
+not a guarantee about future behaviour: the Monitor continues to detect and flag
+deviating activity from a labelled host. Keep time-bounded behavioural
+observations in **Entity Notes** rather than in the label itself.
 
 Role labels are global (not per-network) — assigning a role to an IP or device
 once makes it available wherever that entity appears, including in AI-generated

--- a/docs/sample-files.rst
+++ b/docs/sample-files.rst
@@ -284,47 +284,96 @@ IPs by subnet.
 
 **Step 5 — Annotate key devices**
 
-Click IP badges in the drift panels to open the Entity Detail modal. Assign
-role labels to the named devices:
+Click IP badges in the drift panels to open the Entity Detail modal. There are
+two distinct fields — keep them separate:
+
+- **Role label** (Details tab → *Role*) describes *what a host is* — its stable
+  identity or function (e.g. "File Server (SMB)", "Alice — Staff Workstation").
+  Saving a role label marks it as a **Manual label**. A manual label records the
+  analyst's identity assignment; it is **not** a clean bill of health. Future
+  deviating behaviour from that host is still detected and flagged, so do **not**
+  bake time-bounded behaviour (violations, "FTP exfil weeks 4–6") into the label.
+- **Notes** (Notes tab) is where behavioural observations belong — what the host
+  *did*, when, and with what evidence. Notes are also fed to the LLM during
+  insight generation.
+
+Assign clean role labels to the named devices:
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 18 32 50
 
    * - IP
-     - Suggested role label
+     - Role label
+     - Notes (behavioural observations)
    * - ``10.0.2.10``
      - File Server (SMB)
+     - —
    * - ``10.0.2.20``
      - Mail Server (SMTP/IMAP)
+     - —
    * - ``10.0.2.30``
      - Internal Web Server
+     - —
    * - ``10.0.3.5``
      - Floor Printer A (IPP)
+     - —
    * - ``10.0.3.6``
      - Floor Printer B (IPP)
+     - —
    * - ``10.0.1.10``
-     - Alice — Staff Workstation (compliant)
+     - Alice — Staff Workstation
+     - Compliant throughout; useful as a "normal" baseline for comparison.
    * - ``10.0.1.11``
-     - Bob — Staff Workstation (FTP exfil weeks 4–6)
+     - Bob — Staff Workstation
+     - FTP exfiltration to ``192.0.2.99`` (``STOR report_q4.pdf``), weeks 4–6.
    * - ``10.0.1.12``
-     - Carol — Staff Workstation (Telnet weeks 3–6)
+     - Carol — Staff Workstation
+     - Joined week 3; Telnet to file server with cleartext credentials, weeks 3–6.
    * - ``10.0.4.20``
-     - Bob's Personal Laptop (VPN bypass + BitTorrent)
+     - Bob's Personal Laptop
+     - BYOD on corporate WiFi; WireGuard VPN bypass + BitTorrent, weeks 2–6.
    * - ``10.0.4.50``
-     - Unknown Device — Raspberry Pi OUI (shadow device)
+     - *(leave unlabelled — see below)*
+     - Optional, **after** running Suggest with AI: unknown device, RPi OUI
+       ``b8:27:eb``, no DNS hostname, ARP-spoofs ``10.0.1.11``, SMB + Telnet to
+       file server, weeks 5–6.
 
-Use **Suggest with AI** on ``10.0.4.50`` to see how the LLM characterises the
-device from its traffic behaviour alone (unusual OUI, ARP spoofing, SMB + Telnet
-to internal servers, no hostname).
+Leave ``10.0.4.50`` **without a role label** for now. Then use **Suggest with
+AI** on it to see how the LLM characterises the device from its traffic
+behaviour alone, with no human hint to anchor on (unusual OUI, ARP spoofing,
+SMB + Telnet to internal servers, no hostname).
+
+.. note::
+   **Expected Suggest with AI result for** ``10.0.4.50``. The model should
+   refuse to treat it as a sanctioned asset and instead flag it as an
+   unidentified / rogue device — e.g. *"Unidentified host with a Raspberry Pi
+   (``b8:27:eb``) OUI and no DNS hostname, exhibiting ARP spoofing and lateral
+   SMB/Telnet access to the internal file server — likely an unauthorised or
+   rogue device warranting investigation."* Exact wording varies by model, but a
+   good answer picks up the unusual OUI, the missing hostname, the ARP anomaly,
+   and the internal-server access. This is the payoff of leaving it unlabelled:
+   the suggestion is the AI's blind characterisation, not an echo of your label.
 
 **Step 6 — Add external events**
 
-In the **External Events** panel, log the audit milestone that explains the
-behavioural shift:
+In the **External Events** panel, click **Add Event** and log the audit
+milestone that explains the behavioural shift. Each event has three fields:
 
-- Date: start of week 7 — *"Audit notice issued to staff — policy violations
-  flagged for remediation"*
+- **Date & Time** *(required)* — when the real-world event actually happened, not
+  when you are logging it. Set this to the start of the **week 7** capture window
+  (the date of ``week7_violations_drop_gateway_back.pcap``) so the LLM can line
+  the event up with the violation drop-off. The field pre-fills with the server's
+  current time — change it to the event's real date.
+- **Title** *(required)* — a short, scannable summary, e.g.
+  *"Audit notice issued to staff — policy violations flagged for remediation"*.
+- **Description** *(optional)* — longer context, e.g. *"IT/Security circulated a
+  memo to all staff after preliminary audit findings; staff were told to cease
+  unsanctioned services (VPN, BitTorrent, FTP, Telnet) pending remediation."*
+
+To fix a mistake later — for example if you set the wrong date — click the
+**pencil** icon on the event row to edit any field, or the **trash** icon to
+remove it.
 
 **Step 7 — Generate insights**
 

--- a/frontend/src/components/analysis/AnalysisSummary/AnalysisSummary.tsx
+++ b/frontend/src/components/analysis/AnalysisSummary/AnalysisSummary.tsx
@@ -127,7 +127,7 @@ export const AnalysisSummary = ({ summary, extractedFilesCount }: AnalysisSummar
           </div>
           <div className="card-content">
             <div className="card-label">Uploaded</div>
-            <div className="card-value">{new Date(summary.uploadTime).toLocaleDateString()}</div>
+            <div className="card-value">{new Date(summary.uploadTime).toLocaleDateString('en-GB')}</div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/common/EntityDetailModal/EntityDetailModal.tsx
+++ b/frontend/src/components/common/EntityDetailModal/EntityDetailModal.tsx
@@ -346,7 +346,7 @@ export function EntityDetailModal({
   function formatSnapTime(snap: NetworkSnapshot): string {
     if (!snap.startTime) return snap.fileName;
     const ms = parseDateTime(snap.startTime as unknown as string | number[]);
-    return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+    return new Date(ms).toLocaleDateString('en-GB', { month: 'short', day: 'numeric', year: 'numeric' });
   }
 
   function stringHue(s: string): number {
@@ -510,8 +510,8 @@ export function EntityDetailModal({
                             </span>
                           )}
                           {role.confirmedByHuman && (
-                            <span className="badge bg-success ms-2" style={{ fontSize: '0.65rem' }}>
-                              <i className="bi bi-check-circle me-1" />Confirmed
+                            <span className="badge bg-secondary ms-2" style={{ fontSize: '0.65rem' }} title="Manually labelled by an analyst. Future deviating behaviour can still be flagged.">
+                              <i className="bi bi-tag me-1" />Manual label
                             </span>
                           )}
                         </div>
@@ -834,7 +834,7 @@ export function EntityDetailModal({
                               >
                                 <td className="small">{entry.fileName}</td>
                                 <td className="small text-muted">
-                                  {entry.startTime ? new Date(entry.startTime).toLocaleString() : '—'}
+                                  {entry.startTime ? new Date(entry.startTime).toLocaleString('en-GB') : '—'}
                                 </td>
                                 <td className="text-end small text-muted">
                                   {entry.packetCount != null ? formatNumber(entry.packetCount) : '—'}
@@ -869,7 +869,7 @@ export function EntityDetailModal({
                 />
                 {savedNote && (
                   <p className="text-muted" style={{ fontSize: '0.7rem' }}>
-                    Last updated: {new Date(savedNote.updatedAt).toLocaleString()}
+                    Last updated: {new Date(savedNote.updatedAt).toLocaleString('en-GB')}
                   </p>
                 )}
                 <div className="d-flex gap-2">

--- a/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
+++ b/frontend/src/components/monitor/AddSnapshotModal/AddSnapshotModal.tsx
@@ -49,6 +49,7 @@ export const AddSnapshotModal = ({
   const [subnetOverridesActive, setSubnetOverridesActive] = useState(false);
   const [loadingSubnets, setLoadingSubnets] = useState(false);
   const [newCidr, setNewCidr] = useState('');
+  const [newLabel, setNewLabel] = useState('');
 
   useEffect(() => {
     if (!show) return;
@@ -61,6 +62,7 @@ export const AddSnapshotModal = ({
     setSubnetOverrides([]);
     setSubnetOverridesActive(false);
     setNewCidr('');
+    setNewLabel('');
   }, [show]);
 
   const handleToggleSubnets = async () => {
@@ -103,8 +105,20 @@ export const AddSnapshotModal = ({
     const normalized = cidr.toLowerCase();
     if (subnetOverrides.some(o => o.cidr.trim().toLowerCase() === normalized)) return;
     setSubnetOverridesActive(true);
-    setSubnetOverrides(prev => [...prev, { cidr, label: null, description: null, inherited: false }]);
+    setSubnetOverrides(prev => [...prev, { cidr, label: newLabel.trim() || null, description: null, inherited: false }]);
     setNewCidr('');
+    setNewLabel('');
+  };
+
+  // Warn before discarding unsaved work (selected files or edited subnet overrides).
+  const hasUnsavedChanges = uploadFiles.length > 0 || subnetOverridesActive || newCidr.trim().length > 0 || newLabel.trim().length > 0;
+
+  const handleClose = () => {
+    if (isBusy) return;
+    if (hasUnsavedChanges && !window.confirm('Discard unsaved changes? Your selected file and subnet overrides will be lost.')) {
+      return;
+    }
+    onHide();
   };
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -180,7 +194,7 @@ export const AddSnapshotModal = ({
   };
 
   return (
-    <Modal show={show} onHide={isBusy ? undefined : onHide} size="lg">
+    <Modal show={show} onHide={isBusy ? undefined : handleClose} size="lg">
       <Modal.Header closeButton={!isBusy}>
         <Modal.Title>Add PCAP Snapshot</Modal.Title>
       </Modal.Header>
@@ -296,7 +310,7 @@ export const AddSnapshotModal = ({
                                       onClick={() => removeOverride(i)}
                                       title="Remove"
                                     >
-                                      <i className="bi bi-x" style={{ fontSize: '0.75rem' }} />
+                                      <i className="bi bi-trash" style={{ fontSize: '0.7rem' }} />
                                     </button>
                                   </td>
                                 </tr>
@@ -310,12 +324,20 @@ export const AddSnapshotModal = ({
                         </p>
                       )}
 
-                      <div className="d-flex gap-2 align-items-center">
+                      <div className="d-flex gap-2 align-items-center flex-wrap">
                         <input
                           className="form-control form-control-sm font-monospace"
                           placeholder="e.g. 192.168.1.0/24"
                           value={newCidr}
                           onChange={e => setNewCidr(e.target.value)}
+                          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addOverride(); } }}
+                          style={{ maxWidth: 200, fontSize: '0.8rem' }}
+                        />
+                        <input
+                          className="form-control form-control-sm"
+                          placeholder="Label (optional)"
+                          value={newLabel}
+                          onChange={e => setNewLabel(e.target.value)}
                           onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addOverride(); } }}
                           style={{ maxWidth: 200, fontSize: '0.8rem' }}
                         />

--- a/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
+++ b/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
@@ -60,7 +60,7 @@ function describeEvent(event: ChangeEvent): string {
 export const ChangeEventBadge = ({ event, snapshots, onPatch }: ChangeEventBadgeProps) => {
   const toSnap = snapshots.find(s => s.id === event.toSnapshotId);
   const detectedMs = parseDateTime(event.detectedAt as unknown as string | number[]);
-  const formattedTime = new Date(detectedMs).toLocaleString();
+  const formattedTime = new Date(detectedMs).toLocaleString('en-GB');
 
   const [showNotes, setShowNotes] = useState(false);
   const [draftNotes, setDraftNotes] = useState(event.notes ?? '');

--- a/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
+++ b/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
@@ -58,7 +58,7 @@ interface DeviceSnapshotEntry {
 function formatSnapTime(snap: NetworkSnapshot): string {
   if (!snap.startTime) return snap.fileName;
   const ms = parseDateTime(snap.startTime as unknown as string | number[]);
-  return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  return new Date(ms).toLocaleDateString('en-GB', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
@@ -298,7 +298,7 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
               />
               {savedNote && (
                 <p className="text-muted" style={{ fontSize: '0.7rem' }}>
-                  Last updated: {new Date(savedNote.updatedAt).toLocaleString()}
+                  Last updated: {new Date(savedNote.updatedAt).toLocaleString('en-GB')}
                 </p>
               )}
               <div className="d-flex gap-2">

--- a/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
+++ b/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
@@ -389,7 +389,7 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
                     <div className="fw-semibold">
                       {role.roleLabel || <span className="text-muted fst-italic">No label</span>}
                       {role.llmSuggested && !role.confirmedByHuman && <span className="badge bg-warning text-dark ms-2" style={{ fontSize: '0.65rem' }}><i className="bi bi-stars me-1" />AI suggested</span>}
-                      {role.confirmedByHuman && <span className="badge bg-success ms-2" style={{ fontSize: '0.65rem' }}><i className="bi bi-check-circle me-1" />Confirmed</span>}
+                      {role.confirmedByHuman && <span className="badge bg-secondary ms-2" style={{ fontSize: '0.65rem' }} title="Manually labelled by an analyst. Future deviating behaviour can still be flagged."><i className="bi bi-tag me-1" />Manual label</span>}
                     </div>
                     {role.roleDescription && <div className="text-muted mt-1">{role.roleDescription}</div>}
                     {role.llmSuggested && !role.confirmedByHuman && (

--- a/frontend/src/components/monitor/ExternalEventsPanel/ExternalEventsPanel.tsx
+++ b/frontend/src/components/monitor/ExternalEventsPanel/ExternalEventsPanel.tsx
@@ -48,7 +48,7 @@ export const ExternalEventsPanel = ({ events, onAdd, onUpdate, onDelete }: Exter
     // Pre-fill with server time so the datetime reflects the deployment timezone
     try {
       const res = await apiClient.get<{ now: string }>(API_ENDPOINTS.SYSTEM_TIME);
-      setEventTime(res.data.now);
+      setEventTime(toInputValue(res.data.now));
     } catch {
       setEventTime(toInputValue(new Date().toISOString()));
     }

--- a/frontend/src/components/monitor/ExternalEventsPanel/ExternalEventsPanel.tsx
+++ b/frontend/src/components/monitor/ExternalEventsPanel/ExternalEventsPanel.tsx
@@ -9,11 +9,21 @@ import type { NetworkExternalEvent } from '@/features/insights/types/insights.ty
 interface ExternalEventsPanelProps {
   events: NetworkExternalEvent[];
   onAdd: (eventTime: string, title: string, description?: string) => Promise<void>;
+  onUpdate: (eventId: string, eventTime: string, title: string, description?: string) => Promise<void>;
   onDelete: (eventId: string) => Promise<void>;
 }
 
-export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsPanelProps) => {
+/** Convert an ISO/Date-parseable string to a value for an <input type="datetime-local">. */
+const toInputValue = (value: string): string => {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
+export const ExternalEventsPanel = ({ events, onAdd, onUpdate, onDelete }: ExternalEventsPanelProps) => {
   const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [eventTime, setEventTime] = useState('');
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -21,35 +31,53 @@ export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsP
   const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
-  const openForm = async () => {
+  const resetForm = () => {
+    setEditingId(null);
+    setEventTime('');
+    setTitle('');
+    setDescription('');
+    setError(null);
+    setShowForm(false);
+  };
+
+  const openAddForm = async () => {
+    setEditingId(null);
+    setTitle('');
+    setDescription('');
+    setError(null);
     // Pre-fill with server time so the datetime reflects the deployment timezone
     try {
       const res = await apiClient.get<{ now: string }>(API_ENDPOINTS.SYSTEM_TIME);
       setEventTime(res.data.now);
     } catch {
-      // Fallback to local time formatted for datetime-local input
-      const now = new Date();
-      const pad = (n: number) => String(n).padStart(2, '0');
-      setEventTime(
-        `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`
-      );
+      setEventTime(toInputValue(new Date().toISOString()));
     }
     setShowForm(true);
   };
 
-  const handleAdd = async (e: React.FormEvent) => {
+  const openEditForm = (ev: NetworkExternalEvent) => {
+    setEditingId(ev.id);
+    setEventTime(toInputValue(ev.eventTime));
+    setTitle(ev.title);
+    setDescription(ev.description ?? '');
+    setError(null);
+    setShowForm(true);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !eventTime) return;
     setSaving(true);
     setError(null);
     try {
-      await onAdd(eventTime, title.trim(), description.trim() || undefined);
-      setEventTime('');
-      setTitle('');
-      setDescription('');
-      setShowForm(false);
+      if (editingId) {
+        await onUpdate(editingId, eventTime, title.trim(), description.trim() || undefined);
+      } else {
+        await onAdd(eventTime, title.trim(), description.trim() || undefined);
+      }
+      resetForm();
     } catch {
-      setError('Failed to add event. Please try again.');
+      setError(`Failed to ${editingId ? 'update' : 'add'} event. Please try again.`);
     } finally {
       setSaving(false);
     }
@@ -68,8 +96,8 @@ export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsP
     <div>
       {events.length === 0 && !showForm && (
         <p className="text-muted small mb-3">
-          No external events recorded. Add real-world events (maintenance windows, incidents, etc.)
-          to give the AI context when generating insights.
+          No external events recorded. Add real-world events (maintenance windows, incidents,
+          policy changes, etc.) to give the AI context when generating insights.
         </p>
       )}
 
@@ -87,7 +115,7 @@ export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsP
               {events.map(ev => (
                 <tr key={ev.id}>
                   <td className="text-nowrap small text-muted">
-                    {new Date(ev.eventTime).toLocaleString()}
+                    {new Date(ev.eventTime).toLocaleString('en-GB')}
                   </td>
                   <td>
                     <div className="small fw-semibold">{ev.title}</div>
@@ -96,17 +124,29 @@ export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsP
                     )}
                   </td>
                   <td>
-                    <Button
-                      size="sm"
-                      variant="outline-danger"
-                      onClick={() => handleDelete(ev.id)}
-                      disabled={deletingId === ev.id}
-                    >
-                      {deletingId === ev.id
-                        ? <Spinner animation="border" size="sm" />
-                        : <i className="bi bi-trash" />
-                      }
-                    </Button>
+                    <div className="d-flex gap-1 justify-content-end">
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        title="Edit event"
+                        onClick={() => openEditForm(ev)}
+                        disabled={deletingId === ev.id}
+                      >
+                        <i className="bi bi-pencil" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline-danger"
+                        title="Delete event"
+                        onClick={() => handleDelete(ev.id)}
+                        disabled={deletingId === ev.id}
+                      >
+                        {deletingId === ev.id
+                          ? <Spinner animation="border" size="sm" />
+                          : <i className="bi bi-trash" />
+                        }
+                      </Button>
+                    </div>
                   </td>
                 </tr>
               ))}
@@ -116,8 +156,13 @@ export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsP
       )}
 
       {showForm ? (
-        <form onSubmit={handleAdd} className="border rounded p-3 bg-light">
+        <form onSubmit={handleSubmit} className="border rounded p-3 bg-light">
           {error && <Alert variant="danger" className="py-2 small">{error}</Alert>}
+          <p className="text-muted small mb-3">
+            Record a real-world event that could explain a change in the network's behaviour
+            (e.g. an audit notice, a policy rollout, a maintenance window, or an incident).
+            The AI uses these to correlate observed traffic shifts with known activity.
+          </p>
           <div className="row g-2">
             <div className="col-sm-4">
               <Form.Label className="small fw-semibold">
@@ -130,6 +175,9 @@ export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsP
                 onChange={e => setEventTime(e.target.value)}
                 required
               />
+              <Form.Text className="text-muted" style={{ fontSize: '0.7rem' }}>
+                When the event actually happened (not when you logged it).
+              </Form.Text>
             </div>
             <div className="col-sm-8">
               <Form.Label className="small fw-semibold">
@@ -138,11 +186,14 @@ export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsP
               <Form.Control
                 size="sm"
                 type="text"
-                placeholder="e.g. Water festival begins, Planned maintenance window"
+                placeholder="e.g. Audit notice issued to staff — policy violations flagged for remediation"
                 value={title}
                 onChange={e => setTitle(e.target.value)}
                 required
               />
+              <Form.Text className="text-muted" style={{ fontSize: '0.7rem' }}>
+                A short, scannable summary of what happened.
+              </Form.Text>
             </div>
             <div className="col-12">
               <Form.Label className="small fw-semibold">Description (optional)</Form.Label>
@@ -150,7 +201,7 @@ export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsP
                 as="textarea"
                 size="sm"
                 rows={2}
-                placeholder="Additional context…"
+                placeholder="Additional context — who/what was affected, expected impact, follow-up actions…"
                 value={description}
                 onChange={e => setDescription(e.target.value)}
               />
@@ -159,15 +210,15 @@ export const ExternalEventsPanel = ({ events, onAdd, onDelete }: ExternalEventsP
           <div className="d-flex gap-2 mt-3">
             <Button size="sm" type="submit" variant="primary" disabled={saving || !title.trim() || !eventTime}>
               {saving ? <Spinner animation="border" size="sm" className="me-1" /> : null}
-              Add Event
+              {editingId ? 'Save Changes' : 'Add Event'}
             </Button>
-            <Button size="sm" variant="secondary" onClick={() => { setShowForm(false); setTitle(''); setDescription(''); }} disabled={saving}>
+            <Button size="sm" variant="secondary" onClick={resetForm} disabled={saving}>
               Cancel
             </Button>
           </div>
         </form>
       ) : (
-        <Button size="sm" variant="outline-primary" onClick={openForm}>
+        <Button size="sm" variant="outline-primary" onClick={openAddForm}>
           <i className="bi bi-plus-lg me-1" />Add Event
         </Button>
       )}

--- a/frontend/src/components/monitor/LastSeenModal/LastSeenModal.tsx
+++ b/frontend/src/components/monitor/LastSeenModal/LastSeenModal.tsx
@@ -21,7 +21,7 @@ export const LastSeenModal = ({ show, onHide, entity }: LastSeenModalProps) => {
     : 'protocol';
 
   const formattedDate = entity.lastSeenStartTime
-    ? new Date(parseDateTime(entity.lastSeenStartTime as unknown as string | number[])).toLocaleString()
+    ? new Date(parseDateTime(entity.lastSeenStartTime as unknown as string | number[])).toLocaleString('en-GB')
     : 'Unknown';
 
   return (

--- a/frontend/src/components/monitor/MonitorNetworkDiagram/MonitorNetworkDiagram.tsx
+++ b/frontend/src/components/monitor/MonitorNetworkDiagram/MonitorNetworkDiagram.tsx
@@ -98,7 +98,7 @@ function buildHighlightMap(events: ChangeEvent[], toSnapshotId: string): Map<str
 function formatSnapLabel(snap: NetworkSnapshot): string {
   if (snap.startTime) {
     const ms = parseDateTime(snap.startTime as unknown as string | number[]);
-    return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+    return new Date(ms).toLocaleDateString('en-GB', { month: 'short', day: 'numeric', year: 'numeric' });
   }
   return snap.fileName;
 }

--- a/frontend/src/components/monitor/NetworkAnnotationsPanel/NetworkAnnotationsPanel.tsx
+++ b/frontend/src/components/monitor/NetworkAnnotationsPanel/NetworkAnnotationsPanel.tsx
@@ -73,7 +73,7 @@ function AnnotationRow({
       <div style={{ flex: 1 }}>
         <div className="small" style={{ whiteSpace: 'pre-wrap' }}>{annotation.body}</div>
         <div className="text-muted mt-1" style={{ fontSize: '0.7rem' }}>
-          {new Date(annotation.createdAt).toLocaleString()}
+          {new Date(annotation.createdAt).toLocaleString('en-GB')}
           {annotation.updatedAt !== annotation.createdAt && ' (edited)'}
         </div>
       </div>

--- a/frontend/src/components/monitor/NetworkInsightsPanel/NetworkInsightsPanel.tsx
+++ b/frontend/src/components/monitor/NetworkInsightsPanel/NetworkInsightsPanel.tsx
@@ -266,7 +266,7 @@ export const NetworkInsightsPanel = ({
 
           {/* Footer */}
           <div className="text-muted border-top pt-2 mt-2 d-flex flex-wrap gap-2 align-items-center" style={{ fontSize: '0.7rem' }}>
-            <span>Generated {new Date(insight.generatedAt).toLocaleString()}</span>
+            <span>Generated {new Date(insight.generatedAt).toLocaleString('en-GB')}</span>
             {insight.modelUsed && <span>· {insight.modelUsed}</span>}
             {insight.audience && (
               <span className="badge bg-light text-muted border" style={{ fontSize: '0.65rem', fontWeight: 400 }}>

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -263,6 +263,21 @@ export const SnapshotDetailModal = ({
   const [savingSubnets, setSavingSubnets] = useState(false);
   const subnetOverridesActive = subnetCustomizeMode;
 
+  // Detect unsaved subnet edits by comparing the draft against the persisted overrides.
+  const serializeOverrides = (rows: { cidr: string; label: string | null; description: string | null }[]) =>
+    rows.map(o => `${o.cidr}|${o.label ?? ''}|${o.description ?? ''}`).join(',');
+  const subnetChanged =
+    serializeOverrides(subnetDraft) !== serializeOverrides(snapshot.subnetOverrides ?? []);
+  const hasUnsavedChanges = contextChanged || subnetChanged || subnetNewCidr.trim().length > 0;
+
+  const handleHide = () => {
+    if (hasUnsavedChanges &&
+        !window.confirm('Discard unsaved changes? Your edits to context, notes, or subnet overrides will be lost.')) {
+      return;
+    }
+    onHide();
+  };
+
   // Stable key: changes only when the server-persisted overrides actually change (IDs rotate on each save)
   const savedOverrideKey = (snapshot.subnetOverrides ?? []).map(o => o.id).join(',');
   // Keep draft in sync when parent updates the snapshot (e.g. after save), without resetting on every poll
@@ -367,7 +382,7 @@ export const SnapshotDetailModal = ({
 
   return (
     <>
-    <Modal show onHide={onHide} centered size="xl" scrollable>
+    <Modal show onHide={handleHide} centered size="xl" scrollable>
       <Modal.Header closeButton>
         <Modal.Title>
           <i className="bi bi-camera-reels me-2" />

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -258,6 +258,7 @@ export const SnapshotDetailModal = ({
   );
   const [subnetCustomizeMode, setSubnetCustomizeMode] = useState((snapshot.subnetOverrides ?? []).length > 0);
   const [subnetNewCidr, setSubnetNewCidr] = useState('');
+  const [subnetNewLabel, setSubnetNewLabel] = useState('');
   const [loadingGlobals, setLoadingGlobals] = useState(false);
   const [savingSubnets, setSavingSubnets] = useState(false);
   const subnetOverridesActive = subnetCustomizeMode;
@@ -300,8 +301,9 @@ export const SnapshotDetailModal = ({
   const addSubnetRow = () => {
     const cidr = subnetNewCidr.trim();
     if (!cidr) return;
-    setSubnetDraft(prev => [...prev, { cidr, label: null, description: null, inherited: false }]);
+    setSubnetDraft(prev => [...prev, { cidr, label: subnetNewLabel.trim() || null, description: null, inherited: false }]);
     setSubnetNewCidr('');
+    setSubnetNewLabel('');
   };
 
   const handleSaveSubnets = async () => {
@@ -654,7 +656,7 @@ export const SnapshotDetailModal = ({
                                 onClick={() => removeSubnetRow(i)}
                                 title="Remove"
                               >
-                                <i className="bi bi-x" style={{ fontSize: '0.75rem' }} />
+                                <i className="bi bi-trash" style={{ fontSize: '0.7rem' }} />
                               </button>
                             </td>
                           </tr>
@@ -668,12 +670,20 @@ export const SnapshotDetailModal = ({
                   </p>
                 )}
 
-                <div className="d-flex gap-2 align-items-center mb-3">
+                <div className="d-flex gap-2 align-items-center mb-3 flex-wrap">
                   <input
                     className="form-control form-control-sm font-monospace"
                     placeholder="e.g. 192.168.1.0/24"
                     value={subnetNewCidr}
                     onChange={e => setSubnetNewCidr(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addSubnetRow(); } }}
+                    style={{ maxWidth: 200, fontSize: '0.82rem' }}
+                  />
+                  <input
+                    className="form-control form-control-sm"
+                    placeholder="Label (optional)"
+                    value={subnetNewLabel}
+                    onChange={e => setSubnetNewLabel(e.target.value)}
                     onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addSubnetRow(); } }}
                     style={{ maxWidth: 200, fontSize: '0.82rem' }}
                   />

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -93,7 +93,7 @@ function buildHighlightMap(events: ChangeEvent[], toSnapshotId: string): Map<str
 function formatSnapLabel(snap: NetworkSnapshot): string {
   if (snap.startTime) {
     const ms = parseDateTime(snap.startTime as unknown as string | number[]);
-    return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+    return new Date(ms).toLocaleDateString('en-GB', { month: 'short', day: 'numeric', year: 'numeric' });
   }
   return snap.fileName;
 }

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -22,7 +22,7 @@ type SortDir = 'asc' | 'desc';
 function formatCaptureDate(start: string | null): string {
   if (!start) return '—';
   const ms = parseDateTime(start as unknown as string | number[]);
-  return new Date(ms).toLocaleString();
+  return new Date(ms).toLocaleString('en-GB');
 }
 
 function formatDuration(start: string | null, end: string | null): string {

--- a/frontend/src/components/monitor/SnapshotTrafficChart/SnapshotTrafficChart.tsx
+++ b/frontend/src/components/monitor/SnapshotTrafficChart/SnapshotTrafficChart.tsx
@@ -42,7 +42,7 @@ const GRANULARITY_OPTIONS: { label: string; seconds: number }[] = [
 function formatSnapLabel(snap: NetworkSnapshot): string {
   if (snap.startTime) {
     const ms = parseDateTime(snap.startTime as unknown as string | number[]);
-    return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return new Date(ms).toLocaleDateString('en-GB', { month: 'short', day: 'numeric' });
   }
   return snap.fileName;
 }

--- a/frontend/src/components/monitor/SubnetDiagramModal/SubnetDiagramModal.tsx
+++ b/frontend/src/components/monitor/SubnetDiagramModal/SubnetDiagramModal.tsx
@@ -141,7 +141,7 @@ export function SubnetDiagramModal({ subnet, snapshots, onHide, defaultSnapId }:
             </Form.Select>
             {selectedSnap?.startTime && (
               <small className="text-muted">
-                {new Date(selectedSnap.startTime as unknown as string).toLocaleDateString()}
+                {new Date(selectedSnap.startTime as unknown as string).toLocaleDateString('en-GB')}
               </small>
             )}
             <small className="text-muted ms-auto">

--- a/frontend/src/components/network/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/components/network/NodeDetails/NodeDetails.tsx
@@ -509,7 +509,7 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                             </td>
                             <td className="small">
                               {entry.startTime
-                                ? new Date(entry.startTime).toLocaleString()
+                                ? new Date(entry.startTime).toLocaleString('en-GB')
                                 : '—'}
                             </td>
                             <td className="text-end small">
@@ -555,7 +555,7 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                 />
                 {savedNote && (
                   <p className="text-muted" style={{ fontSize: '0.7rem' }}>
-                    Last updated: {new Date(savedNote.updatedAt).toLocaleString()}
+                    Last updated: {new Date(savedNote.updatedAt).toLocaleString('en-GB')}
                   </p>
                 )}
                 <div className="d-flex gap-2">

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -137,7 +137,7 @@ export const FileList = () => {
     if (diffMins < 60) return `${diffMins} min ago`;
     if (diffMins < 1440) return `${Math.floor(diffMins / 60)} hours ago`;
 
-    return date.toLocaleDateString();
+    return date.toLocaleDateString('en-GB');
   };
 
   const handleConfirmDelete = async () => {

--- a/frontend/src/features/insights/services/insightsService.ts
+++ b/frontend/src/features/insights/services/insightsService.ts
@@ -81,6 +81,21 @@ export const insightsService = {
       })
       .then(r => r.data),
 
+  updateExternalEvent: (
+    networkId: string,
+    eventId: string,
+    eventTime: string,
+    title: string,
+    description?: string,
+  ): Promise<NetworkExternalEvent> =>
+    apiClient
+      .put<NetworkExternalEvent>(MONITOR_ENDPOINTS.EXTERNAL_EVENT(networkId, eventId), {
+        eventTime,
+        title,
+        description,
+      })
+      .then(r => r.data),
+
   deleteExternalEvent: (networkId: string, eventId: string): Promise<void> =>
     apiClient
       .delete(MONITOR_ENDPOINTS.EXTERNAL_EVENT(networkId, eventId))

--- a/frontend/src/pages/FilterGenerator/FilterGeneratorPage.tsx
+++ b/frontend/src/pages/FilterGenerator/FilterGeneratorPage.tsx
@@ -179,7 +179,7 @@ export const FilterGeneratorPage = () => {
   };
 
   const formatTimestamp = (timestamp: number) => {
-    return new Date(timestamp).toLocaleString();
+    return new Date(timestamp).toLocaleString('en-GB');
   };
 
   const formatBytes = (bytes: number) => {

--- a/frontend/src/pages/Monitor/NetworkDetailPage.tsx
+++ b/frontend/src/pages/Monitor/NetworkDetailPage.tsx
@@ -332,7 +332,11 @@ export const NetworkDetailPage = () => {
   ) => {
     if (!networkId) return;
     const ev = await insightsService.updateExternalEvent(networkId, eventId, eventTime, title, description);
-    setExternalEvents(prev => prev.map(e => (e.id === eventId ? ev : e)));
+    setExternalEvents(prev =>
+      prev
+        .map(e => (e.id === eventId ? ev : e))
+        .sort((a, b) => new Date(b.eventTime).getTime() - new Date(a.eventTime).getTime()),
+    );
   };
 
   const handleDeleteExternalEvent = async (eventId: string) => {

--- a/frontend/src/pages/Monitor/NetworkDetailPage.tsx
+++ b/frontend/src/pages/Monitor/NetworkDetailPage.tsx
@@ -324,6 +324,17 @@ export const NetworkDetailPage = () => {
     setExternalEvents(prev => [ev, ...prev]);
   };
 
+  const handleUpdateExternalEvent = async (
+    eventId: string,
+    eventTime: string,
+    title: string,
+    description?: string,
+  ) => {
+    if (!networkId) return;
+    const ev = await insightsService.updateExternalEvent(networkId, eventId, eventTime, title, description);
+    setExternalEvents(prev => prev.map(e => (e.id === eventId ? ev : e)));
+  };
+
   const handleDeleteExternalEvent = async (eventId: string) => {
     if (!networkId) return;
     await insightsService.deleteExternalEvent(networkId, eventId);
@@ -825,6 +836,7 @@ export const NetworkDetailPage = () => {
           <ExternalEventsPanel
             events={externalEvents}
             onAdd={handleAddExternalEvent}
+            onUpdate={handleUpdateExternalEvent}
             onDelete={handleDeleteExternalEvent}
           />
         </Card.Body>

--- a/frontend/src/utils/formatters/index.ts
+++ b/frontend/src/utils/formatters/index.ts
@@ -42,11 +42,11 @@ export const formatDuration = (ms: number): string => {
 /**
  * Format timestamp to readable date/time
  * @param timestamp - Unix timestamp in milliseconds
- * @returns Formatted string (e.g., "Jan 31, 2026 14:30:45")
+ * @returns Formatted string (e.g., "31 Jan 2026, 14:30:45")
  */
 export const formatTimestamp = (timestamp: number): string => {
   const date = new Date(timestamp);
-  return date.toLocaleString('en-US', {
+  return date.toLocaleString('en-GB', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -931,6 +931,10 @@
             "type": "string"
           }
         },
+        "required": [
+          "eventTime",
+          "title"
+        ],
         "type": "object"
       },
       "CreateNetworkRequest": {
@@ -5951,6 +5955,55 @@
           }
         },
         "summary": "Delete an external event",
+        "tags": [
+          "Network External Events"
+        ]
+      },
+      "put": {
+        "operationId": "updateExternalEvent",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "networkId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "eventId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateExternalEventRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/NetworkExternalEventDto"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Update an external event",
         "tags": [
           "Network External Events"
         ]


### PR DESCRIPTION
Monitor-mode demo polish across the subnet modal, role labelling, external events, date formatting, and the demo walkthrough docs.

## Changes

### Subnet Overrides modal (Add PCAP Snapshot)
- **Label input on "Add CIDR"** — you can now set a label when adding a CIDR, not only after.
- Row remove control uses a **trash icon** instead of an `x`.
- **Unsaved-changes warning** when closing the modal (header ✕ / backdrop) with a selected file or edited overrides.

### Node roles
- The green **"Confirmed"** badge is now a neutral grey **"Manual label"** badge with a tooltip clarifying it records an analyst's identity assignment and does **not** suppress future drift flagging. UI-only relabel — the `confirmed_by_human` column is unchanged.

### External Events
- New backend `PUT /monitor/networks/{networkId}/external-events/{eventId}` endpoint.
- **Edit flow** (pencil → prefilled form incl. date → Save Changes), which fixes editing the event date.
- Inline guidance explaining what to enter for **Date & Time / Title / Description**.

### Dates
- Standardised date display to **day-first** (`en-GB`) across ~20 call sites and the shared `formatTimestamp`, keeping year/time formatting unchanged. Number/time-only formatting untouched.

### Docs (Office Audit demo walkthrough)
- Step 5 splits **role label (identity)** from **Notes (behavioural observations)**; shadow device `10.0.4.50` left **unlabelled** with the **expected Suggest-with-AI result** documented.
- Step 6 expanded with explicit field guidance and edit/delete tips.

## Verification
- `tsc --noEmit` clean; `docker compose up -d --build` succeeds, backend healthy.
- Playwright against the live demo network: label input + trash icon + unsaved-changes warning in the subnet modal; external-event pencil/trash + prefilled edit form; day-first dates (`19/02/2024`, `09/03/2026, 09:00:00`). New PUT route returns 404/400 correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edit existing external events directly from the interface
  * Add optional labels to subnet overrides
  * Unsaved changes warning when closing snapshot modal with pending edits

* **Improvements**
  * Standardized date/time formatting across all interfaces
  * Updated role label terminology from "Confirmed" to "Manual label"

* **Documentation**
  * Expanded device annotation guidance with behavioral notes section
  * Added detailed external event field specifications (Date & Time, Title, Description)
  * Clarified distinction between role labels and time-bound observations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->