### PR TITLE
refactor(analysis): extract timeline into its own module

### DIFF
--- a/backend/src/main/java/com/tracepcap/story/service/StoryService.java
+++ b/backend/src/main/java/com/tracepcap/story/service/StoryService.java
@@ -2,11 +2,11 @@ package com.tracepcap.story.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tracepcap.analysis.dto.TimelineDataDto;
+import com.tracepcap.timeline.dto.TimelineDataDto;
 import com.tracepcap.analysis.entity.AnalysisResultEntity;
 import com.tracepcap.analysis.repository.AnalysisResultRepository;
 import com.tracepcap.analysis.repository.ConversationRepository;
-import com.tracepcap.analysis.service.TimelineService;
+import com.tracepcap.timeline.service.TimelineService;
 import com.tracepcap.common.exception.ContextLengthExceededException;
 import com.tracepcap.common.exception.LlmException;
 import com.tracepcap.common.exception.ResourceNotFoundException;

--- a/backend/src/main/java/com/tracepcap/timeline/controller/TimelineController.java
+++ b/backend/src/main/java/com/tracepcap/timeline/controller/TimelineController.java
@@ -1,7 +1,7 @@
-package com.tracepcap.analysis.controller;
+package com.tracepcap.timeline.controller;
 
-import com.tracepcap.analysis.dto.TimelineDataDto;
-import com.tracepcap.analysis.service.TimelineService;
+import com.tracepcap.timeline.dto.TimelineDataDto;
+import com.tracepcap.timeline.service.TimelineService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;

--- a/backend/src/main/java/com/tracepcap/timeline/dto/TimelineDataDto.java
+++ b/backend/src/main/java/com/tracepcap/timeline/dto/TimelineDataDto.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.dto;
+package com.tracepcap.timeline.dto;
 
 import java.time.LocalDateTime;
 import java.util.Map;

--- a/backend/src/main/java/com/tracepcap/timeline/service/TimelineService.java
+++ b/backend/src/main/java/com/tracepcap/timeline/service/TimelineService.java
@@ -1,6 +1,6 @@
-package com.tracepcap.analysis.service;
+package com.tracepcap.timeline.service;
 
-import com.tracepcap.analysis.dto.TimelineDataDto;
+import com.tracepcap.timeline.dto.TimelineDataDto;
 import com.tracepcap.analysis.entity.ConversationEntity;
 import com.tracepcap.analysis.repository.ConversationRepository;
 import com.tracepcap.common.exception.ResourceNotFoundException;


### PR DESCRIPTION
**Slice 2 of #416** — continues decomposing the `analysis` god-package.

Timeline is **pure read/aggregation** (computed on demand from conversations; not invoked by the ingest pipeline), so unlike signatures it needs **no port** — it's a clean move with `analysis` no longer referencing it.

## What changed

- `TimelineController` → `com.tracepcap.timeline.controller` (path `/timeline` **unchanged**)
- `TimelineService` → `com.tracepcap.timeline.service`
- `TimelineDataDto` → `com.tracepcap.timeline.dto`
- Updated the one external consumer: `StoryService`'s two timeline imports.

Dependency direction is `timeline → analysis` (timeline queries `ConversationRepository`); `analysis` has no dependency on `timeline`.

## Verification

- ✅ `docker compose build backend` compiles; Spring context boots.
- ✅ `GET /api/v1/timeline/{fileId}?interval=60` returns real aggregated data (HTTP 200).
- ✅ **OpenAPI baseline unchanged** (path + method names stable).
- ✅ `mvn verify` (JUnit + Testcontainers) passes — `PipelineIntegrationTest` exercises the `/timeline` endpoint.

Part of #416. No API/contract changes; no DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)