### PR TITLE
refactor(analysis): extract host classification into its own module via port

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -16,6 +16,7 @@ import com.tracepcap.analysis.repository.HostClassificationRepository;
 import com.tracepcap.analysis.repository.IpGeoInfoRepository;
 import com.tracepcap.analysis.repository.PacketRepository;
 import com.tracepcap.analysis.spi.FileExtractionStage;
+import com.tracepcap.analysis.spi.HostClassifier;
 import com.tracepcap.analysis.spi.SignatureApplier;
 import com.tracepcap.analysis.service.hostlog.DnsQueryLogExtractor;
 import com.tracepcap.analysis.service.hostlog.HostServiceLogExtractor;
@@ -77,7 +78,7 @@ public class AnalysisService {
   private final TsharkEnrichmentService tsharkEnrichmentService;
   private final SuricataService suricataService;
   private final SignatureApplier signatureApplier;
-  private final DeviceClassifierService deviceClassifierService;
+  private final HostClassifier hostClassifier;
   private final HostnameResolverService hostnameResolverService;
   private final List<HostServiceLogExtractor> hostServiceLogExtractors;
   private final GeoIpService geoIpService;
@@ -153,7 +154,7 @@ public class AnalysisService {
         // (e.g. a DNS responder → DNS_SERVER). Adding a role needs no change here.
         ServiceLogOutcome serviceLogs = runServiceLogExtractors(file, tempFile);
         List<HostClassificationEntity> hostClassifications =
-            deviceClassifierService.classify(
+            hostClassifier.classify(
                 file,
                 parseResult.getConversations(),
                 parseResult.getHostTtls(),

--- a/backend/src/main/java/com/tracepcap/analysis/spi/HostClassifier.java
+++ b/backend/src/main/java/com/tracepcap/analysis/spi/HostClassifier.java
@@ -1,0 +1,30 @@
+package com.tracepcap.analysis.spi;
+
+import com.tracepcap.analysis.entity.HostClassificationEntity;
+import com.tracepcap.analysis.service.HostnameResolverService;
+import com.tracepcap.analysis.service.PcapParserService;
+import com.tracepcap.file.entity.FileEntity;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Port for classifying hosts (device type / role) from observed traffic during the analysis
+ * pipeline.
+ *
+ * <p>Defined in {@code analysis} (the ingest core) and implemented by the {@code hostclassification}
+ * feature module, so the pipeline depends on this abstraction rather than on the concrete
+ * classification engine. Returns the core {@link HostClassificationEntity} records, which the
+ * pipeline post-processes (e.g. service-log suspicions) and persists.
+ */
+public interface HostClassifier {
+
+  List<HostClassificationEntity> classify(
+      FileEntity file,
+      List<PcapParserService.ConversationInfo> conversations,
+      Map<String, Integer> hostTtls,
+      Map<String, String> hostMacs,
+      Map<String, String> deviceOverrides,
+      Map<String, HostnameResolverService.ResolvedHostname> hostnames,
+      Map<String, Set<String>> serviceRolesByIp);
+}

--- a/backend/src/main/java/com/tracepcap/hostclassification/controller/HostClassificationsController.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/controller/HostClassificationsController.java
@@ -1,6 +1,6 @@
-package com.tracepcap.analysis.controller;
+package com.tracepcap.hostclassification.controller;
 
-import com.tracepcap.analysis.dto.HostClassificationResponse;
+import com.tracepcap.hostclassification.dto.HostClassificationResponse;
 import com.tracepcap.analysis.entity.HostClassificationEntity;
 import com.tracepcap.analysis.repository.HostClassificationRepository;
 import io.swagger.v3.oas.annotations.Operation;

--- a/backend/src/main/java/com/tracepcap/hostclassification/dto/HostClassificationResponse.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/dto/HostClassificationResponse.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.dto;
+package com.tracepcap.hostclassification.dto;
 
 import java.util.List;
 import lombok.Builder;

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/DeviceClassifierService.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/DeviceClassifierService.java
@@ -1,11 +1,14 @@
-package com.tracepcap.analysis.service;
+package com.tracepcap.hostclassification.service;
 
 import com.tracepcap.analysis.entity.HostClassificationEntity;
-import com.tracepcap.analysis.service.classifier.DeviceClassificationSignal;
-import com.tracepcap.analysis.service.classifier.DeviceTypes;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.HostProfile;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.analysis.service.HostnameResolverService;
+import com.tracepcap.analysis.service.PcapParserService;
+import com.tracepcap.analysis.spi.HostClassifier;
+import com.tracepcap.hostclassification.service.classifier.DeviceClassificationSignal;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.HostProfile;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import com.tracepcap.file.entity.FileEntity;
 import jakarta.annotation.PostConstruct;
 import java.io.BufferedReader;
@@ -38,7 +41,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class DeviceClassifierService {
+public class DeviceClassifierService implements HostClassifier {
 
   /** Score margin (winner − runner-up) that maps to 100% confidence; smaller margins scale down. */
   private static final int CONFIDENCE_MARGIN_FOR_FULL = 60;
@@ -142,6 +145,7 @@ public class DeviceClassifierService {
    *     (may be empty); feeds role-aware signals and is recorded on each host
    * @return one HostClassificationEntity per unique IP
    */
+  @Override
   public List<HostClassificationEntity> classify(
       FileEntity file,
       List<PcapParserService.ConversationInfo> conversations,

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/DeviceClassificationSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/DeviceClassificationSignal.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.service.classifier;
+package com.tracepcap.hostclassification.service.classifier;
 
 /**
  * A pluggable contributor to device classification. Each implementation inspects a {@link HostContext}

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/DeviceTypes.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/DeviceTypes.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.service.classifier;
+package com.tracepcap.hostclassification.service.classifier;
 
 /**
  * Canonical device-type identifiers a {@link DeviceClassificationSignal} can vote for. Plain string

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/HostContext.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/HostContext.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.service.classifier;
+package com.tracepcap.hostclassification.service.classifier;
 
 import java.util.Set;
 

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/HostProfile.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/HostProfile.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.service.classifier;
+package com.tracepcap.hostclassification.service.classifier;
 
 import java.util.LinkedHashSet;
 import java.util.Set;

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/ScoreBoard.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/ScoreBoard.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.service.classifier;
+package com.tracepcap.hostclassification.service.classifier;
 
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/ApiServerSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/ApiServerSignal.java
@@ -1,9 +1,9 @@
-package com.tracepcap.analysis.service.classifier.signals;
+package com.tracepcap.hostclassification.service.classifier.signals;
 
-import com.tracepcap.analysis.service.classifier.DeviceClassificationSignal;
-import com.tracepcap.analysis.service.classifier.DeviceTypes;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.hostclassification.service.classifier.DeviceClassificationSignal;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import com.tracepcap.analysis.service.hostlog.WebServerLogExtractor;
 import org.springframework.stereotype.Component;
 

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/AppProfileSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/AppProfileSignal.java
@@ -1,9 +1,9 @@
-package com.tracepcap.analysis.service.classifier.signals;
+package com.tracepcap.hostclassification.service.classifier.signals;
 
-import com.tracepcap.analysis.service.classifier.DeviceClassificationSignal;
-import com.tracepcap.analysis.service.classifier.DeviceTypes;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.hostclassification.service.classifier.DeviceClassificationSignal;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import com.tracepcap.config.DeviceClassificationProperties;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/DnsServerSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/DnsServerSignal.java
@@ -1,9 +1,9 @@
-package com.tracepcap.analysis.service.classifier.signals;
+package com.tracepcap.hostclassification.service.classifier.signals;
 
-import com.tracepcap.analysis.service.classifier.DeviceClassificationSignal;
-import com.tracepcap.analysis.service.classifier.DeviceTypes;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.hostclassification.service.classifier.DeviceClassificationSignal;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import com.tracepcap.analysis.service.hostlog.DnsQueryLogExtractor;
 import org.springframework.stereotype.Component;
 

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/OuiHintSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/OuiHintSignal.java
@@ -1,8 +1,8 @@
-package com.tracepcap.analysis.service.classifier.signals;
+package com.tracepcap.hostclassification.service.classifier.signals;
 
-import com.tracepcap.analysis.service.classifier.DeviceClassificationSignal;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.hostclassification.service.classifier.DeviceClassificationSignal;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import org.springframework.stereotype.Component;
 
 /**

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/TrafficPatternSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/TrafficPatternSignal.java
@@ -1,10 +1,10 @@
-package com.tracepcap.analysis.service.classifier.signals;
+package com.tracepcap.hostclassification.service.classifier.signals;
 
-import com.tracepcap.analysis.service.classifier.DeviceClassificationSignal;
-import com.tracepcap.analysis.service.classifier.DeviceTypes;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.HostProfile;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.hostclassification.service.classifier.DeviceClassificationSignal;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.HostProfile;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import org.springframework.stereotype.Component;
 
 /**

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/TtlSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/TtlSignal.java
@@ -1,9 +1,9 @@
-package com.tracepcap.analysis.service.classifier.signals;
+package com.tracepcap.hostclassification.service.classifier.signals;
 
-import com.tracepcap.analysis.service.classifier.DeviceClassificationSignal;
-import com.tracepcap.analysis.service.classifier.DeviceTypes;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.hostclassification.service.classifier.DeviceClassificationSignal;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import org.springframework.stereotype.Component;
 
 /**

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/WebServerSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/WebServerSignal.java
@@ -1,15 +1,15 @@
-package com.tracepcap.analysis.service.classifier.signals;
+package com.tracepcap.hostclassification.service.classifier.signals;
 
-import com.tracepcap.analysis.service.classifier.DeviceClassificationSignal;
-import com.tracepcap.analysis.service.classifier.DeviceTypes;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.hostclassification.service.classifier.DeviceClassificationSignal;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import com.tracepcap.analysis.service.hostlog.WebServerLogExtractor;
 import org.springframework.stereotype.Component;
 
 /**
  * Classifies a host as a {@code WEB_SERVER} when it was observed serving HTTP/TLS but not in an
- * API-like way (see {@link com.tracepcap.analysis.service.classifier.signals.ApiServerSignal}). Like
+ * API-like way (see {@link com.tracepcap.hostclassification.service.classifier.signals.ApiServerSignal}). Like
  * {@link DnsServerSignal}, this is authoritative observed evidence, so it carries a dominant weight
  * that outranks the heuristic signals.
  */

--- a/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/ScoreBoardTest.java
+++ b/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/ScoreBoardTest.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.service.classifier;
+package com.tracepcap.hostclassification.service.classifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/DnsServerSignalTest.java
+++ b/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/DnsServerSignalTest.java
@@ -1,11 +1,11 @@
-package com.tracepcap.analysis.service.classifier.signals;
+package com.tracepcap.hostclassification.service.classifier.signals;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.tracepcap.analysis.service.classifier.DeviceTypes;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.HostProfile;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.HostProfile;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 

--- a/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/WebApiServerSignalTest.java
+++ b/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/WebApiServerSignalTest.java
@@ -1,11 +1,11 @@
-package com.tracepcap.analysis.service.classifier.signals;
+package com.tracepcap.hostclassification.service.classifier.signals;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.tracepcap.analysis.service.classifier.DeviceTypes;
-import com.tracepcap.analysis.service.classifier.HostContext;
-import com.tracepcap.analysis.service.classifier.HostProfile;
-import com.tracepcap.analysis.service.classifier.ScoreBoard;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.HostProfile;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
**Slice 5 of #416** — continues decomposing the `analysis` god-package using the port pattern.

## What changed

- **New port** `com.tracepcap.analysis.spi.HostClassifier` (owned by the ingest core).
- Moved to `com.tracepcap.hostclassification.*`:
  - `DeviceClassifierService` → `service`, now `implements HostClassifier`
  - the entire `classifier/**` engine (5 core classes + 7 signal impls) → `service.classifier`
  - `HostClassificationsController` → `controller` (path `/files/{fileId}/host-classifications` **unchanged**)
  - `HostClassificationResponse` → `dto`
  - the 3 classifier unit tests → mirrored test package
- `AnalysisService` now calls the `HostClassifier` **port** instead of the concrete service.

## Kept in `analysis` core (deliberate)

`HostClassificationEntity` + `HostClassificationRepository` stay put: the producer **returns** the entities, the pipeline post-processes them (`applyServiceLogSuspicions`) and persists them, and `report` reads them. Keeping them in core avoids the port pointing back at the feature — and means **`ReportService`/`CompareReportService` need no changes**. (Contrast with `extraction`, whose producer saves its own entity via a `void` port.)

## Verification

- ✅ `docker compose build backend` compiles (incl. tests); Spring context boots (port auto-wired, no bean conflicts).
- ✅ `GET /api/v1/files/{fileId}/host-classifications` returns 200.
- ✅ **OpenAPI baseline unchanged**.
- ✅ `mvn verify` (JUnit + Testcontainers) passes — classifier unit tests + ingest classification exercised.

Part of #416. No API/contract changes; no DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)