### PR TITLE
refactor(analysis): extract host service logs (hostlog) into its own module

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -18,10 +18,10 @@ import com.tracepcap.analysis.repository.PacketRepository;
 import com.tracepcap.analysis.spi.FileExtractionStage;
 import com.tracepcap.analysis.spi.HostClassifier;
 import com.tracepcap.analysis.spi.SignatureApplier;
-import com.tracepcap.analysis.service.hostlog.DnsQueryLogExtractor;
-import com.tracepcap.analysis.service.hostlog.HostServiceLogExtractor;
-import com.tracepcap.analysis.service.hostlog.HostServiceLogResult;
-import com.tracepcap.analysis.service.hostlog.HostServiceSuspicion;
+import com.tracepcap.analysis.spi.ServiceLogRoles;
+import com.tracepcap.analysis.spi.HostServiceLogExtractor;
+import com.tracepcap.analysis.spi.HostServiceLogResult;
+import com.tracepcap.analysis.spi.HostServiceSuspicion;
 import com.tracepcap.common.dto.PagedResponse;
 import com.tracepcap.common.exception.ResourceNotFoundException;
 import com.tracepcap.file.entity.FileEntity;
@@ -1165,7 +1165,7 @@ public class AnalysisService {
     for (HostServiceSuspicion s : suspicions) {
       HostClassificationEntity host = byIp.get(s.ip());
       if (host == null) continue; // external server with no classification — skip silently
-      if (DnsQueryLogExtractor.ROLE.equals(s.role())) {
+      if (ServiceLogRoles.DNS.equals(s.role())) {
         host.setDnsSuspicious(true);
       }
       // Future roles: else if (HttpEndpointLogExtractor.ROLE.equals(s.role())) host.setWebSuspicious(true);

--- a/backend/src/main/java/com/tracepcap/analysis/spi/HostServiceLogExtractor.java
+++ b/backend/src/main/java/com/tracepcap/analysis/spi/HostServiceLogExtractor.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.service.hostlog;
+package com.tracepcap.analysis.spi;
 
 import com.tracepcap.file.entity.FileEntity;
 import java.io.File;
@@ -7,7 +7,7 @@ import java.io.File;
  * Extracts a per-host "service activity log" for hosts acting in a particular server role.
  *
  * <p>This is the reusable seam behind the Network Intelligence per-host service views. DNS is the
- * first implementation ({@link DnsQueryLogExtractor}, surfacing which domains a DNS server resolves
+ * first implementation ({@code DnsQueryLogExtractor}, surfacing which domains a DNS server resolves
  * and which fail); future roles — e.g. an HTTP/API endpoint log for web servers — implement this
  * same contract and are picked up automatically.
  *

--- a/backend/src/main/java/com/tracepcap/analysis/spi/HostServiceLogResult.java
+++ b/backend/src/main/java/com/tracepcap/analysis/spi/HostServiceLogResult.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.service.hostlog;
+package com.tracepcap.analysis.spi;
 
 import java.util.List;
 import java.util.Map;

--- a/backend/src/main/java/com/tracepcap/analysis/spi/HostServiceSuspicion.java
+++ b/backend/src/main/java/com/tracepcap/analysis/spi/HostServiceSuspicion.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.service.hostlog;
+package com.tracepcap.analysis.spi;
 
 /**
  * A server host flagged as suspicious by a {@link HostServiceLogExtractor}.

--- a/backend/src/main/java/com/tracepcap/analysis/spi/ServiceLogRoles.java
+++ b/backend/src/main/java/com/tracepcap/analysis/spi/ServiceLogRoles.java
@@ -1,0 +1,21 @@
+package com.tracepcap.analysis.spi;
+
+/**
+ * Canonical service-role identifiers reported by {@link HostServiceLogExtractor} implementations and
+ * consumed across modules (the ingest pipeline, device-classification signals, and network
+ * intelligence). Kept in the SPI as shared vocabulary so consumers depend on this contract rather
+ * than on a concrete extractor in the {@code hostlog} module.
+ */
+public final class ServiceLogRoles {
+
+  private ServiceLogRoles() {}
+
+  /** Host acts as a DNS resolver. */
+  public static final String DNS = "dns";
+
+  /** Host serves web (HTML/TLS) content. */
+  public static final String WEB = "web";
+
+  /** Host serves API-like (JSON/REST) responses. */
+  public static final String API = "api";
+}

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/ApiServerSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/ApiServerSignal.java
@@ -4,12 +4,12 @@ import com.tracepcap.hostclassification.service.classifier.DeviceClassificationS
 import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
 import com.tracepcap.hostclassification.service.classifier.HostContext;
 import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
-import com.tracepcap.analysis.service.hostlog.WebServerLogExtractor;
+import com.tracepcap.analysis.spi.ServiceLogRoles;
 import org.springframework.stereotype.Component;
 
 /**
  * Classifies a host as an {@code API_SERVER} when it served HTTP in an API-like way (JSON responses,
- * REST write verbs, or {@code /api}-style paths — decided by {@link WebServerLogExtractor}). Like
+ * REST write verbs, or {@code /api}-style paths — decided by {@code WebServerLogExtractor}). Like
  * {@link DnsServerSignal}, this is authoritative observed evidence with a dominant weight so it wins
  * over the heuristic signals. A host is tagged {@code api} <em>or</em> {@code web}, never both, so
  * this and {@link WebServerSignal} don't collide.
@@ -26,7 +26,7 @@ public class ApiServerSignal implements DeviceClassificationSignal {
 
   @Override
   public void contribute(HostContext ctx, ScoreBoard board) {
-    if (ctx.hasServiceRole(WebServerLogExtractor.ROLE_API)) {
+    if (ctx.hasServiceRole(ServiceLogRoles.API)) {
       board.add(DeviceTypes.API_SERVER, WEIGHT, "Served an HTTP API → +" + WEIGHT);
     }
   }

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/DnsServerSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/DnsServerSignal.java
@@ -4,12 +4,12 @@ import com.tracepcap.hostclassification.service.classifier.DeviceClassificationS
 import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
 import com.tracepcap.hostclassification.service.classifier.HostContext;
 import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
-import com.tracepcap.analysis.service.hostlog.DnsQueryLogExtractor;
+import com.tracepcap.analysis.spi.ServiceLogRoles;
 import org.springframework.stereotype.Component;
 
 /**
  * Classifies a host as a {@code DNS_SERVER} when it was observed answering DNS queries (the {@code
- * dns} service role, detected by {@link DnsQueryLogExtractor}). This is authoritative evidence — the
+ * dns} service role, detected by {@code DnsQueryLogExtractor}). This is authoritative evidence — the
  * host actually served DNS — so it carries a strong weight that outranks the heuristic signals,
  * making a resolver classify as a DNS server rather than a generic SERVER/ROUTER.
  *
@@ -35,7 +35,7 @@ public class DnsServerSignal implements DeviceClassificationSignal {
 
   @Override
   public void contribute(HostContext ctx, ScoreBoard board) {
-    if (ctx.hasServiceRole(DnsQueryLogExtractor.ROLE)) {
+    if (ctx.hasServiceRole(ServiceLogRoles.DNS)) {
       board.add(DeviceTypes.DNS_SERVER, WEIGHT, "Answered DNS queries → +" + WEIGHT);
     }
   }

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/WebServerSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/WebServerSignal.java
@@ -4,7 +4,7 @@ import com.tracepcap.hostclassification.service.classifier.DeviceClassificationS
 import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
 import com.tracepcap.hostclassification.service.classifier.HostContext;
 import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
-import com.tracepcap.analysis.service.hostlog.WebServerLogExtractor;
+import com.tracepcap.analysis.spi.ServiceLogRoles;
 import org.springframework.stereotype.Component;
 
 /**
@@ -25,7 +25,7 @@ public class WebServerSignal implements DeviceClassificationSignal {
 
   @Override
   public void contribute(HostContext ctx, ScoreBoard board) {
-    if (ctx.hasServiceRole(WebServerLogExtractor.ROLE_WEB)) {
+    if (ctx.hasServiceRole(ServiceLogRoles.WEB)) {
       board.add(DeviceTypes.WEB_SERVER, WEIGHT, "Served HTTP/TLS → +" + WEIGHT);
     }
   }

--- a/backend/src/main/java/com/tracepcap/hostlog/entity/DnsQueryLogEntity.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/entity/DnsQueryLogEntity.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.entity;
+package com.tracepcap.hostlog.entity;
 
 import com.tracepcap.file.entity.FileEntity;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/tracepcap/hostlog/entity/HttpEndpointLogEntity.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/entity/HttpEndpointLogEntity.java
@@ -1,4 +1,4 @@
-package com.tracepcap.analysis.entity;
+package com.tracepcap.hostlog.entity;
 
 import com.tracepcap.file.entity.FileEntity;
 import jakarta.persistence.*;

--- a/backend/src/main/java/com/tracepcap/hostlog/repository/DnsQueryLogRepository.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/repository/DnsQueryLogRepository.java
@@ -1,6 +1,6 @@
-package com.tracepcap.analysis.repository;
+package com.tracepcap.hostlog.repository;
 
-import com.tracepcap.analysis.entity.DnsQueryLogEntity;
+import com.tracepcap.hostlog.entity.DnsQueryLogEntity;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/src/main/java/com/tracepcap/hostlog/repository/HttpEndpointLogRepository.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/repository/HttpEndpointLogRepository.java
@@ -1,6 +1,6 @@
-package com.tracepcap.analysis.repository;
+package com.tracepcap.hostlog.repository;
 
-import com.tracepcap.analysis.entity.HttpEndpointLogEntity;
+import com.tracepcap.hostlog.entity.HttpEndpointLogEntity;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/src/main/java/com/tracepcap/hostlog/service/DnsQueryLogExtractor.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/service/DnsQueryLogExtractor.java
@@ -1,7 +1,11 @@
-package com.tracepcap.analysis.service.hostlog;
+package com.tracepcap.hostlog.service;
 
-import com.tracepcap.analysis.entity.DnsQueryLogEntity;
-import com.tracepcap.analysis.repository.DnsQueryLogRepository;
+import com.tracepcap.analysis.spi.HostServiceLogExtractor;
+import com.tracepcap.analysis.spi.HostServiceLogResult;
+import com.tracepcap.analysis.spi.HostServiceSuspicion;
+import com.tracepcap.analysis.spi.ServiceLogRoles;
+import com.tracepcap.hostlog.entity.DnsQueryLogEntity;
+import com.tracepcap.hostlog.repository.DnsQueryLogRepository;
 import com.tracepcap.file.entity.FileEntity;
 import java.io.BufferedReader;
 import java.io.File;
@@ -24,7 +28,7 @@ import org.springframework.stereotype.Service;
 
 /**
  * Extracts the DNS query log for hosts acting as DNS servers (#362) — the first implementation of
- * {@link HostServiceLogExtractor}.
+ * {@link com.tracepcap.analysis.spi.HostServiceLogExtractor}.
  *
  * <p>Runs a single read-only tshark pass over the capture, selecting DNS <em>responses</em>, and
  * aggregates them per {@code (serverIp, queryName, queryType)} into {@link DnsQueryLogEntity} rows:
@@ -41,7 +45,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class DnsQueryLogExtractor implements HostServiceLogExtractor {
 
-  public static final String ROLE = "dns";
+  public static final String ROLE = ServiceLogRoles.DNS;
 
   private static final int QUERY_NAME_MAX_LENGTH = 255;
 

--- a/backend/src/main/java/com/tracepcap/hostlog/service/DnsQueryLogExtractor.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/service/DnsQueryLogExtractor.java
@@ -45,7 +45,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class DnsQueryLogExtractor implements HostServiceLogExtractor {
 
-  public static final String ROLE = ServiceLogRoles.DNS;
+  private static final String ROLE = ServiceLogRoles.DNS;
 
   private static final int QUERY_NAME_MAX_LENGTH = 255;
 

--- a/backend/src/main/java/com/tracepcap/hostlog/service/WebServerLogExtractor.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/service/WebServerLogExtractor.java
@@ -1,7 +1,10 @@
-package com.tracepcap.analysis.service.hostlog;
+package com.tracepcap.hostlog.service;
 
-import com.tracepcap.analysis.entity.HttpEndpointLogEntity;
-import com.tracepcap.analysis.repository.HttpEndpointLogRepository;
+import com.tracepcap.analysis.spi.HostServiceLogExtractor;
+import com.tracepcap.analysis.spi.HostServiceLogResult;
+import com.tracepcap.analysis.spi.ServiceLogRoles;
+import com.tracepcap.hostlog.entity.HttpEndpointLogEntity;
+import com.tracepcap.hostlog.repository.HttpEndpointLogRepository;
 import com.tracepcap.file.entity.FileEntity;
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,7 +29,7 @@ import org.springframework.stereotype.Service;
 
 /**
  * Detects web/API-server hosts and logs the cleartext HTTP endpoints they served (#362 follow-up) —
- * the web/API counterpart of {@link DnsQueryLogExtractor}.
+ * the web/API counterpart of {@code DnsQueryLogExtractor}.
  *
  * <p>Two read-only tshark passes:
  *
@@ -50,8 +53,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class WebServerLogExtractor implements HostServiceLogExtractor {
 
-  public static final String ROLE_WEB = "web";
-  public static final String ROLE_API = "api";
+  public static final String ROLE_WEB = ServiceLogRoles.WEB;
+  public static final String ROLE_API = ServiceLogRoles.API;
 
   private static final int PATH_MAX_LENGTH = 2048;
 

--- a/backend/src/main/java/com/tracepcap/hostlog/service/WebServerLogExtractor.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/service/WebServerLogExtractor.java
@@ -53,8 +53,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class WebServerLogExtractor implements HostServiceLogExtractor {
 
-  public static final String ROLE_WEB = ServiceLogRoles.WEB;
-  public static final String ROLE_API = ServiceLogRoles.API;
+  private static final String ROLE_WEB = ServiceLogRoles.WEB;
+  private static final String ROLE_API = ServiceLogRoles.API;
 
   private static final int PATH_MAX_LENGTH = 2048;
 

--- a/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
@@ -523,7 +523,7 @@ public class NetworkIntelligenceService {
               return ServiceServerSummaryDto.builder()
                   .serverIp(host.getIp())
                   .hostname(host.getHostname())
-                  .role(hasRole(host, ServiceLogRoles.API) ? "api" : "web")
+                  .role(hasRole(host, ServiceLogRoles.API) ? ServiceLogRoles.API : ServiceLogRoles.WEB)
                   .totalRequests(c.total())
                   .okCount(c.success)
                   .failedCount(c.clientError + c.serverError)

--- a/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
@@ -2,17 +2,17 @@ package com.tracepcap.intelligence.service;
 
 import com.tracepcap.analysis.dto.ConversationFilterParams;
 import com.tracepcap.analysis.entity.ConversationEntity;
-import com.tracepcap.analysis.entity.DnsQueryLogEntity;
+import com.tracepcap.hostlog.entity.DnsQueryLogEntity;
 import com.tracepcap.analysis.entity.HostClassificationEntity;
-import com.tracepcap.analysis.entity.HttpEndpointLogEntity;
+import com.tracepcap.hostlog.entity.HttpEndpointLogEntity;
 import com.tracepcap.analysis.entity.IpGeoInfoEntity;
 import com.tracepcap.analysis.repository.ConversationRepository;
-import com.tracepcap.analysis.repository.DnsQueryLogRepository;
+import com.tracepcap.hostlog.repository.DnsQueryLogRepository;
 import com.tracepcap.analysis.repository.HostClassificationRepository;
-import com.tracepcap.analysis.repository.HttpEndpointLogRepository;
+import com.tracepcap.hostlog.repository.HttpEndpointLogRepository;
 import com.tracepcap.analysis.repository.IpGeoInfoRepository;
 import com.tracepcap.analysis.repository.PacketRepository;
-import com.tracepcap.analysis.service.hostlog.WebServerLogExtractor;
+import com.tracepcap.analysis.spi.ServiceLogRoles;
 import com.tracepcap.analysis.service.GeoIpService;
 import com.tracepcap.intelligence.dto.*;
 import com.tracepcap.intelligence.entity.IpOrgRuleEntity;
@@ -507,8 +507,8 @@ public class NetworkIntelligenceService {
   public List<ServiceServerSummaryDto> computeWebServers(UUID fileId) {
     List<HostClassificationEntity> webHosts =
         hostClassificationRepository.findByFileId(fileId).stream()
-            .filter(h -> hasRole(h, WebServerLogExtractor.ROLE_API)
-                || hasRole(h, WebServerLogExtractor.ROLE_WEB))
+            .filter(h -> hasRole(h, ServiceLogRoles.API)
+                || hasRole(h, ServiceLogRoles.WEB))
             .toList();
     if (webHosts.isEmpty()) return List.of();
 
@@ -523,7 +523,7 @@ public class NetworkIntelligenceService {
               return ServiceServerSummaryDto.builder()
                   .serverIp(host.getIp())
                   .hostname(host.getHostname())
-                  .role(hasRole(host, WebServerLogExtractor.ROLE_API) ? "api" : "web")
+                  .role(hasRole(host, ServiceLogRoles.API) ? "api" : "web")
                   .totalRequests(c.total())
                   .okCount(c.success)
                   .failedCount(c.clientError + c.serverError)
@@ -578,7 +578,7 @@ public class NetworkIntelligenceService {
     return WebServerDetailResponse.builder()
         .serverIp(serverIp)
         .hostname(host != null ? host.getHostname() : null)
-        .api(host != null && hasRole(host, WebServerLogExtractor.ROLE_API))
+        .api(host != null && hasRole(host, ServiceLogRoles.API))
         .totalRequests(c.total())
         .successCount(c.success)
         .clientErrorCount(c.clientError)

--- a/backend/src/test/java/com/tracepcap/hostlog/service/DnsQueryLogExtractorTest.java
+++ b/backend/src/test/java/com/tracepcap/hostlog/service/DnsQueryLogExtractorTest.java
@@ -1,10 +1,10 @@
-package com.tracepcap.analysis.service.hostlog;
+package com.tracepcap.hostlog.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.tracepcap.analysis.service.hostlog.DnsQueryLogExtractor.QueryAgg;
-import com.tracepcap.analysis.service.hostlog.DnsQueryLogExtractor.QueryKey;
-import com.tracepcap.analysis.service.hostlog.DnsQueryLogExtractor.ServerStats;
+import com.tracepcap.hostlog.service.DnsQueryLogExtractor.QueryAgg;
+import com.tracepcap.hostlog.service.DnsQueryLogExtractor.QueryKey;
+import com.tracepcap.hostlog.service.DnsQueryLogExtractor.ServerStats;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/tracepcap/hostlog/service/WebServerLogExtractorTest.java
+++ b/backend/src/test/java/com/tracepcap/hostlog/service/WebServerLogExtractorTest.java
@@ -1,9 +1,9 @@
-package com.tracepcap.analysis.service.hostlog;
+package com.tracepcap.hostlog.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.tracepcap.analysis.service.hostlog.WebServerLogExtractor.EndpointAgg;
-import com.tracepcap.analysis.service.hostlog.WebServerLogExtractor.WebServerStats;
+import com.tracepcap.hostlog.service.WebServerLogExtractor.EndpointAgg;
+import com.tracepcap.hostlog.service.WebServerLogExtractor.WebServerStats;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;


### PR DESCRIPTION
**Slice 6 of #416** (the last extraction slice). The per-host service-log extractors were already an SPI (`List<HostServiceLogExtractor>`); this promotes that seam into `analysis.spi` and moves the implementations + storage into a `hostlog` module.

## What changed

- **SPI contract → `com.tracepcap.analysis.spi`:** `HostServiceLogExtractor` (interface), `HostServiceLogResult`, `HostServiceSuspicion`, and a **new `ServiceLogRoles`** holding the shared `dns`/`web`/`api` role vocabulary.
- **Feature → `com.tracepcap.hostlog.*`:** `DnsQueryLogExtractor`/`WebServerLogExtractor` (`service`), `DnsQueryLog`/`HttpEndpointLog` entities (`entity`), their repositories (`repository`), and the two extractor tests.

## Decoupled a real core→feature leak

`AnalysisService` referenced `DnsQueryLogExtractor.ROLE`, and the classifier signals + `intelligence` reached into the extractors' `ROLE`/`ROLE_WEB`/`ROLE_API` constants. All now use `ServiceLogRoles` from the SPI, so **nothing outside `hostlog` depends on the concrete extractors**. `intelligence` still reads the log *entities* — a legitimate feature→feature data dependency.

## Verification

- ✅ `docker compose build backend` compiles (incl. tests); Spring boots with both extractor beans collected via the SPI.
- ✅ **OpenAPI baseline unchanged**.
- ✅ `mvn verify` (JUnit + Testcontainers) passes — extractor unit tests + ingest service-log extraction + intelligence reads exercised.

Part of #416. No API/contract changes; no DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized service log handling components into a more coherent module structure for improved maintainability and consistency.
  * Centralized service role identifier definitions to reduce duplication and improve code reusability across the system.
  * Adjusted visibility of internal role constants to enforce better encapsulation and prevent unintended external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->