### PR TITLE
refactor(frontend): decompose EntityDetailModal god-component

### DIFF
--- a/frontend/src/components/common/EntityDetailModal/EntityDetailModal.tsx
+++ b/frontend/src/components/common/EntityDetailModal/EntityDetailModal.tsx
@@ -1,89 +1,17 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { apiClient } from '@/services/api/client';
-import {
-  entityNotesService,
-  type EntityNote,
-  type EntityHistoryEntry,
-  type EntityType,
-} from '@/features/notes/services/entityNotesService';
-import { insightsService } from '@/features/insights/services/insightsService';
-import type { NodeRole } from '@/features/insights/types/insights.types';
-import { buildDeviceSignals, confidenceLevel, type DeviceSignalInfo } from '@/utils/deviceType';
-import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
-import { parseDateTime } from '@/utils/dateUtils';
-import { Badge } from '@govtechsg/sgds-react';
-
-type Tab = 'details' | 'notes';
-
-interface HostClassification {
-  ip: string | null;
-  mac: string | null;
-  manufacturer: string | null;
-  deviceType: string | null;
-  confidence: number | null;
-  ttl: number | null;
-}
-
-interface IpSnapshotEntry {
-  snap: NetworkSnapshot;
-  host: HostClassification | null;
-  apps: string[];
-  protocols: string[];
-}
-
-interface EntityDetailModalProps {
-  entityType: EntityType;
-  entityKey: string;
-  /** Display label (may differ from key) */
-  displayName: string;
-  /** Current file ID — used to fetch stats and mark history rows */
-  fileId: string;
-  /** Badge element rendered in the modal header */
-  badge?: React.ReactNode;
-  /** Whether the entity was seen in the most recent snapshot (Monitor context) */
-  isActive?: boolean;
-  /** ISO timestamp of last seen time — used to compute "inactive X days ago" */
-  lastSeenTime?: string | null;
-  /** Called when "View conversations" is clicked */
-  onViewConversations?: () => void;
-  /** Monitor snapshots — when provided for IP type, shows per-snapshot MAC/device history */
-  snapshots?: NetworkSnapshot[];
-  onClose: () => void;
-  zIndex?: number;
-}
-
-interface ConvRow {
-  srcIp: string;
-  dstIp: string;
-  packetCount: number;
-  totalBytes: number;
-}
-
-interface ConvApiResponse {
-  data: ConvRow[];
-  total: number;
-}
-
-interface EntityStats {
-  conversationCount: number;
-  packetCount: number;
-  totalBytes: number;
-  /** Distinct peer IPs (for APPLICATION/PROTOCOL only) */
-  topPeers: { ip: string; bytes: number }[];
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
-}
-
-function formatNumber(num: number): string {
-  return num.toLocaleString();
-}
+import { useEntityRole } from './hooks/useEntityRole';
+import { useEntityStats } from './hooks/useEntityStats';
+import { useEntityNote } from './hooks/useEntityNote';
+import { useEntityHistory } from './hooks/useEntityHistory';
+import { useHostClassification } from './hooks/useHostClassification';
+import { useIpSnapshotHistory } from './hooks/useIpSnapshotHistory';
+import { RoleSection } from './sections/RoleSection';
+import { HostClassificationSection } from './sections/HostClassificationSection';
+import { EntityStatsSection } from './sections/EntityStatsSection';
+import { SnapshotHistoryTable } from './sections/SnapshotHistoryTable';
+import { CaptureHistoryTable } from './sections/CaptureHistoryTable';
+import { NotesTab } from './sections/NotesTab';
+import type { EntityDetailModalProps, Tab } from './types';
 
 export function EntityDetailModal({
   entityType,
@@ -98,44 +26,17 @@ export function EntityDetailModal({
   onClose,
   zIndex,
 }: EntityDetailModalProps) {
-  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<Tab>('details');
   const [nestedIp, setNestedIp] = useState<string | null>(null);
 
-  // Details state
-  const [stats, setStats] = useState<EntityStats | null>(null);
-  const [statsLoading, setStatsLoading] = useState(false);
-  const [statsError, setStatsError] = useState<string | null>(null);
-
-  // Notes state
-  const [noteText, setNoteText] = useState('');
-  const [savedNote, setSavedNote] = useState<EntityNote | null>(null);
-  const [noteSaving, setNoteSaving] = useState(false);
-  const [noteDeleting, setNoteDeleting] = useState(false);
-
-  // Node role state (IP and DEVICE only)
   const showRole = entityType === 'IP' || entityType === 'DEVICE';
-  const [role, setRole] = useState<NodeRole | null>(null);
-  const [roleLoading, setRoleLoading] = useState(false);
-  const [roleSuggesting, setRoleSuggesting] = useState(false);
-  const [roleSuggestError, setRoleSuggestError] = useState<string | null>(null);
-  const [roleInfoOpen, setRoleInfoOpen] = useState(false);
-  const [roleEditing, setRoleEditing] = useState(false);
-  const [roleLabelDraft, setRoleLabelDraft] = useState('');
-  const [roleDescDraft, setRoleDescDraft] = useState('');
-  const [roleSaving, setRoleSaving] = useState(false);
 
-  // History state
-  const [history, setHistory] = useState<EntityHistoryEntry[]>([]);
-  const [historyLoading, setHistoryLoading] = useState(false);
-  const [historyError, setHistoryError] = useState<string | null>(null);
-
-  // Host classification for IP type
-  const [hostClass, setHostClass] = useState<HostClassification | null>(null);
-
-  // Per-snapshot MAC/device history for IP type (when snapshots prop is provided)
-  const [ipSnapHistory, setIpSnapHistory] = useState<IpSnapshotEntry[]>([]);
-  const [ipHistoryLoading, setIpHistoryLoading] = useState(false);
+  const role = useEntityRole(entityType, entityKey, fileId, showRole);
+  const { stats, statsLoading, statsError } = useEntityStats(entityType, entityKey, fileId);
+  const note = useEntityNote(entityType, entityKey);
+  const { history, historyLoading, historyError } = useEntityHistory(entityType, entityKey);
+  const hostClass = useHostClassification(entityType, entityKey, fileId);
+  const { ipSnapHistory, ipHistoryLoading } = useIpSnapshotHistory(entityType, entityKey, snapshots);
 
   // ESC closes — but not if a nested IP modal is open (let the nested one handle it first)
   useEffect(() => {
@@ -151,218 +52,6 @@ export function EntityDetailModal({
     document.body.style.overflow = 'hidden';
     return () => { document.body.style.overflow = ''; };
   }, []);
-
-  // Load node role on mount for IP/DEVICE
-  useEffect(() => {
-    if (!showRole) return;
-    setRoleLoading(true);
-    insightsService
-      .getNodeRole(entityType, entityKey)
-      .then(r => setRole(r))
-      .finally(() => setRoleLoading(false));
-  }, [showRole, entityType, entityKey]);
-
-  // Fetch host classification for IP type
-  useEffect(() => {
-    if (entityType !== 'IP' || !fileId) return;
-    apiClient
-      .get<HostClassification[]>(`/files/${fileId}/host-classifications`)
-      .then(r => {
-        const match = r.data.find(h => h.ip === entityKey);
-        setHostClass(match ?? null);
-      })
-      .catch(() => {});
-  }, [entityType, entityKey, fileId]);
-
-  // Load per-snapshot MAC/device history for IP type when snapshots are provided
-  useEffect(() => {
-    if (entityType !== 'IP' || !snapshots || snapshots.length === 0) return;
-    setIpHistoryLoading(true);
-    const sorted = [...snapshots].sort((a, b) => a.snapshotOrder - b.snapshotOrder);
-    Promise.all(
-      sorted.map(snap =>
-        apiClient
-          .get<HostClassification[]>(`/files/${snap.fileId}/host-classifications`)
-          .then(r => ({ snap, host: r.data.find(h => h.ip === entityKey) ?? null }))
-          .catch(() => ({ snap, host: null }))
-      )
-    ).then(results => {
-      // Only keep snapshots where this IP appeared
-      const seen = results.filter(r => r.host !== null);
-      if (seen.length === 0) { setIpSnapHistory([]); setIpHistoryLoading(false); return; }
-      // Fetch conversations for protocols/apps per seen snapshot
-      return Promise.all(
-        seen.map(({ snap, host }) =>
-          apiClient
-            .get<{ data: { appName: string | null; tsharkProtocol: string | null }[] }>(
-              `/conversations/${snap.fileId}?ip=${encodeURIComponent(entityKey)}&pageSize=10000`
-            )
-            .then(r => ({
-              snap,
-              host,
-              apps: [...new Set(r.data.data.map(c => c.appName).filter(Boolean) as string[])].sort(),
-              protocols: [...new Set(r.data.data.map(c => c.tsharkProtocol).filter(Boolean) as string[])].sort(),
-            }))
-            .catch(() => ({ snap, host, apps: [], protocols: [] }))
-        )
-      ).then(entries => { setIpSnapHistory(entries); setIpHistoryLoading(false); });
-    }).catch(() => setIpHistoryLoading(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entityType, entityKey, snapshots?.map(s => s.id).join(',')]);
-
-  // Fetch stats for the Details tab (only when fileId is present)
-  useEffect(() => {
-    if (!fileId || (entityType !== 'APPLICATION' && entityType !== 'PROTOCOL')) return;
-    setStatsLoading(true);
-    setStatsError(null);
-    const param = entityType === 'APPLICATION' ? `apps=${encodeURIComponent(entityKey)}` : `l7Protocols=${encodeURIComponent(entityKey)}`;
-    apiClient
-      .get<ConvApiResponse>(`/conversations/${fileId}?${param}&pageSize=500&page=1`)
-      .then(res => {
-        const rows = res.data.data;
-        const total = res.data.total;
-        const packets = rows.reduce((s, r) => s + r.packetCount, 0);
-        const bytes = rows.reduce((s, r) => s + r.totalBytes, 0);
-        // Aggregate bytes per peer IP
-        const peerBytes = new Map<string, number>();
-        for (const r of rows) {
-          peerBytes.set(r.srcIp, (peerBytes.get(r.srcIp) ?? 0) + r.totalBytes);
-          peerBytes.set(r.dstIp, (peerBytes.get(r.dstIp) ?? 0) + r.totalBytes);
-        }
-        const topPeers = Array.from(peerBytes.entries())
-          .sort((a, b) => b[1] - a[1])
-          .slice(0, 10)
-          .map(([ip, b]) => ({ ip, bytes: b }));
-        setStats({ conversationCount: total, packetCount: packets, totalBytes: bytes, topPeers });
-      })
-      .catch(() => setStatsError('Failed to load details'))
-      .finally(() => setStatsLoading(false));
-  }, [fileId, entityType, entityKey]);
-
-  // Load note on mount
-  useEffect(() => {
-    entityNotesService.getNote(entityType, entityKey).then(note => {
-      if (note) { setSavedNote(note); setNoteText(note.note); }
-    });
-  }, [entityType, entityKey]);
-
-  // Load history on mount
-  useEffect(() => {
-    if (history.length > 0 || historyLoading) return;
-    setHistoryLoading(true);
-    setHistoryError(null);
-    entityNotesService
-      .getHistory(entityType, entityKey)
-      .then(entries => setHistory(entries))
-      .catch(() => setHistoryError('Failed to load history'))
-      .finally(() => setHistoryLoading(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entityType, entityKey]);
-
-  const handleSuggestRole = async () => {
-    if (!fileId) return;
-    setRoleSuggesting(true);
-    setRoleSuggestError(null);
-    try {
-      const suggested = await insightsService.suggestNodeRole(entityType, entityKey, fileId);
-      setRole(suggested);
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Suggestion failed.';
-      setRoleSuggestError(msg);
-    } finally {
-      setRoleSuggesting(false);
-    }
-  };
-
-  const handleAcceptRole = async () => {
-    if (!role) return;
-    setRoleSaving(true);
-    try {
-      const updated = await insightsService.upsertNodeRole(
-        entityType,
-        entityKey,
-        role.roleLabel ?? '',
-        role.roleDescription ?? '',
-        true,
-      );
-      setRole(updated);
-    } finally {
-      setRoleSaving(false);
-    }
-  };
-
-  const handleDiscardRole = async () => {
-    setRoleSaving(true);
-    try {
-      await insightsService.deleteNodeRole(entityType, entityKey);
-      setRole(null);
-    } finally {
-      setRoleSaving(false);
-    }
-  };
-
-  const handleOpenEdit = () => {
-    setRoleLabelDraft(role?.roleLabel ?? '');
-    setRoleDescDraft(role?.roleDescription ?? '');
-    setRoleEditing(true);
-  };
-
-  const handleSaveRole = async () => {
-    setRoleSaving(true);
-    try {
-      const updated = await insightsService.upsertNodeRole(
-        entityType,
-        entityKey,
-        roleLabelDraft,
-        roleDescDraft,
-        true,
-      );
-      setRole(updated);
-      setRoleEditing(false);
-    } finally {
-      setRoleSaving(false);
-    }
-  };
-
-  const handleSaveNote = async () => {
-    setNoteSaving(true);
-    try {
-      const updated = await entityNotesService.upsertNote(entityType, entityKey, noteText);
-      setSavedNote(updated);
-    } finally { setNoteSaving(false); }
-  };
-
-  const handleDeleteNote = async () => {
-    setNoteDeleting(true);
-    try {
-      await entityNotesService.deleteNote(entityType, entityKey);
-      setSavedNote(null);
-      setNoteText('');
-    } finally { setNoteDeleting(false); }
-  };
-
-  const noteChanged = noteText !== (savedNote?.note ?? '');
-
-  function formatSnapTime(snap: NetworkSnapshot): string {
-    if (!snap.startTime) return snap.fileName;
-    const ms = parseDateTime(snap.startTime as unknown as string | number[]);
-    return new Date(ms).toLocaleDateString('en-GB', { month: 'short', day: 'numeric', year: 'numeric' });
-  }
-
-  function stringHue(s: string): number {
-    let h = 0;
-    for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) & 0xffffffff;
-    return Math.abs(h) % 360;
-  }
-
-  function hashBadgeStyle(s: string) {
-    const hue = stringHue(s);
-    return {
-      background: `hsl(${hue}, 40%, 88%)`,
-      color: `hsl(${hue}, 50%, 28%)`,
-      border: `1px solid hsl(${hue}, 35%, 72%)`,
-    };
-  }
 
   const entityLabel =
     entityType === 'PROTOCOL' ? 'protocol'
@@ -381,6 +70,9 @@ export function EntityDetailModal({
     }
     return <span className="badge bg-secondary ms-2" style={{ fontSize: '0.7rem' }}>Inactive</span>;
   })() : null;
+
+  const hasFileStats = !!fileId && (entityType === 'APPLICATION' || entityType === 'PROTOCOL');
+  const showSnapshotHistory = entityType === 'IP' && !!snapshots && snapshots.length > 0;
 
   return (
     <>
@@ -417,7 +109,7 @@ export function EntityDetailModal({
                     {tab === 'notes' && (
                       <>
                         <i className="bi bi-sticky me-1" />
-                        {savedNote && (
+                        {note.savedNote && (
                           <span className="badge bg-warning text-dark ms-1" style={{ fontSize: '0.6rem' }}>1</span>
                         )}
                       </>
@@ -434,287 +126,23 @@ export function EntityDetailModal({
             {/* ── DETAILS TAB ──────────────────────────────────────── */}
             {activeTab === 'details' && (
               <div>
-                {/* ── Role section (IP and DEVICE only) ── */}
-                {showRole && (
-                  <div className="mb-4">
-                    <h6 className="border-bottom pb-1 mb-2 d-flex align-items-center justify-content-between">
-                      <span>Role</span>
-                      {!roleEditing && !roleLoading && (
-                        <div className="d-flex gap-1">
-                          <button
-                            className="btn btn-outline-secondary btn-sm py-0"
-                            style={{ fontSize: '0.75rem' }}
-                            onClick={handleOpenEdit}
-                          >
-                            <i className="bi bi-pencil me-1" />Edit
-                          </button>
-                          {fileId && (
-                            <div className="d-flex align-items-center gap-1">
-                              <button
-                                className="btn btn-outline-secondary btn-sm py-0"
-                                style={{ fontSize: '0.75rem' }}
-                                onClick={handleSuggestRole}
-                                disabled={roleSuggesting}
-                              >
-                                {roleSuggesting
-                                  ? <><span className="spinner-border spinner-border-sm me-1" role="status" />Suggesting…</>
-                                  : <><i className="bi bi-stars me-1" />Suggest with AI</>
-                                }
-                              </button>
-                              <button
-                                className="btn btn-link btn-sm p-0 text-muted"
-                                style={{ fontSize: '0.8rem', lineHeight: 1 }}
-                                onClick={() => setRoleInfoOpen(o => !o)}
-                                title="How does this work?"
-                              >
-                                <i className="bi bi-info-circle" />
-                              </button>
-                            </div>
-                          )}
-                        </div>
-                      )}
-                    </h6>
+                {showRole && <RoleSection fileId={fileId} role={role} />}
 
-                    {roleInfoOpen && (
-                      <div className="p-2 rounded mb-2 small text-muted" style={{ background: 'var(--tp-bg-subtle, #f8f9fa)', border: '1px solid var(--bs-border-color)' }}>
-                        <strong>How it works:</strong> The AI analyses traffic signals for this entity — manufacturer OUI, device type, TTL, observed applications and protocols — and suggests an operational role label. If the signals are too sparse or generic to make a meaningful assessment, it will decline rather than guess.
-                      </div>
-                    )}
-
-                    {roleLoading && (
-                      <div className="text-muted small fst-italic">Loading role…</div>
-                    )}
-
-                    {roleSuggestError && (
-                      <div className="d-flex align-items-start gap-2 p-2 rounded mb-2 small" style={{ background: 'var(--bs-warning-bg-subtle, #fff3cd)', color: 'var(--bs-warning-text-emphasis, #664d03)', border: '1px solid var(--bs-warning-border-subtle, #ffc107)' }}>
-                        <i className="bi bi-exclamation-triangle-fill mt-1 flex-shrink-0" />
-                        <span>{roleSuggestError}</span>
-                      </div>
-                    )}
-
-                    {!roleLoading && !role && !roleEditing && (
-                      <p className="text-muted small fst-italic mb-0">
-                        No role assigned.
-                      </p>
-                    )}
-
-                    {!roleLoading && role && !roleEditing && (
-                      <div
-                        className={`p-2 rounded small ${role.llmSuggested && !role.confirmedByHuman ? 'bg-warning-subtle border border-warning-subtle' : 'bg-light'}`}
-                      >
-                        <div className="fw-semibold">
-                          {role.roleLabel || <span className="text-muted fst-italic">No label</span>}
-                          {role.llmSuggested && !role.confirmedByHuman && (
-                            <span className="badge bg-warning text-dark ms-2" style={{ fontSize: '0.65rem' }}>
-                              <i className="bi bi-stars me-1" />AI suggested
-                            </span>
-                          )}
-                          {role.confirmedByHuman && (
-                            <span className="badge bg-secondary ms-2" style={{ fontSize: '0.65rem' }} title="Manually labelled by an analyst. Future deviating behaviour can still be flagged.">
-                              <i className="bi bi-tag me-1" />Manual label
-                            </span>
-                          )}
-                        </div>
-                        {role.roleDescription && (
-                          <div className="text-muted mt-1">{role.roleDescription}</div>
-                        )}
-                        {role.llmSuggested && !role.confirmedByHuman && (
-                          <div className="d-flex gap-2 mt-2">
-                            <button
-                              className="btn btn-success btn-sm py-0"
-                              style={{ fontSize: '0.75rem' }}
-                              onClick={handleAcceptRole}
-                              disabled={roleSaving}
-                            >
-                              <i className="bi bi-check-lg me-1" />Accept
-                            </button>
-                            <button
-                              className="btn btn-outline-secondary btn-sm py-0"
-                              style={{ fontSize: '0.75rem' }}
-                              onClick={handleDiscardRole}
-                              disabled={roleSaving}
-                            >
-                              <i className="bi bi-x-lg me-1" />Discard
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {roleEditing && (
-                      <div>
-                        <input
-                          className="form-control form-control-sm mb-2"
-                          placeholder="Role label (e.g. SCADA Controller)"
-                          value={roleLabelDraft}
-                          onChange={e => setRoleLabelDraft(e.target.value)}
-                        />
-                        <textarea
-                          className="form-control form-control-sm mb-2"
-                          rows={2}
-                          placeholder="Description (optional)"
-                          value={roleDescDraft}
-                          onChange={e => setRoleDescDraft(e.target.value)}
-                        />
-                        <div className="d-flex gap-2">
-                          <button
-                            className="btn btn-primary btn-sm py-0"
-                            style={{ fontSize: '0.75rem' }}
-                            onClick={handleSaveRole}
-                            disabled={roleSaving || !roleLabelDraft.trim()}
-                          >
-                            {roleSaving
-                              ? <><span className="spinner-border spinner-border-sm me-1" role="status" />Saving…</>
-                              : <><i className="bi bi-floppy me-1" />Save</>
-                            }
-                          </button>
-                          <button
-                            className="btn btn-outline-secondary btn-sm py-0"
-                            style={{ fontSize: '0.75rem' }}
-                            onClick={() => setRoleEditing(false)}
-                            disabled={roleSaving}
-                          >
-                            Cancel
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {/* Host classification signals for IP type */}
                 {entityType === 'IP' && hostClass && (
-                  <div className="mb-4">
-                    <h6 className="border-bottom pb-1 mb-2">Device Classification</h6>
-                    <div className="d-flex gap-4 flex-wrap mb-2">
-                      {hostClass.manufacturer && (
-                        <div>
-                          <small className="text-muted d-block">Manufacturer</small>
-                          <strong>{hostClass.manufacturer}</strong>
-                        </div>
-                      )}
-                      {hostClass.deviceType && (
-                        <div>
-                          <small className="text-muted d-block">Device Type</small>
-                          <strong>{hostClass.deviceType}</strong>
-                        </div>
-                      )}
-                      {hostClass.ttl != null && (
-                        <div>
-                          <small className="text-muted d-block">TTL</small>
-                          <strong>{hostClass.ttl}</strong>
-                        </div>
-                      )}
-                      {hostClass.confidence != null && (
-                        <div>
-                          <small className="text-muted d-block">Confidence</small>
-                          <strong>{hostClass.confidence}%{hostClass.confidence != null && <span className="text-muted fw-normal"> — {confidenceLevel(hostClass.confidence)}</span>}</strong>
-                        </div>
-                      )}
-                    </div>
-                    {(() => {
-                      const signalInfo: DeviceSignalInfo = {
-                        manufacturer: hostClass.manufacturer ?? undefined,
-                        ttl: hostClass.ttl ?? undefined,
-                        confidence: hostClass.confidence ?? 0,
-                        deviceType: hostClass.deviceType ?? undefined,
-                        apps: [],
-                      };
-                      const { fired, missing } = buildDeviceSignals(signalInfo);
-                      return (
-                        <>
-                          {fired.length > 0 && (
-                            <div className="border rounded p-2 mb-2" style={{ background: 'var(--tp-bg-subtle)', fontSize: '0.78rem' }}>
-                              <small className="text-muted fw-semibold d-block mb-1">
-                                <i className="bi bi-bar-chart-steps me-1" />How this is derived
-                              </small>
-                              <ul className="mb-0 ps-3">
-                                {fired.map((s, i) => <li key={i} className="text-muted">{s}</li>)}
-                              </ul>
-                            </div>
-                          )}
-                          {missing.length > 0 && (
-                            <div className="border rounded p-2" style={{ background: 'var(--bs-warning-bg-subtle, #fff3cd)', borderColor: 'var(--bs-warning-border-subtle, #ffc107)', fontSize: '0.78rem' }}>
-                              <small className="fw-semibold d-block mb-1" style={{ color: 'var(--bs-warning-text-emphasis, #664d03)' }}>
-                                <i className="bi bi-lightbulb me-1" />What would improve confidence
-                              </small>
-                              <ul className="mb-0 ps-3" style={{ color: 'var(--bs-warning-text-emphasis, #664d03)' }}>
-                                {missing.map((s, i) => <li key={i}>{s}</li>)}
-                              </ul>
-                            </div>
-                          )}
-                        </>
-                      );
-                    })()}
-                  </div>
+                  <HostClassificationSection hostClass={hostClass} />
                 )}
 
-                {/* Stats fetched from conversations API */}
-                {fileId && (entityType === 'APPLICATION' || entityType === 'PROTOCOL') && (
-                  <>
-                    {statsLoading && (
-                      <div className="text-center py-4">
-                        <div className="spinner-border spinner-border-sm text-primary" role="status" />
-                        <p className="text-muted mt-2 small">Loading stats…</p>
-                      </div>
-                    )}
-                    {statsError && (
-                      <div className="alert alert-warning py-2 small">{statsError}</div>
-                    )}
-                    {!statsLoading && !statsError && stats && (
-                      <>
-                        <div className="row g-3 mb-4">
-                          <div className="col-4 text-center">
-                            <div className="fw-bold fs-5">{formatNumber(stats.conversationCount)}</div>
-                            <small className="text-muted">Conversations</small>
-                          </div>
-                          <div className="col-4 text-center">
-                            <div className="fw-bold fs-5">{formatNumber(stats.packetCount)}</div>
-                            <small className="text-muted">Packets</small>
-                          </div>
-                          <div className="col-4 text-center">
-                            <div className="fw-bold fs-5">{formatBytes(stats.totalBytes)}</div>
-                            <small className="text-muted">Total bytes</small>
-                          </div>
-                        </div>
-
-                        {stats.topPeers.length > 0 && (
-                          <>
-                            <h6 className="border-bottom pb-1 mb-2">
-                              Top IPs{stats.topPeers.length === 10 ? ' (top 10)' : ''}
-                            </h6>
-                            <div className="table-responsive rounded border overflow-hidden">
-                              <table className="table table-sm table-hover mb-0">
-                                <thead className="table-light" style={{ fontSize: '0.8rem' }}>
-                                  <tr>
-                                    <th>IP Address</th>
-                                    <th className="text-end">Bytes</th>
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  {stats.topPeers.map(peer => (
-                                    <tr
-                                      key={peer.ip}
-                                      style={{ cursor: 'pointer' }}
-                                      onClick={() => setNestedIp(peer.ip)}
-                                      title="View IP details"
-                                    >
-                                      <td className="font-monospace small">{peer.ip}</td>
-                                      <td className="text-end small">{formatBytes(peer.bytes)}</td>
-                                    </tr>
-                                  ))}
-                                </tbody>
-                              </table>
-                            </div>
-                          </>
-                        )}
-                      </>
-                    )}
-                  </>
+                {hasFileStats && (
+                  <EntityStatsSection
+                    stats={stats}
+                    statsLoading={statsLoading}
+                    statsError={statsError}
+                    onSelectPeer={setNestedIp}
+                  />
                 )}
 
                 {/* Fallback for entity types without file stats and no role section */}
-                {!showRole && (!fileId || (entityType !== 'APPLICATION' && entityType !== 'PROTOCOL')) && (
+                {!showRole && !hasFileStats && (
                   <p className="text-muted small fst-italic">
                     No per-file stats available in this context.
                   </p>
@@ -732,172 +160,33 @@ export function EntityDetailModal({
                   </div>
                 )}
 
-                {/* ── Snapshot History (IP + snapshots) or Capture History (generic) ── */}
-                {entityType === 'IP' && snapshots && snapshots.length > 0 ? (
-                  <div className="mt-4">
-                    <h6 className="text-muted fw-semibold mb-2">
-                      <i className="bi bi-clock-history me-1" />Snapshot History
-                    </h6>
-                    {ipHistoryLoading && (
-                      <div className="text-muted small py-2">
-                        <span className="spinner-border spinner-border-sm me-2" role="status" />Loading…
-                      </div>
-                    )}
-                    {!ipHistoryLoading && ipSnapHistory.length === 0 && (
-                      <p className="text-muted small fst-italic">Not seen in any snapshots.</p>
-                    )}
-                    {!ipHistoryLoading && ipSnapHistory.length > 0 && (
-                      <div className="table-responsive rounded border overflow-hidden">
-                        <table className="table table-sm table-hover mb-0">
-                          <thead className="table-light" style={{ fontSize: '0.8rem' }}>
-                            <tr>
-                              <th className="text-muted fw-normal">#</th>
-                              <th className="text-muted fw-normal">Snapshot</th>
-                              <th className="text-muted fw-normal">MAC Address</th>
-                              <th className="text-muted fw-normal">Manufacturer</th>
-                              <th className="text-muted fw-normal">Device Type</th>
-                              <th className="text-muted fw-normal">Protocols / Apps</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {ipSnapHistory.map(({ snap, host, protocols, apps }, idx) => (
-                              <tr key={snap.id}>
-                                <td><small className="text-muted">{snap.snapshotOrder + 1}</small></td>
-                                <td>
-                                  <small className="text-muted d-block">{formatSnapTime(snap)}</small>
-                                  <small className="text-muted text-break" style={{ fontSize: '0.7rem' }}>{snap.fileName}</small>
-                                </td>
-                                <td>
-                                  <code style={{ fontSize: '0.75rem' }}>{host?.mac ?? '—'}</code>
-                                  {idx > 0 && host?.mac && ipSnapHistory[idx - 1].host?.mac &&
-                                    host.mac !== ipSnapHistory[idx - 1].host!.mac && (
-                                      <Badge bg="warning" text="dark" className="ms-1" style={{ fontSize: '0.65rem' }}>changed</Badge>
-                                    )}
-                                </td>
-                                <td><small className="text-muted">{host?.manufacturer ?? '—'}</small></td>
-                                <td><small className="text-muted">{host?.deviceType ?? '—'}</small></td>
-                                <td>
-                                  {protocols.length === 0 && apps.length === 0 ? (
-                                    <small className="text-muted">—</small>
-                                  ) : (
-                                    <div className="d-flex flex-wrap gap-1">
-                                      {protocols.map(p => (
-                                        <Badge key={p} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(p) }}>{p}</Badge>
-                                      ))}
-                                      {apps.map(a => (
-                                        <Badge key={a} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(a) }}>{a}</Badge>
-                                      ))}
-                                    </div>
-                                  )}
-                                </td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                    )}
-                  </div>
+                {showSnapshotHistory ? (
+                  <SnapshotHistoryTable ipSnapHistory={ipSnapHistory} ipHistoryLoading={ipHistoryLoading} />
                 ) : (
-                  <div className="mt-4">
-                    <h6 className="text-muted fw-semibold mb-2">
-                      <i className="bi bi-clock-history me-1" />Capture History
-                    </h6>
-                    {historyLoading && (
-                      <div className="text-muted small py-2">
-                        <span className="spinner-border spinner-border-sm me-2" role="status" />Loading…
-                      </div>
-                    )}
-                    {historyError && (
-                      <div className="alert alert-warning py-2 small">{historyError}</div>
-                    )}
-                    {!historyLoading && !historyError && history.length === 0 && (
-                      <p className="text-muted small fst-italic">Not seen in any uploaded files.</p>
-                    )}
-                    {!historyLoading && history.length > 0 && (
-                      <div className="table-responsive rounded border overflow-hidden">
-                        <table className="table table-sm table-hover mb-0">
-                          <thead className="table-light" style={{ fontSize: '0.8rem' }}>
-                            <tr>
-                              <th className="text-muted fw-normal">File</th>
-                              <th className="text-muted fw-normal">Capture Start</th>
-                              <th className="text-end text-muted fw-normal">Packets</th>
-                              <th className="text-end text-muted fw-normal">Bytes</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {history.map(entry => (
-                              <tr
-                                key={entry.fileId}
-                                style={{ cursor: 'pointer' }}
-                                onClick={() => { onClose(); navigate(`/analysis/${entry.fileId}`); }}
-                                title="Open in analysis"
-                              >
-                                <td className="small">{entry.fileName}</td>
-                                <td className="small text-muted">
-                                  {entry.startTime ? new Date(entry.startTime).toLocaleString('en-GB') : '—'}
-                                </td>
-                                <td className="text-end small text-muted">
-                                  {entry.packetCount != null ? formatNumber(entry.packetCount) : '—'}
-                                </td>
-                                <td className="text-end small text-muted">
-                                  {entry.totalBytes != null ? formatBytes(entry.totalBytes) : '—'}
-                                </td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                    )}
-                  </div>
+                  <CaptureHistoryTable
+                    history={history}
+                    historyLoading={historyLoading}
+                    historyError={historyError}
+                    onClose={onClose}
+                  />
                 )}
               </div>
             )}
 
             {/* ── NOTES TAB ────────────────────────────────────────── */}
             {activeTab === 'notes' && (
-              <div>
-                <p className="text-muted small mb-2">
-                  Notes are saved globally for this {entityLabel} and persist across all captures.
-                </p>
-                <textarea
-                  className="form-control mb-2"
-                  rows={6}
-                  style={{ fontSize: '0.875rem' }}
-                  placeholder={`Add notes about ${displayName}…`}
-                  value={noteText}
-                  onChange={e => setNoteText(e.target.value)}
-                />
-                {savedNote && (
-                  <p className="text-muted" style={{ fontSize: '0.7rem' }}>
-                    Last updated: {new Date(savedNote.updatedAt).toLocaleString('en-GB')}
-                  </p>
-                )}
-                <div className="d-flex gap-2">
-                  <button
-                    className="btn btn-primary btn-sm"
-                    onClick={handleSaveNote}
-                    disabled={noteSaving || !noteChanged}
-                  >
-                    {noteSaving ? (
-                      <><span className="spinner-border spinner-border-sm me-1" role="status" />Saving…</>
-                    ) : (
-                      <><i className="bi bi-floppy me-1" />Save Note</>
-                    )}
-                  </button>
-                  {savedNote && (
-                    <button
-                      className="btn btn-outline-danger btn-sm"
-                      onClick={handleDeleteNote}
-                      disabled={noteDeleting}
-                    >
-                      {noteDeleting
-                        ? <span className="spinner-border spinner-border-sm" role="status" />
-                        : <><i className="bi bi-trash me-1" />Delete</>
-                      }
-                    </button>
-                  )}
-                </div>
-              </div>
+              <NotesTab
+                entityLabel={entityLabel}
+                displayName={displayName}
+                noteText={note.noteText}
+                setNoteText={note.setNoteText}
+                savedNote={note.savedNote}
+                noteSaving={note.noteSaving}
+                noteDeleting={note.noteDeleting}
+                noteChanged={note.noteChanged}
+                onSave={note.save}
+                onDelete={note.remove}
+              />
             )}
           </div>
         </div>

--- a/frontend/src/components/common/EntityDetailModal/format.ts
+++ b/frontend/src/components/common/EntityDetailModal/format.ts
@@ -17,7 +17,7 @@ export function formatNumber(num: number): string {
 
 export function formatSnapTime(snap: NetworkSnapshot): string {
   if (!snap.startTime) return snap.fileName;
-  const ms = parseDateTime(snap.startTime as unknown as string | number[]);
+  const ms = parseDateTime(snap.startTime);
   return new Date(ms).toLocaleDateString('en-GB', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 

--- a/frontend/src/components/common/EntityDetailModal/format.ts
+++ b/frontend/src/components/common/EntityDetailModal/format.ts
@@ -1,0 +1,37 @@
+import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
+import { parseDateTime } from '@/utils/dateUtils';
+
+// NOTE: these mirror utils/formatters but keep this modal's historical formatting
+// (2-decimal bytes, default-locale numbers). Reconciled separately in the helper-dedup slice.
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
+}
+
+export function formatNumber(num: number): string {
+  return num.toLocaleString();
+}
+
+export function formatSnapTime(snap: NetworkSnapshot): string {
+  if (!snap.startTime) return snap.fileName;
+  const ms = parseDateTime(snap.startTime as unknown as string | number[]);
+  return new Date(ms).toLocaleDateString('en-GB', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export function stringHue(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) & 0xffffffff;
+  return Math.abs(h) % 360;
+}
+
+export function hashBadgeStyle(s: string) {
+  const hue = stringHue(s);
+  return {
+    background: `hsl(${hue}, 40%, 88%)`,
+    color: `hsl(${hue}, 50%, 28%)`,
+    border: `1px solid hsl(${hue}, 35%, 72%)`,
+  };
+}

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityHistory.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityHistory.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import {
+  entityNotesService,
+  type EntityHistoryEntry,
+  type EntityType,
+} from '@/features/notes/services/entityNotesService';
+
+/**
+ * Capture history: which uploaded files this entity appeared in.
+ */
+export function useEntityHistory(entityType: EntityType, entityKey: string) {
+  const [history, setHistory] = useState<EntityHistoryEntry[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (history.length > 0 || historyLoading) return;
+    setHistoryLoading(true);
+    setHistoryError(null);
+    entityNotesService
+      .getHistory(entityType, entityKey)
+      .then(entries => setHistory(entries))
+      .catch(() => setHistoryError('Failed to load history'))
+      .finally(() => setHistoryLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entityType, entityKey]);
+
+  return { history, historyLoading, historyError };
+}

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityHistory.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityHistory.ts
@@ -14,15 +14,17 @@ export function useEntityHistory(entityType: EntityType, entityKey: string) {
   const [historyError, setHistoryError] = useState<string | null>(null);
 
   useEffect(() => {
+    let active = true;
     // Reset so a previous entity's history can't leak when the modal is reused.
     setHistory([]);
     setHistoryLoading(true);
     setHistoryError(null);
     entityNotesService
       .getHistory(entityType, entityKey)
-      .then(entries => setHistory(entries))
-      .catch(() => setHistoryError('Failed to load history'))
-      .finally(() => setHistoryLoading(false));
+      .then(entries => { if (active) setHistory(entries); })
+      .catch(() => { if (active) setHistoryError('Failed to load history'); })
+      .finally(() => { if (active) setHistoryLoading(false); });
+    return () => { active = false; };
   }, [entityType, entityKey]);
 
   return { history, historyLoading, historyError };

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityHistory.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityHistory.ts
@@ -14,7 +14,8 @@ export function useEntityHistory(entityType: EntityType, entityKey: string) {
   const [historyError, setHistoryError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (history.length > 0 || historyLoading) return;
+    // Reset so a previous entity's history can't leak when the modal is reused.
+    setHistory([]);
     setHistoryLoading(true);
     setHistoryError(null);
     entityNotesService
@@ -22,7 +23,6 @@ export function useEntityHistory(entityType: EntityType, entityKey: string) {
       .then(entries => setHistory(entries))
       .catch(() => setHistoryError('Failed to load history'))
       .finally(() => setHistoryLoading(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entityType, entityKey]);
 
   return { history, historyLoading, historyError };

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityNote.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityNote.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import {
+  entityNotesService,
+  type EntityNote,
+  type EntityType,
+} from '@/features/notes/services/entityNotesService';
+
+/**
+ * Global per-entity note: load on mount, edit draft, save, delete.
+ */
+export function useEntityNote(entityType: EntityType, entityKey: string) {
+  const [noteText, setNoteText] = useState('');
+  const [savedNote, setSavedNote] = useState<EntityNote | null>(null);
+  const [noteSaving, setNoteSaving] = useState(false);
+  const [noteDeleting, setNoteDeleting] = useState(false);
+
+  useEffect(() => {
+    entityNotesService.getNote(entityType, entityKey).then(note => {
+      if (note) { setSavedNote(note); setNoteText(note.note); }
+    });
+  }, [entityType, entityKey]);
+
+  const save = async () => {
+    setNoteSaving(true);
+    try {
+      const updated = await entityNotesService.upsertNote(entityType, entityKey, noteText);
+      setSavedNote(updated);
+    } finally { setNoteSaving(false); }
+  };
+
+  const remove = async () => {
+    setNoteDeleting(true);
+    try {
+      await entityNotesService.deleteNote(entityType, entityKey);
+      setSavedNote(null);
+      setNoteText('');
+    } finally { setNoteDeleting(false); }
+  };
+
+  const noteChanged = noteText !== (savedNote?.note ?? '');
+
+  return { noteText, setNoteText, savedNote, noteSaving, noteDeleting, noteChanged, save, remove };
+}

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityNote.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityNote.ts
@@ -15,12 +15,14 @@ export function useEntityNote(entityType: EntityType, entityKey: string) {
   const [noteDeleting, setNoteDeleting] = useState(false);
 
   useEffect(() => {
+    let active = true;
     // Reset so a previous entity's note can't leak when the modal is reused.
     setSavedNote(null);
     setNoteText('');
     entityNotesService.getNote(entityType, entityKey).then(note => {
-      if (note) { setSavedNote(note); setNoteText(note.note); }
+      if (active && note) { setSavedNote(note); setNoteText(note.note); }
     });
+    return () => { active = false; };
   }, [entityType, entityKey]);
 
   const save = async () => {

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityNote.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityNote.ts
@@ -15,6 +15,9 @@ export function useEntityNote(entityType: EntityType, entityKey: string) {
   const [noteDeleting, setNoteDeleting] = useState(false);
 
   useEffect(() => {
+    // Reset so a previous entity's note can't leak when the modal is reused.
+    setSavedNote(null);
+    setNoteText('');
     entityNotesService.getNote(entityType, entityKey).then(note => {
       if (note) { setSavedNote(note); setNoteText(note.note); }
     });

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityNote.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityNote.ts
@@ -19,9 +19,11 @@ export function useEntityNote(entityType: EntityType, entityKey: string) {
     // Reset so a previous entity's note can't leak when the modal is reused.
     setSavedNote(null);
     setNoteText('');
-    entityNotesService.getNote(entityType, entityKey).then(note => {
-      if (active && note) { setSavedNote(note); setNoteText(note.note); }
-    });
+    entityNotesService.getNote(entityType, entityKey)
+      .then(note => {
+        if (active && note) { setSavedNote(note); setNoteText(note.note); }
+      })
+      .catch(err => { console.error('Failed to fetch entity note:', err); });
     return () => { active = false; };
   }, [entityType, entityKey]);
 
@@ -30,6 +32,8 @@ export function useEntityNote(entityType: EntityType, entityKey: string) {
     try {
       const updated = await entityNotesService.upsertNote(entityType, entityKey, noteText);
       setSavedNote(updated);
+    } catch (err) {
+      console.error('Failed to save note:', err);
     } finally { setNoteSaving(false); }
   };
 
@@ -39,6 +43,8 @@ export function useEntityNote(entityType: EntityType, entityKey: string) {
       await entityNotesService.deleteNote(entityType, entityKey);
       setSavedNote(null);
       setNoteText('');
+    } catch (err) {
+      console.error('Failed to delete note:', err);
     } finally { setNoteDeleting(false); }
   };
 

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityRole.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityRole.ts
@@ -20,6 +20,11 @@ export function useEntityRole(entityType: EntityType, entityKey: string, fileId:
 
   // Load node role on mount for IP/DEVICE
   useEffect(() => {
+    // Reset so a previous entity's role/drafts can't leak when the modal is reused.
+    setRole(null);
+    setRoleLabelDraft('');
+    setRoleDescDraft('');
+    setRoleEditing(false);
     if (!showRole) return;
     setRoleLoading(true);
     insightsService

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityRole.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityRole.ts
@@ -21,16 +21,21 @@ export function useEntityRole(entityType: EntityType, entityKey: string, fileId:
   // Load node role on mount for IP/DEVICE
   useEffect(() => {
     let active = true;
-    // Reset so a previous entity's role/drafts can't leak when the modal is reused.
+    // Reset all transient role state so nothing leaks when the modal is reused.
     setRole(null);
     setRoleLabelDraft('');
     setRoleDescDraft('');
     setRoleEditing(false);
-    if (!showRole) return;
+    setRoleSuggesting(false);
+    setRoleSuggestError(null);
+    setRoleSaving(false);
+    setRoleInfoOpen(false);
+    if (!showRole) { setRoleLoading(false); return; }
     setRoleLoading(true);
     insightsService
       .getNodeRole(entityType, entityKey)
       .then(r => { if (active) setRole(r); })
+      .catch(err => { console.error('Failed to fetch node role:', err); })
       .finally(() => { if (active) setRoleLoading(false); });
     return () => { active = false; };
   }, [showRole, entityType, entityKey]);
@@ -62,6 +67,8 @@ export function useEntityRole(entityType: EntityType, entityKey: string, fileId:
         true,
       );
       setRole(updated);
+    } catch (err) {
+      console.error('Failed to accept role:', err);
     } finally {
       setRoleSaving(false);
     }
@@ -72,6 +79,8 @@ export function useEntityRole(entityType: EntityType, entityKey: string, fileId:
     try {
       await insightsService.deleteNodeRole(entityType, entityKey);
       setRole(null);
+    } catch (err) {
+      console.error('Failed to discard role:', err);
     } finally {
       setRoleSaving(false);
     }
@@ -95,6 +104,8 @@ export function useEntityRole(entityType: EntityType, entityKey: string, fileId:
       );
       setRole(updated);
       setRoleEditing(false);
+    } catch (err) {
+      console.error('Failed to save role:', err);
     } finally {
       setRoleSaving(false);
     }

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityRole.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityRole.ts
@@ -20,6 +20,7 @@ export function useEntityRole(entityType: EntityType, entityKey: string, fileId:
 
   // Load node role on mount for IP/DEVICE
   useEffect(() => {
+    let active = true;
     // Reset so a previous entity's role/drafts can't leak when the modal is reused.
     setRole(null);
     setRoleLabelDraft('');
@@ -29,8 +30,9 @@ export function useEntityRole(entityType: EntityType, entityKey: string, fileId:
     setRoleLoading(true);
     insightsService
       .getNodeRole(entityType, entityKey)
-      .then(r => setRole(r))
-      .finally(() => setRoleLoading(false));
+      .then(r => { if (active) setRole(r); })
+      .finally(() => { if (active) setRoleLoading(false); });
+    return () => { active = false; };
   }, [showRole, entityType, entityKey]);
 
   const suggest = async () => {

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityRole.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityRole.ts
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+import { insightsService } from '@/features/insights/services/insightsService';
+import type { NodeRole } from '@/features/insights/types/insights.types';
+import type { EntityType } from '@/features/notes/services/entityNotesService';
+
+/**
+ * Node role state + actions for IP/DEVICE entities (load, AI suggest, accept,
+ * discard, manual edit/save).
+ */
+export function useEntityRole(entityType: EntityType, entityKey: string, fileId: string, showRole: boolean) {
+  const [role, setRole] = useState<NodeRole | null>(null);
+  const [roleLoading, setRoleLoading] = useState(false);
+  const [roleSuggesting, setRoleSuggesting] = useState(false);
+  const [roleSuggestError, setRoleSuggestError] = useState<string | null>(null);
+  const [roleInfoOpen, setRoleInfoOpen] = useState(false);
+  const [roleEditing, setRoleEditing] = useState(false);
+  const [roleLabelDraft, setRoleLabelDraft] = useState('');
+  const [roleDescDraft, setRoleDescDraft] = useState('');
+  const [roleSaving, setRoleSaving] = useState(false);
+
+  // Load node role on mount for IP/DEVICE
+  useEffect(() => {
+    if (!showRole) return;
+    setRoleLoading(true);
+    insightsService
+      .getNodeRole(entityType, entityKey)
+      .then(r => setRole(r))
+      .finally(() => setRoleLoading(false));
+  }, [showRole, entityType, entityKey]);
+
+  const suggest = async () => {
+    if (!fileId) return;
+    setRoleSuggesting(true);
+    setRoleSuggestError(null);
+    try {
+      const suggested = await insightsService.suggestNodeRole(entityType, entityKey, fileId);
+      setRole(suggested);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Suggestion failed.';
+      setRoleSuggestError(msg);
+    } finally {
+      setRoleSuggesting(false);
+    }
+  };
+
+  const accept = async () => {
+    if (!role) return;
+    setRoleSaving(true);
+    try {
+      const updated = await insightsService.upsertNodeRole(
+        entityType,
+        entityKey,
+        role.roleLabel ?? '',
+        role.roleDescription ?? '',
+        true,
+      );
+      setRole(updated);
+    } finally {
+      setRoleSaving(false);
+    }
+  };
+
+  const discard = async () => {
+    setRoleSaving(true);
+    try {
+      await insightsService.deleteNodeRole(entityType, entityKey);
+      setRole(null);
+    } finally {
+      setRoleSaving(false);
+    }
+  };
+
+  const openEdit = () => {
+    setRoleLabelDraft(role?.roleLabel ?? '');
+    setRoleDescDraft(role?.roleDescription ?? '');
+    setRoleEditing(true);
+  };
+
+  const save = async () => {
+    setRoleSaving(true);
+    try {
+      const updated = await insightsService.upsertNodeRole(
+        entityType,
+        entityKey,
+        roleLabelDraft,
+        roleDescDraft,
+        true,
+      );
+      setRole(updated);
+      setRoleEditing(false);
+    } finally {
+      setRoleSaving(false);
+    }
+  };
+
+  return {
+    role,
+    roleLoading,
+    roleSuggesting,
+    roleSuggestError,
+    roleInfoOpen,
+    setRoleInfoOpen,
+    roleEditing,
+    setRoleEditing,
+    roleLabelDraft,
+    setRoleLabelDraft,
+    roleDescDraft,
+    setRoleDescDraft,
+    roleSaving,
+    suggest,
+    accept,
+    discard,
+    openEdit,
+    save,
+  };
+}

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
@@ -25,6 +25,7 @@ export function useEntityStats(entityType: EntityType, entityKey: string, fileId
   const [statsError, setStatsError] = useState<string | null>(null);
 
   useEffect(() => {
+    let active = true;
     // Reset so a previous entity's stats can't leak when the modal is reused.
     setStats(null);
     if (!fileId || (entityType !== 'APPLICATION' && entityType !== 'PROTOCOL')) return;
@@ -34,6 +35,7 @@ export function useEntityStats(entityType: EntityType, entityKey: string, fileId
     apiClient
       .get<ConvApiResponse>(`/conversations/${fileId}?${param}&pageSize=500&page=1`)
       .then(res => {
+        if (!active) return;
         const rows = res.data.data;
         const total = res.data.total;
         const packets = rows.reduce((s, r) => s + r.packetCount, 0);
@@ -50,8 +52,9 @@ export function useEntityStats(entityType: EntityType, entityKey: string, fileId
           .map(([ip, b]) => ({ ip, bytes: b }));
         setStats({ conversationCount: total, packetCount: packets, totalBytes: bytes, topPeers });
       })
-      .catch(() => setStatsError('Failed to load details'))
-      .finally(() => setStatsLoading(false));
+      .catch(() => { if (active) setStatsError('Failed to load details'); })
+      .finally(() => { if (active) setStatsLoading(false); });
+    return () => { active = false; };
   }, [fileId, entityType, entityKey]);
 
   return { stats, statsLoading, statsError };

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
@@ -25,6 +25,8 @@ export function useEntityStats(entityType: EntityType, entityKey: string, fileId
   const [statsError, setStatsError] = useState<string | null>(null);
 
   useEffect(() => {
+    // Reset so a previous entity's stats can't leak when the modal is reused.
+    setStats(null);
     if (!fileId || (entityType !== 'APPLICATION' && entityType !== 'PROTOCOL')) return;
     setStatsLoading(true);
     setStatsError(null);

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/services/api/client';
+import type { EntityType } from '@/features/notes/services/entityNotesService';
+import type { EntityStats } from '../types';
+
+interface ConvRow {
+  srcIp: string;
+  dstIp: string;
+  packetCount: number;
+  totalBytes: number;
+}
+
+interface ConvApiResponse {
+  data: ConvRow[];
+  total: number;
+}
+
+/**
+ * Aggregate stats (conversation/packet/byte totals + top peer IPs) for
+ * APPLICATION/PROTOCOL entities, derived from the conversations API.
+ */
+export function useEntityStats(entityType: EntityType, entityKey: string, fileId: string) {
+  const [stats, setStats] = useState<EntityStats | null>(null);
+  const [statsLoading, setStatsLoading] = useState(false);
+  const [statsError, setStatsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!fileId || (entityType !== 'APPLICATION' && entityType !== 'PROTOCOL')) return;
+    setStatsLoading(true);
+    setStatsError(null);
+    const param = entityType === 'APPLICATION' ? `apps=${encodeURIComponent(entityKey)}` : `l7Protocols=${encodeURIComponent(entityKey)}`;
+    apiClient
+      .get<ConvApiResponse>(`/conversations/${fileId}?${param}&pageSize=500&page=1`)
+      .then(res => {
+        const rows = res.data.data;
+        const total = res.data.total;
+        const packets = rows.reduce((s, r) => s + r.packetCount, 0);
+        const bytes = rows.reduce((s, r) => s + r.totalBytes, 0);
+        // Aggregate bytes per peer IP
+        const peerBytes = new Map<string, number>();
+        for (const r of rows) {
+          peerBytes.set(r.srcIp, (peerBytes.get(r.srcIp) ?? 0) + r.totalBytes);
+          peerBytes.set(r.dstIp, (peerBytes.get(r.dstIp) ?? 0) + r.totalBytes);
+        }
+        const topPeers = Array.from(peerBytes.entries())
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 10)
+          .map(([ip, b]) => ({ ip, bytes: b }));
+        setStats({ conversationCount: total, packetCount: packets, totalBytes: bytes, topPeers });
+      })
+      .catch(() => setStatsError('Failed to load details'))
+      .finally(() => setStatsLoading(false));
+  }, [fileId, entityType, entityKey]);
+
+  return { stats, statsLoading, statsError };
+}

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
@@ -26,11 +26,12 @@ export function useEntityStats(entityType: EntityType, entityKey: string, fileId
 
   useEffect(() => {
     let active = true;
-    // Reset so a previous entity's stats can't leak when the modal is reused.
+    // Reset so a previous entity's stats/flags can't leak when the modal is reused.
     setStats(null);
+    setStatsLoading(false);
+    setStatsError(null);
     if (!fileId || (entityType !== 'APPLICATION' && entityType !== 'PROTOCOL')) return;
     setStatsLoading(true);
-    setStatsError(null);
     const param = entityType === 'APPLICATION' ? `apps=${encodeURIComponent(entityKey)}` : `l7Protocols=${encodeURIComponent(entityKey)}`;
     apiClient
       .get<ConvApiResponse>(`/conversations/${fileId}?${param}&pageSize=500&page=1`)

--- a/frontend/src/components/common/EntityDetailModal/hooks/useHostClassification.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useHostClassification.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/services/api/client';
+import type { EntityType } from '@/features/notes/services/entityNotesService';
+import type { HostClassification } from '../types';
+
+/**
+ * Host classification signals (manufacturer/device type/TTL/confidence) for an IP
+ * in the current file.
+ */
+export function useHostClassification(entityType: EntityType, entityKey: string, fileId: string) {
+  const [hostClass, setHostClass] = useState<HostClassification | null>(null);
+
+  useEffect(() => {
+    if (entityType !== 'IP' || !fileId) return;
+    apiClient
+      .get<HostClassification[]>(`/files/${fileId}/host-classifications`)
+      .then(r => {
+        const match = r.data.find(h => h.ip === entityKey);
+        setHostClass(match ?? null);
+      })
+      .catch(() => {});
+  }, [entityType, entityKey, fileId]);
+
+  return hostClass;
+}

--- a/frontend/src/components/common/EntityDetailModal/hooks/useHostClassification.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useHostClassification.ts
@@ -11,6 +11,8 @@ export function useHostClassification(entityType: EntityType, entityKey: string,
   const [hostClass, setHostClass] = useState<HostClassification | null>(null);
 
   useEffect(() => {
+    // Reset so a previous entity's classification can't leak when the modal is reused.
+    setHostClass(null);
     if (entityType !== 'IP' || !fileId) return;
     apiClient
       .get<HostClassification[]>(`/files/${fileId}/host-classifications`)

--- a/frontend/src/components/common/EntityDetailModal/hooks/useHostClassification.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useHostClassification.ts
@@ -11,16 +11,19 @@ export function useHostClassification(entityType: EntityType, entityKey: string,
   const [hostClass, setHostClass] = useState<HostClassification | null>(null);
 
   useEffect(() => {
+    let active = true;
     // Reset so a previous entity's classification can't leak when the modal is reused.
     setHostClass(null);
     if (entityType !== 'IP' || !fileId) return;
     apiClient
       .get<HostClassification[]>(`/files/${fileId}/host-classifications`)
       .then(r => {
+        if (!active) return;
         const match = r.data.find(h => h.ip === entityKey);
         setHostClass(match ?? null);
       })
       .catch(() => {});
+    return () => { active = false; };
   }, [entityType, entityKey, fileId]);
 
   return hostClass;

--- a/frontend/src/components/common/EntityDetailModal/hooks/useIpSnapshotHistory.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useIpSnapshotHistory.ts
@@ -13,7 +13,11 @@ export function useIpSnapshotHistory(entityType: EntityType, entityKey: string, 
   const [ipHistoryLoading, setIpHistoryLoading] = useState(false);
 
   useEffect(() => {
+    // Reset so a previous entity's history can't leak when the modal is reused.
+    setIpSnapHistory([]);
     if (entityType !== 'IP' || !snapshots || snapshots.length === 0) return;
+    // `active` guards against stale responses applying after the entity changes/unmounts.
+    let active = true;
     setIpHistoryLoading(true);
     const sorted = [...snapshots].sort((a, b) => a.snapshotOrder - b.snapshotOrder);
     Promise.all(
@@ -24,6 +28,7 @@ export function useIpSnapshotHistory(entityType: EntityType, entityKey: string, 
           .catch(() => ({ snap, host: null }))
       )
     ).then(results => {
+      if (!active) return;
       // Only keep snapshots where this IP appeared
       const seen = results.filter(r => r.host !== null);
       if (seen.length === 0) { setIpSnapHistory([]); setIpHistoryLoading(false); return; }
@@ -42,8 +47,13 @@ export function useIpSnapshotHistory(entityType: EntityType, entityKey: string, 
             }))
             .catch(() => ({ snap, host, apps: [], protocols: [] }))
         )
-      ).then(entries => { setIpSnapHistory(entries); setIpHistoryLoading(false); });
-    }).catch(() => setIpHistoryLoading(false));
+      ).then(entries => {
+        if (!active) return;
+        setIpSnapHistory(entries);
+        setIpHistoryLoading(false);
+      });
+    }).catch(() => { if (active) setIpHistoryLoading(false); });
+    return () => { active = false; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entityType, entityKey, snapshots?.map(s => s.id).join(',')]);
 

--- a/frontend/src/components/common/EntityDetailModal/hooks/useIpSnapshotHistory.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useIpSnapshotHistory.ts
@@ -55,7 +55,7 @@ export function useIpSnapshotHistory(entityType: EntityType, entityKey: string, 
     }).catch(() => { if (active) setIpHistoryLoading(false); });
     return () => { active = false; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entityType, entityKey, snapshots?.map(s => s.id).join(',')]);
+  }, [entityType, entityKey, snapshots?.map(s => s.id)?.join(',')]);
 
   return { ipSnapHistory, ipHistoryLoading };
 }

--- a/frontend/src/components/common/EntityDetailModal/hooks/useIpSnapshotHistory.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useIpSnapshotHistory.ts
@@ -15,6 +15,7 @@ export function useIpSnapshotHistory(entityType: EntityType, entityKey: string, 
   useEffect(() => {
     // Reset so a previous entity's history can't leak when the modal is reused.
     setIpSnapHistory([]);
+    setIpHistoryLoading(false);
     if (entityType !== 'IP' || !snapshots || snapshots.length === 0) return;
     // `active` guards against stale responses applying after the entity changes/unmounts.
     let active = true;

--- a/frontend/src/components/common/EntityDetailModal/hooks/useIpSnapshotHistory.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useIpSnapshotHistory.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/services/api/client';
+import type { EntityType } from '@/features/notes/services/entityNotesService';
+import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
+import type { HostClassification, IpSnapshotEntry } from '../types';
+
+/**
+ * Per-snapshot MAC/device/protocol history for an IP across a Monitor network's
+ * snapshots (only the snapshots where the IP actually appeared).
+ */
+export function useIpSnapshotHistory(entityType: EntityType, entityKey: string, snapshots?: NetworkSnapshot[]) {
+  const [ipSnapHistory, setIpSnapHistory] = useState<IpSnapshotEntry[]>([]);
+  const [ipHistoryLoading, setIpHistoryLoading] = useState(false);
+
+  useEffect(() => {
+    if (entityType !== 'IP' || !snapshots || snapshots.length === 0) return;
+    setIpHistoryLoading(true);
+    const sorted = [...snapshots].sort((a, b) => a.snapshotOrder - b.snapshotOrder);
+    Promise.all(
+      sorted.map(snap =>
+        apiClient
+          .get<HostClassification[]>(`/files/${snap.fileId}/host-classifications`)
+          .then(r => ({ snap, host: r.data.find(h => h.ip === entityKey) ?? null }))
+          .catch(() => ({ snap, host: null }))
+      )
+    ).then(results => {
+      // Only keep snapshots where this IP appeared
+      const seen = results.filter(r => r.host !== null);
+      if (seen.length === 0) { setIpSnapHistory([]); setIpHistoryLoading(false); return; }
+      // Fetch conversations for protocols/apps per seen snapshot
+      return Promise.all(
+        seen.map(({ snap, host }) =>
+          apiClient
+            .get<{ data: { appName: string | null; tsharkProtocol: string | null }[] }>(
+              `/conversations/${snap.fileId}?ip=${encodeURIComponent(entityKey)}&pageSize=10000`
+            )
+            .then(r => ({
+              snap,
+              host,
+              apps: [...new Set(r.data.data.map(c => c.appName).filter(Boolean) as string[])].sort(),
+              protocols: [...new Set(r.data.data.map(c => c.tsharkProtocol).filter(Boolean) as string[])].sort(),
+            }))
+            .catch(() => ({ snap, host, apps: [], protocols: [] }))
+        )
+      ).then(entries => { setIpSnapHistory(entries); setIpHistoryLoading(false); });
+    }).catch(() => setIpHistoryLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entityType, entityKey, snapshots?.map(s => s.id).join(',')]);
+
+  return { ipSnapHistory, ipHistoryLoading };
+}

--- a/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
@@ -1,0 +1,68 @@
+import { useNavigate } from 'react-router-dom';
+import type { EntityHistoryEntry } from '@/features/notes/services/entityNotesService';
+import { formatBytes, formatNumber } from '../format';
+
+interface CaptureHistoryTableProps {
+  history: EntityHistoryEntry[];
+  historyLoading: boolean;
+  historyError: string | null;
+  onClose: () => void;
+}
+
+/** Generic capture history: which uploaded files this entity appeared in. */
+export function CaptureHistoryTable({ history, historyLoading, historyError, onClose }: CaptureHistoryTableProps) {
+  const navigate = useNavigate();
+  return (
+    <div className="mt-4">
+      <h6 className="text-muted fw-semibold mb-2">
+        <i className="bi bi-clock-history me-1" />Capture History
+      </h6>
+      {historyLoading && (
+        <div className="text-muted small py-2">
+          <span className="spinner-border spinner-border-sm me-2" role="status" />Loading…
+        </div>
+      )}
+      {historyError && (
+        <div className="alert alert-warning py-2 small">{historyError}</div>
+      )}
+      {!historyLoading && !historyError && history.length === 0 && (
+        <p className="text-muted small fst-italic">Not seen in any uploaded files.</p>
+      )}
+      {!historyLoading && history.length > 0 && (
+        <div className="table-responsive rounded border overflow-hidden">
+          <table className="table table-sm table-hover mb-0">
+            <thead className="table-light" style={{ fontSize: '0.8rem' }}>
+              <tr>
+                <th className="text-muted fw-normal">File</th>
+                <th className="text-muted fw-normal">Capture Start</th>
+                <th className="text-end text-muted fw-normal">Packets</th>
+                <th className="text-end text-muted fw-normal">Bytes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map(entry => (
+                <tr
+                  key={entry.fileId}
+                  style={{ cursor: 'pointer' }}
+                  onClick={() => { onClose(); navigate(`/analysis/${entry.fileId}`); }}
+                  title="Open in analysis"
+                >
+                  <td className="small">{entry.fileName}</td>
+                  <td className="small text-muted">
+                    {entry.startTime ? new Date(entry.startTime).toLocaleString('en-GB') : '—'}
+                  </td>
+                  <td className="text-end small text-muted">
+                    {entry.packetCount != null ? formatNumber(entry.packetCount) : '—'}
+                  </td>
+                  <td className="text-end small text-muted">
+                    {entry.totalBytes != null ? formatBytes(entry.totalBytes) : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
@@ -28,7 +28,7 @@ export function CaptureHistoryTable({ history, historyLoading, historyError, onC
       {!historyLoading && !historyError && history.length === 0 && (
         <p className="text-muted small fst-italic">Not seen in any uploaded files.</p>
       )}
-      {!historyLoading && history.length > 0 && (
+      {!historyLoading && !historyError && history.length > 0 && (
         <div className="table-responsive rounded border overflow-hidden">
           <table className="table table-sm table-hover mb-0">
             <thead className="table-light" style={{ fontSize: '0.8rem' }}>
@@ -44,7 +44,16 @@ export function CaptureHistoryTable({ history, historyLoading, historyError, onC
                 <tr
                   key={entry.fileId}
                   style={{ cursor: 'pointer' }}
+                  role="button"
+                  tabIndex={0}
                   onClick={() => { onClose(); navigate(`/analysis/${entry.fileId}`); }}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      onClose();
+                      navigate(`/analysis/${entry.fileId}`);
+                    }
+                  }}
                   title="Open in analysis"
                 >
                   <td className="small">{entry.fileName}</td>

--- a/frontend/src/components/common/EntityDetailModal/sections/EntityStatsSection.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/EntityStatsSection.tsx
@@ -1,0 +1,75 @@
+import { formatBytes, formatNumber } from '../format';
+import type { EntityStats } from '../types';
+
+interface EntityStatsSectionProps {
+  stats: EntityStats | null;
+  statsLoading: boolean;
+  statsError: string | null;
+  onSelectPeer: (ip: string) => void;
+}
+
+/** Aggregate stats + top-peer table for APPLICATION/PROTOCOL entities. */
+export function EntityStatsSection({ stats, statsLoading, statsError, onSelectPeer }: EntityStatsSectionProps) {
+  return (
+    <>
+      {statsLoading && (
+        <div className="text-center py-4">
+          <div className="spinner-border spinner-border-sm text-primary" role="status" />
+          <p className="text-muted mt-2 small">Loading stats…</p>
+        </div>
+      )}
+      {statsError && (
+        <div className="alert alert-warning py-2 small">{statsError}</div>
+      )}
+      {!statsLoading && !statsError && stats && (
+        <>
+          <div className="row g-3 mb-4">
+            <div className="col-4 text-center">
+              <div className="fw-bold fs-5">{formatNumber(stats.conversationCount)}</div>
+              <small className="text-muted">Conversations</small>
+            </div>
+            <div className="col-4 text-center">
+              <div className="fw-bold fs-5">{formatNumber(stats.packetCount)}</div>
+              <small className="text-muted">Packets</small>
+            </div>
+            <div className="col-4 text-center">
+              <div className="fw-bold fs-5">{formatBytes(stats.totalBytes)}</div>
+              <small className="text-muted">Total bytes</small>
+            </div>
+          </div>
+
+          {stats.topPeers.length > 0 && (
+            <>
+              <h6 className="border-bottom pb-1 mb-2">
+                Top IPs{stats.topPeers.length === 10 ? ' (top 10)' : ''}
+              </h6>
+              <div className="table-responsive rounded border overflow-hidden">
+                <table className="table table-sm table-hover mb-0">
+                  <thead className="table-light" style={{ fontSize: '0.8rem' }}>
+                    <tr>
+                      <th>IP Address</th>
+                      <th className="text-end">Bytes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {stats.topPeers.map(peer => (
+                      <tr
+                        key={peer.ip}
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => onSelectPeer(peer.ip)}
+                        title="View IP details"
+                      >
+                        <td className="font-monospace small">{peer.ip}</td>
+                        <td className="text-end small">{formatBytes(peer.bytes)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/common/EntityDetailModal/sections/EntityStatsSection.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/EntityStatsSection.tsx
@@ -56,7 +56,15 @@ export function EntityStatsSection({ stats, statsLoading, statsError, onSelectPe
                       <tr
                         key={peer.ip}
                         style={{ cursor: 'pointer' }}
+                        role="button"
+                        tabIndex={0}
                         onClick={() => onSelectPeer(peer.ip)}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            onSelectPeer(peer.ip);
+                          }
+                        }}
                         title="View IP details"
                       >
                         <td className="font-monospace small">{peer.ip}</td>

--- a/frontend/src/components/common/EntityDetailModal/sections/HostClassificationSection.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/HostClassificationSection.tsx
@@ -1,0 +1,70 @@
+import { buildDeviceSignals, confidenceLevel, type DeviceSignalInfo } from '@/utils/deviceType';
+import type { HostClassification } from '../types';
+
+interface HostClassificationSectionProps {
+  hostClass: HostClassification;
+}
+
+/** Device classification signals (manufacturer/type/TTL/confidence) for an IP. */
+export function HostClassificationSection({ hostClass }: HostClassificationSectionProps) {
+  const signalInfo: DeviceSignalInfo = {
+    manufacturer: hostClass.manufacturer ?? undefined,
+    ttl: hostClass.ttl ?? undefined,
+    confidence: hostClass.confidence ?? 0,
+    deviceType: hostClass.deviceType ?? undefined,
+    apps: [],
+  };
+  const { fired, missing } = buildDeviceSignals(signalInfo);
+
+  return (
+    <div className="mb-4">
+      <h6 className="border-bottom pb-1 mb-2">Device Classification</h6>
+      <div className="d-flex gap-4 flex-wrap mb-2">
+        {hostClass.manufacturer && (
+          <div>
+            <small className="text-muted d-block">Manufacturer</small>
+            <strong>{hostClass.manufacturer}</strong>
+          </div>
+        )}
+        {hostClass.deviceType && (
+          <div>
+            <small className="text-muted d-block">Device Type</small>
+            <strong>{hostClass.deviceType}</strong>
+          </div>
+        )}
+        {hostClass.ttl != null && (
+          <div>
+            <small className="text-muted d-block">TTL</small>
+            <strong>{hostClass.ttl}</strong>
+          </div>
+        )}
+        {hostClass.confidence != null && (
+          <div>
+            <small className="text-muted d-block">Confidence</small>
+            <strong>{hostClass.confidence}%{hostClass.confidence != null && <span className="text-muted fw-normal"> — {confidenceLevel(hostClass.confidence)}</span>}</strong>
+          </div>
+        )}
+      </div>
+      {fired.length > 0 && (
+        <div className="border rounded p-2 mb-2" style={{ background: 'var(--tp-bg-subtle)', fontSize: '0.78rem' }}>
+          <small className="text-muted fw-semibold d-block mb-1">
+            <i className="bi bi-bar-chart-steps me-1" />How this is derived
+          </small>
+          <ul className="mb-0 ps-3">
+            {fired.map((s, i) => <li key={i} className="text-muted">{s}</li>)}
+          </ul>
+        </div>
+      )}
+      {missing.length > 0 && (
+        <div className="border rounded p-2" style={{ background: 'var(--bs-warning-bg-subtle, #fff3cd)', borderColor: 'var(--bs-warning-border-subtle, #ffc107)', fontSize: '0.78rem' }}>
+          <small className="fw-semibold d-block mb-1" style={{ color: 'var(--bs-warning-text-emphasis, #664d03)' }}>
+            <i className="bi bi-lightbulb me-1" />What would improve confidence
+          </small>
+          <ul className="mb-0 ps-3" style={{ color: 'var(--bs-warning-text-emphasis, #664d03)' }}>
+            {missing.map((s, i) => <li key={i}>{s}</li>)}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/EntityDetailModal/sections/NotesTab.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/NotesTab.tsx
@@ -31,7 +31,11 @@ export function NotesTab({
       <p className="text-muted small mb-2">
         Notes are saved globally for this {entityLabel} and persist across all captures.
       </p>
+      <label htmlFor="entity-note-textarea" className="visually-hidden">
+        Notes for {displayName}
+      </label>
       <textarea
+        id="entity-note-textarea"
         className="form-control mb-2"
         rows={6}
         style={{ fontSize: '0.875rem' }}
@@ -48,7 +52,7 @@ export function NotesTab({
         <button
           className="btn btn-primary btn-sm"
           onClick={onSave}
-          disabled={noteSaving || !noteChanged}
+          disabled={noteSaving || noteDeleting || !noteChanged}
         >
           {noteSaving ? (
             <><span className="spinner-border spinner-border-sm me-1" role="status" />Saving…</>
@@ -60,7 +64,7 @@ export function NotesTab({
           <button
             className="btn btn-outline-danger btn-sm"
             onClick={onDelete}
-            disabled={noteDeleting}
+            disabled={noteDeleting || noteSaving}
           >
             {noteDeleting
               ? <span className="spinner-border spinner-border-sm" role="status" />

--- a/frontend/src/components/common/EntityDetailModal/sections/NotesTab.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/NotesTab.tsx
@@ -1,0 +1,74 @@
+import type { EntityNote } from '@/features/notes/services/entityNotesService';
+
+interface NotesTabProps {
+  entityLabel: string;
+  displayName: string;
+  noteText: string;
+  setNoteText: (v: string) => void;
+  savedNote: EntityNote | null;
+  noteSaving: boolean;
+  noteDeleting: boolean;
+  noteChanged: boolean;
+  onSave: () => void;
+  onDelete: () => void;
+}
+
+/** Notes tab — global per-entity note editor. */
+export function NotesTab({
+  entityLabel,
+  displayName,
+  noteText,
+  setNoteText,
+  savedNote,
+  noteSaving,
+  noteDeleting,
+  noteChanged,
+  onSave,
+  onDelete,
+}: NotesTabProps) {
+  return (
+    <div>
+      <p className="text-muted small mb-2">
+        Notes are saved globally for this {entityLabel} and persist across all captures.
+      </p>
+      <textarea
+        className="form-control mb-2"
+        rows={6}
+        style={{ fontSize: '0.875rem' }}
+        placeholder={`Add notes about ${displayName}…`}
+        value={noteText}
+        onChange={e => setNoteText(e.target.value)}
+      />
+      {savedNote && (
+        <p className="text-muted" style={{ fontSize: '0.7rem' }}>
+          Last updated: {new Date(savedNote.updatedAt).toLocaleString('en-GB')}
+        </p>
+      )}
+      <div className="d-flex gap-2">
+        <button
+          className="btn btn-primary btn-sm"
+          onClick={onSave}
+          disabled={noteSaving || !noteChanged}
+        >
+          {noteSaving ? (
+            <><span className="spinner-border spinner-border-sm me-1" role="status" />Saving…</>
+          ) : (
+            <><i className="bi bi-floppy me-1" />Save Note</>
+          )}
+        </button>
+        {savedNote && (
+          <button
+            className="btn btn-outline-danger btn-sm"
+            onClick={onDelete}
+            disabled={noteDeleting}
+          >
+            {noteDeleting
+              ? <span className="spinner-border spinner-border-sm" role="status" />
+              : <><i className="bi bi-trash me-1" />Delete</>
+            }
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/EntityDetailModal/sections/RoleSection.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/RoleSection.tsx
@@ -1,0 +1,156 @@
+import type { useEntityRole } from '../hooks/useEntityRole';
+
+interface RoleSectionProps {
+  fileId: string;
+  role: ReturnType<typeof useEntityRole>;
+}
+
+/** Role panel for IP/DEVICE entities — view, AI-suggest, accept/discard, manual edit. */
+export function RoleSection({ fileId, role: r }: RoleSectionProps) {
+  return (
+    <div className="mb-4">
+      <h6 className="border-bottom pb-1 mb-2 d-flex align-items-center justify-content-between">
+        <span>Role</span>
+        {!r.roleEditing && !r.roleLoading && (
+          <div className="d-flex gap-1">
+            <button
+              className="btn btn-outline-secondary btn-sm py-0"
+              style={{ fontSize: '0.75rem' }}
+              onClick={r.openEdit}
+            >
+              <i className="bi bi-pencil me-1" />Edit
+            </button>
+            {fileId && (
+              <div className="d-flex align-items-center gap-1">
+                <button
+                  className="btn btn-outline-secondary btn-sm py-0"
+                  style={{ fontSize: '0.75rem' }}
+                  onClick={r.suggest}
+                  disabled={r.roleSuggesting}
+                >
+                  {r.roleSuggesting
+                    ? <><span className="spinner-border spinner-border-sm me-1" role="status" />Suggesting…</>
+                    : <><i className="bi bi-stars me-1" />Suggest with AI</>
+                  }
+                </button>
+                <button
+                  className="btn btn-link btn-sm p-0 text-muted"
+                  style={{ fontSize: '0.8rem', lineHeight: 1 }}
+                  onClick={() => r.setRoleInfoOpen(o => !o)}
+                  title="How does this work?"
+                >
+                  <i className="bi bi-info-circle" />
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </h6>
+
+      {r.roleInfoOpen && (
+        <div className="p-2 rounded mb-2 small text-muted" style={{ background: 'var(--tp-bg-subtle, #f8f9fa)', border: '1px solid var(--bs-border-color)' }}>
+          <strong>How it works:</strong> The AI analyses traffic signals for this entity — manufacturer OUI, device type, TTL, observed applications and protocols — and suggests an operational role label. If the signals are too sparse or generic to make a meaningful assessment, it will decline rather than guess.
+        </div>
+      )}
+
+      {r.roleLoading && (
+        <div className="text-muted small fst-italic">Loading role…</div>
+      )}
+
+      {r.roleSuggestError && (
+        <div className="d-flex align-items-start gap-2 p-2 rounded mb-2 small" style={{ background: 'var(--bs-warning-bg-subtle, #fff3cd)', color: 'var(--bs-warning-text-emphasis, #664d03)', border: '1px solid var(--bs-warning-border-subtle, #ffc107)' }}>
+          <i className="bi bi-exclamation-triangle-fill mt-1 flex-shrink-0" />
+          <span>{r.roleSuggestError}</span>
+        </div>
+      )}
+
+      {!r.roleLoading && !r.role && !r.roleEditing && (
+        <p className="text-muted small fst-italic mb-0">
+          No role assigned.
+        </p>
+      )}
+
+      {!r.roleLoading && r.role && !r.roleEditing && (
+        <div
+          className={`p-2 rounded small ${r.role.llmSuggested && !r.role.confirmedByHuman ? 'bg-warning-subtle border border-warning-subtle' : 'bg-light'}`}
+        >
+          <div className="fw-semibold">
+            {r.role.roleLabel || <span className="text-muted fst-italic">No label</span>}
+            {r.role.llmSuggested && !r.role.confirmedByHuman && (
+              <span className="badge bg-warning text-dark ms-2" style={{ fontSize: '0.65rem' }}>
+                <i className="bi bi-stars me-1" />AI suggested
+              </span>
+            )}
+            {r.role.confirmedByHuman && (
+              <span className="badge bg-secondary ms-2" style={{ fontSize: '0.65rem' }} title="Manually labelled by an analyst. Future deviating behaviour can still be flagged.">
+                <i className="bi bi-tag me-1" />Manual label
+              </span>
+            )}
+          </div>
+          {r.role.roleDescription && (
+            <div className="text-muted mt-1">{r.role.roleDescription}</div>
+          )}
+          {r.role.llmSuggested && !r.role.confirmedByHuman && (
+            <div className="d-flex gap-2 mt-2">
+              <button
+                className="btn btn-success btn-sm py-0"
+                style={{ fontSize: '0.75rem' }}
+                onClick={r.accept}
+                disabled={r.roleSaving}
+              >
+                <i className="bi bi-check-lg me-1" />Accept
+              </button>
+              <button
+                className="btn btn-outline-secondary btn-sm py-0"
+                style={{ fontSize: '0.75rem' }}
+                onClick={r.discard}
+                disabled={r.roleSaving}
+              >
+                <i className="bi bi-x-lg me-1" />Discard
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {r.roleEditing && (
+        <div>
+          <input
+            className="form-control form-control-sm mb-2"
+            placeholder="Role label (e.g. SCADA Controller)"
+            value={r.roleLabelDraft}
+            onChange={e => r.setRoleLabelDraft(e.target.value)}
+          />
+          <textarea
+            className="form-control form-control-sm mb-2"
+            rows={2}
+            placeholder="Description (optional)"
+            value={r.roleDescDraft}
+            onChange={e => r.setRoleDescDraft(e.target.value)}
+          />
+          <div className="d-flex gap-2">
+            <button
+              className="btn btn-primary btn-sm py-0"
+              style={{ fontSize: '0.75rem' }}
+              onClick={r.save}
+              disabled={r.roleSaving || !r.roleLabelDraft.trim()}
+            >
+              {r.roleSaving
+                ? <><span className="spinner-border spinner-border-sm me-1" role="status" />Saving…</>
+                : <><i className="bi bi-floppy me-1" />Save</>
+              }
+            </button>
+            <button
+              className="btn btn-outline-secondary btn-sm py-0"
+              style={{ fontSize: '0.75rem' }}
+              onClick={() => r.setRoleEditing(false)}
+              disabled={r.roleSaving}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
@@ -1,0 +1,77 @@
+import { Badge } from '@govtechsg/sgds-react';
+import { formatSnapTime, hashBadgeStyle } from '../format';
+import type { IpSnapshotEntry } from '../types';
+
+interface SnapshotHistoryTableProps {
+  ipSnapHistory: IpSnapshotEntry[];
+  ipHistoryLoading: boolean;
+}
+
+/** Per-snapshot MAC/device/protocol history for an IP (Monitor context). */
+export function SnapshotHistoryTable({ ipSnapHistory, ipHistoryLoading }: SnapshotHistoryTableProps) {
+  return (
+    <div className="mt-4">
+      <h6 className="text-muted fw-semibold mb-2">
+        <i className="bi bi-clock-history me-1" />Snapshot History
+      </h6>
+      {ipHistoryLoading && (
+        <div className="text-muted small py-2">
+          <span className="spinner-border spinner-border-sm me-2" role="status" />Loading…
+        </div>
+      )}
+      {!ipHistoryLoading && ipSnapHistory.length === 0 && (
+        <p className="text-muted small fst-italic">Not seen in any snapshots.</p>
+      )}
+      {!ipHistoryLoading && ipSnapHistory.length > 0 && (
+        <div className="table-responsive rounded border overflow-hidden">
+          <table className="table table-sm table-hover mb-0">
+            <thead className="table-light" style={{ fontSize: '0.8rem' }}>
+              <tr>
+                <th className="text-muted fw-normal">#</th>
+                <th className="text-muted fw-normal">Snapshot</th>
+                <th className="text-muted fw-normal">MAC Address</th>
+                <th className="text-muted fw-normal">Manufacturer</th>
+                <th className="text-muted fw-normal">Device Type</th>
+                <th className="text-muted fw-normal">Protocols / Apps</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ipSnapHistory.map(({ snap, host, protocols, apps }, idx) => (
+                <tr key={snap.id}>
+                  <td><small className="text-muted">{snap.snapshotOrder + 1}</small></td>
+                  <td>
+                    <small className="text-muted d-block">{formatSnapTime(snap)}</small>
+                    <small className="text-muted text-break" style={{ fontSize: '0.7rem' }}>{snap.fileName}</small>
+                  </td>
+                  <td>
+                    <code style={{ fontSize: '0.75rem' }}>{host?.mac ?? '—'}</code>
+                    {idx > 0 && host?.mac && ipSnapHistory[idx - 1].host?.mac &&
+                      host.mac !== ipSnapHistory[idx - 1].host!.mac && (
+                        <Badge bg="warning" text="dark" className="ms-1" style={{ fontSize: '0.65rem' }}>changed</Badge>
+                      )}
+                  </td>
+                  <td><small className="text-muted">{host?.manufacturer ?? '—'}</small></td>
+                  <td><small className="text-muted">{host?.deviceType ?? '—'}</small></td>
+                  <td>
+                    {protocols.length === 0 && apps.length === 0 ? (
+                      <small className="text-muted">—</small>
+                    ) : (
+                      <div className="d-flex flex-wrap gap-1">
+                        {protocols.map(p => (
+                          <Badge key={p} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(p) }}>{p}</Badge>
+                        ))}
+                        {apps.map(a => (
+                          <Badge key={a} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(a) }}>{a}</Badge>
+                        ))}
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
@@ -57,11 +57,11 @@ export function SnapshotHistoryTable({ ipSnapHistory, ipHistoryLoading }: Snapsh
                       <small className="text-muted">—</small>
                     ) : (
                       <div className="d-flex flex-wrap gap-1">
-                        {protocols.map(p => (
-                          <Badge key={p} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(p) }}>{p}</Badge>
+                        {protocols.map((p, i) => (
+                          <Badge key={`proto-${p}-${i}`} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(p) }}>{p}</Badge>
                         ))}
-                        {apps.map(a => (
-                          <Badge key={a} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(a) }}>{a}</Badge>
+                        {apps.map((a, i) => (
+                          <Badge key={`app-${a}-${i}`} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(a) }}>{a}</Badge>
                         ))}
                       </div>
                     )}

--- a/frontend/src/components/common/EntityDetailModal/types.ts
+++ b/frontend/src/components/common/EntityDetailModal/types.ts
@@ -1,0 +1,49 @@
+import type { EntityType } from '@/features/notes/services/entityNotesService';
+import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
+
+export type Tab = 'details' | 'notes';
+
+export interface HostClassification {
+  ip: string | null;
+  mac: string | null;
+  manufacturer: string | null;
+  deviceType: string | null;
+  confidence: number | null;
+  ttl: number | null;
+}
+
+export interface IpSnapshotEntry {
+  snap: NetworkSnapshot;
+  host: HostClassification | null;
+  apps: string[];
+  protocols: string[];
+}
+
+export interface EntityStats {
+  conversationCount: number;
+  packetCount: number;
+  totalBytes: number;
+  /** Distinct peer IPs (for APPLICATION/PROTOCOL only) */
+  topPeers: { ip: string; bytes: number }[];
+}
+
+export interface EntityDetailModalProps {
+  entityType: EntityType;
+  entityKey: string;
+  /** Display label (may differ from key) */
+  displayName: string;
+  /** Current file ID — used to fetch stats and mark history rows */
+  fileId: string;
+  /** Badge element rendered in the modal header */
+  badge?: React.ReactNode;
+  /** Whether the entity was seen in the most recent snapshot (Monitor context) */
+  isActive?: boolean;
+  /** ISO timestamp of last seen time — used to compute "inactive X days ago" */
+  lastSeenTime?: string | null;
+  /** Called when "View conversations" is clicked */
+  onViewConversations?: () => void;
+  /** Monitor snapshots — when provided for IP type, shows per-snapshot MAC/device history */
+  snapshots?: NetworkSnapshot[];
+  onClose: () => void;
+  zIndex?: number;
+}


### PR DESCRIPTION
## What

First slice of the **frontend decomposition** epic (the frontend counterpart to the backend `analysis` god-package split). Breaks apart the 919-line `EntityDetailModal.tsx` god-component into a lean **~208-line orchestrator** plus cohesive, single-responsibility units. **Behaviour-preserving** — no functional changes.

### Structure

```
EntityDetailModal/
  EntityDetailModal.tsx   # shell: wires hooks → sections, owns tab + nested-modal state
  types.ts                # shared interfaces
  format.ts               # local format helpers (bytes/number/snap-time/badge hue)
  hooks/
    useEntityRole.ts          # role load + AI-suggest/accept/discard/edit/save
    useEntityStats.ts         # APPLICATION/PROTOCOL aggregate stats + top peers
    useEntityNote.ts          # global per-entity note
    useEntityHistory.ts       # capture history
    useHostClassification.ts  # IP device-classification signals
    useIpSnapshotHistory.ts   # per-snapshot MAC/device/protocol history
  sections/
    RoleSection.tsx
    HostClassificationSection.tsx
    EntityStatsSection.tsx
    SnapshotHistoryTable.tsx
    CaptureHistoryTable.tsx
    NotesTab.tsx
```

## Why

The component mixed **25 `useState` + 9 `useEffect`** across six unrelated concerns (stats, notes, role, history, host classification, snapshot history), all interleaved with ~530 lines of JSX. Extracting the data concerns into hooks and the JSX into sections makes each unit independently readable and testable.

## Notes

- Public API unchanged — importers go through the stable `index.ts` barrel.
- Local `formatBytes`/`formatNumber` kept **verbatim** (they differ subtly from `utils/formatters`: 2-decimal bytes, default-locale numbers). Reconciling these is deferred to the dedicated helper-dedup slice to keep this PR purely structural.

## Verification

- `npx tsc --noEmit` (from `frontend/`) — clean
- `docker compose up -d --build` — all services healthy
- Playwright walkthrough, **no console errors**:
  - APPLICATION modal: stats / top-IPs / View Conversations / capture history / Notes tab / Esc-close
  - IP modal (Monitor): role section / device classification + "what would improve confidence" / snapshot history / Active badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity detail modal now displays organized sections for device classification, entity statistics, and role management with AI-powered suggestions
  * Added dedicated IP snapshot history view showing per-snapshot apps and protocols
  * Introduced per-entity notes management with save/delete functionality
  * Added capture history table for file-level navigation

* **Refactor**
  * Modal UI restructured into focused sections for improved organization and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->