### PR TITLE
refactor(analysis): extract signatures module via dependency-inversion port

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -141,9 +141,8 @@ public class AnalysisService {
 
         // Stage 4: Signatures, device classification, geo-IP
         t = System.currentTimeMillis();
-        signatureApplier.applySignatures(parseResult.getConversations());
         Map<String, String> deviceOverrides =
-            signatureApplier.getDeviceTypeOverrides(parseResult.getConversations());
+            signatureApplier.applySignatures(parseResult.getConversations());
         // resolve() degrades gracefully and never throws — it returns a (possibly empty) map.
         Map<String, HostnameResolverService.ResolvedHostname> hostnames =
             hostnameResolverService.resolve(tempFile);

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -15,6 +15,7 @@ import com.tracepcap.analysis.repository.ConversationRepository;
 import com.tracepcap.analysis.repository.HostClassificationRepository;
 import com.tracepcap.analysis.repository.IpGeoInfoRepository;
 import com.tracepcap.analysis.repository.PacketRepository;
+import com.tracepcap.analysis.spi.SignatureApplier;
 import com.tracepcap.analysis.service.hostlog.DnsQueryLogExtractor;
 import com.tracepcap.analysis.service.hostlog.HostServiceLogExtractor;
 import com.tracepcap.analysis.service.hostlog.HostServiceLogResult;
@@ -74,7 +75,7 @@ public class AnalysisService {
   private final NdpiService ndpiService;
   private final TsharkEnrichmentService tsharkEnrichmentService;
   private final SuricataService suricataService;
-  private final CustomSignatureService customSignatureService;
+  private final SignatureApplier signatureApplier;
   private final DeviceClassifierService deviceClassifierService;
   private final HostnameResolverService hostnameResolverService;
   private final List<HostServiceLogExtractor> hostServiceLogExtractors;
@@ -140,9 +141,9 @@ public class AnalysisService {
 
         // Stage 4: Signatures, device classification, geo-IP
         t = System.currentTimeMillis();
-        customSignatureService.applySignatures(parseResult.getConversations());
+        signatureApplier.applySignatures(parseResult.getConversations());
         Map<String, String> deviceOverrides =
-            customSignatureService.getDeviceTypeOverrides(parseResult.getConversations());
+            signatureApplier.getDeviceTypeOverrides(parseResult.getConversations());
         // resolve() degrades gracefully and never throws — it returns a (possibly empty) map.
         Map<String, HostnameResolverService.ResolvedHostname> hostnames =
             hostnameResolverService.resolve(tempFile);

--- a/backend/src/main/java/com/tracepcap/analysis/spi/SignatureApplier.java
+++ b/backend/src/main/java/com/tracepcap/analysis/spi/SignatureApplier.java
@@ -1,0 +1,26 @@
+package com.tracepcap.analysis.spi;
+
+import com.tracepcap.analysis.service.PcapParserService;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Port for applying custom detection signatures during the analysis pipeline.
+ *
+ * <p>Defined in {@code analysis} (the ingest core) and implemented by the {@code signatures} feature
+ * module, so the pipeline depends on this abstraction rather than on the concrete implementation.
+ */
+public interface SignatureApplier {
+
+  /**
+   * Evaluates all configured rules against each conversation and appends matched rule names to the
+   * conversation's custom-signatures list, in place.
+   */
+  void applySignatures(List<PcapParserService.ConversationInfo> conversations);
+
+  /**
+   * Returns a map of IP address → custom device type for IPs involved in conversations matched by a
+   * rule carrying a {@code device_type}. Call after {@link #applySignatures}.
+   */
+  Map<String, String> getDeviceTypeOverrides(List<PcapParserService.ConversationInfo> conversations);
+}

--- a/backend/src/main/java/com/tracepcap/analysis/spi/SignatureApplier.java
+++ b/backend/src/main/java/com/tracepcap/analysis/spi/SignatureApplier.java
@@ -13,14 +13,15 @@ import java.util.Map;
 public interface SignatureApplier {
 
   /**
-   * Evaluates all configured rules against each conversation and appends matched rule names to the
-   * conversation's custom-signatures list, in place.
+   * Evaluates all configured rules against each conversation in a single pass: appends matched rule
+   * names to each conversation's custom-signatures list (in place), and returns a map of IP address
+   * → custom device type for IPs matched by a rule carrying a {@code device_type}.
+   *
+   * <p>Combining both outputs into one call avoids re-reading and re-parsing the rules file, and
+   * removes the ordering dependency the previous two-method contract had (the device-type overrides
+   * are derived from the matches applied here).
+   *
+   * @return device-type overrides keyed by IP; empty if no rules carry a {@code device_type}
    */
-  void applySignatures(List<PcapParserService.ConversationInfo> conversations);
-
-  /**
-   * Returns a map of IP address → custom device type for IPs involved in conversations matched by a
-   * rule carrying a {@code device_type}. Call after {@link #applySignatures}.
-   */
-  Map<String, String> getDeviceTypeOverrides(List<PcapParserService.ConversationInfo> conversations);
+  Map<String, String> applySignatures(List<PcapParserService.ConversationInfo> conversations);
 }

--- a/backend/src/main/java/com/tracepcap/signatures/controller/SignaturesController.java
+++ b/backend/src/main/java/com/tracepcap/signatures/controller/SignaturesController.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.controller;
+package com.tracepcap.signatures.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/backend/src/main/java/com/tracepcap/signatures/service/CustomSignatureService.java
+++ b/backend/src/main/java/com/tracepcap/signatures/service/CustomSignatureService.java
@@ -1,5 +1,7 @@
-package com.tracepcap.analysis.service;
+package com.tracepcap.signatures.service;
 
+import com.tracepcap.analysis.service.PcapParserService;
+import com.tracepcap.analysis.spi.SignatureApplier;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -47,7 +49,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
  */
 @Slf4j
 @Service
-public class CustomSignatureService {
+public class CustomSignatureService implements SignatureApplier {
 
   @Value("${tracepcap.signatures.path:/app/config/signatures.yml}")
   private String signaturesPath;
@@ -56,6 +58,7 @@ public class CustomSignatureService {
    * Evaluates all loaded rules against each conversation and appends matched rule names to the
    * conversation's {@code flowRisks} list in-place.
    */
+  @Override
   public void applySignatures(List<PcapParserService.ConversationInfo> conversations) {
     List<Map<String, Object>> rules = loadRules();
     if (rules.isEmpty() || conversations.isEmpty()) return;
@@ -114,6 +117,7 @@ public class CustomSignatureService {
    *     ip: "192.168.1.50"
    * </pre>
    */
+  @Override
   public Map<String, String> getDeviceTypeOverrides(
       List<PcapParserService.ConversationInfo> conversations) {
     List<Map<String, Object>> rules = loadRules();

--- a/backend/src/main/java/com/tracepcap/signatures/service/CustomSignatureService.java
+++ b/backend/src/main/java/com/tracepcap/signatures/service/CustomSignatureService.java
@@ -55,13 +55,29 @@ public class CustomSignatureService implements SignatureApplier {
   private String signaturesPath;
 
   /**
-   * Evaluates all loaded rules against each conversation and appends matched rule names to the
-   * conversation's {@code flowRisks} list in-place.
+   * Evaluates all loaded rules against each conversation in a single pass: appends matched rule
+   * names to the conversation's {@code customSignatures} list in-place, and returns the device-type
+   * overrides derived from those matches.
+   *
+   * <p>The rules file is loaded once here and reused for both outputs, so callers no longer need a
+   * separate {@code getDeviceTypeOverrides} call (which re-read and re-parsed the file).
+   *
+   * <p>Device-type override example YAML:
+   *
+   * <pre>
+   * - name: my_cctv
+   *   device_type: "CCTV Camera"
+   *   match:
+   *     ip: "192.168.1.50"
+   * </pre>
+   *
+   * @return map of IP address → custom device type for IPs matched by a rule carrying a {@code
+   *     device_type}; empty if there are none
    */
   @Override
-  public void applySignatures(List<PcapParserService.ConversationInfo> conversations) {
+  public Map<String, String> applySignatures(List<PcapParserService.ConversationInfo> conversations) {
     List<Map<String, Object>> rules = loadRules();
-    if (rules.isEmpty() || conversations.isEmpty()) return;
+    if (rules.isEmpty() || conversations.isEmpty()) return Map.of();
 
     int matchCount = 0;
     for (PcapParserService.ConversationInfo conv : conversations) {
@@ -101,28 +117,17 @@ public class CustomSignatureService implements SignatureApplier {
           matchCount,
           conversations.size());
     }
+
+    return computeDeviceTypeOverrides(rules, conversations);
   }
 
   /**
-   * Returns a map of IP address → custom device type for any IPs that were involved in
-   * conversations matched by a rule containing a {@code device_type} field. Call this after {@link
-   * #applySignatures} so the conversations already carry their matched rule names.
-   *
-   * <p>Example YAML:
-   *
-   * <pre>
-   * - name: my_cctv
-   *   device_type: "CCTV Camera"
-   *   match:
-   *     ip: "192.168.1.50"
-   * </pre>
+   * Derives IP → custom device-type overrides from the already-loaded {@code rules} and the matches
+   * applied by {@link #applySignatures}. Only IPs from conversations matched by a rule carrying a
+   * {@code device_type} are included.
    */
-  @Override
-  public Map<String, String> getDeviceTypeOverrides(
-      List<PcapParserService.ConversationInfo> conversations) {
-    List<Map<String, Object>> rules = loadRules();
-    if (rules.isEmpty()) return Map.of();
-
+  private Map<String, String> computeDeviceTypeOverrides(
+      List<Map<String, Object>> rules, List<PcapParserService.ConversationInfo> conversations) {
     // Build rule-name → device_type map in one pass over rules
     Map<String, String> ruleDeviceType = new HashMap<>();
     for (Map<String, Object> rule : rules) {


### PR DESCRIPTION
**Slice 1 of #416** — decomposing the `analysis` god-package into feature modules using **proper dependency inversion** (ports), starting with the cleanest producer: signatures.

## What changed

- **New port** `com.tracepcap.analysis.spi.SignatureApplier`, owned by the ingest core.
- `CustomSignatureService` → `com.tracepcap.signatures.service`, now `implements SignatureApplier`.
- `SignaturesController` → `com.tracepcap.signatures.controller` (path `/signatures` **unchanged**).
- `AnalysisService` now depends on the `SignatureApplier` **port**, not the concrete class.

Dependency direction is now **`signatures` → `analysis`** (feature depends on core's published port/types); `analysis` no longer references the signatures implementation. This establishes the pattern the remaining slices in #416 will follow.

## Why this slice first

Signatures is the cleanest producer to extract: a self-contained YAML-backed controller, no JPA entity to move, and a small two-method producer surface — so it demonstrates the port inversion without entity/persistence complications.

## Verification

- ✅ `docker compose build backend` compiles; Spring context boots (port wired to the single impl).
- ✅ `GET /api/v1/signatures` and `/signatures/rules` return 200.
- ✅ **OpenAPI baseline unchanged** — paths and `operationId`s stable (method names kept unique per CONTRIBUTING.md).
- ✅ `mvn verify` (JUnit + Testcontainers) passes — exercises the ingest pipeline end-to-end.

Part of #416. No API/contract changes; no DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured internal signature analysis pipeline for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->