### PR TITLE
fix(frontend): auto-fetch session reconstruction on tab select

### DIFF
--- a/frontend/src/components/conversation/SessionTab/SessionTab.tsx
+++ b/frontend/src/components/conversation/SessionTab/SessionTab.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Badge, Button, ButtonGroup, Card } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
 import { conversationService } from '@/features/conversation/services/conversationService';
@@ -391,12 +391,15 @@ export function SessionTab({ conversationId }: SessionTabProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeView, setActiveView] = useState<'parsed' | 'stun' | 'raw'>('parsed');
+  const latestRequestRef = useRef(0);
 
-  const handleReconstruct = async () => {
+  const handleReconstruct = useCallback(async () => {
+    const requestId = ++latestRequestRef.current;
     setLoading(true);
     setError(null);
     try {
       const data = await conversationService.reconstructSession(conversationId);
+      if (requestId !== latestRequestRef.current) return;
       setSession(data);
       if (data.httpExchanges && data.httpExchanges.length > 0) {
         setActiveView('parsed');
@@ -406,15 +409,18 @@ export function SessionTab({ conversationId }: SessionTabProps) {
         setActiveView('raw');
       }
     } catch (e: unknown) {
+      if (requestId !== latestRequestRef.current) return;
       setError(e instanceof Error ? e.message : 'Request failed');
     } finally {
-      setLoading(false);
+      if (requestId === latestRequestRef.current) setLoading(false);
     }
-  };
+  }, [conversationId]);
 
   useEffect(() => {
+    setSession(null);
+    setError(null);
     handleReconstruct();
-  }, [conversationId]);
+  }, [conversationId, handleReconstruct]);
 
   if (loading) {
     return (

--- a/frontend/src/components/conversation/SessionTab/SessionTab.tsx
+++ b/frontend/src/components/conversation/SessionTab/SessionTab.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Badge, Button, ButtonGroup, Card } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
 import { conversationService } from '@/features/conversation/services/conversationService';
@@ -412,20 +412,9 @@ export function SessionTab({ conversationId }: SessionTabProps) {
     }
   };
 
-  // ── Pre-flight states ──────────────────────────────────────────────────────
-
-  if (!session && !loading && !error) {
-    return (
-      <div className="text-center py-5">
-        <p className="text-muted mb-3">
-          Reconstruct the full application-layer byte stream for this conversation.
-        </p>
-        <Button variant="primary" onClick={handleReconstruct}>
-          Reconstruct Session
-        </Button>
-      </div>
-    );
-  }
+  useEffect(() => {
+    handleReconstruct();
+  }, [conversationId]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- Remove the manual "Reconstruct Session" button gate from the Session tab
- Auto-trigger session reconstruction via `useEffect` when the tab is selected (component mounts)
- Reduces unnecessary user friction — clicking the tab already signals intent to view session data

## Test plan
- [ ] Open a conversation detail view and switch to the Session tab
- [ ] Verify the session data loads automatically without needing to click a button
- [ ] Verify the loading spinner displays while reconstruction is in progress
- [ ] Verify error state still shows retry button on failure
- [ ] Verify the refresh button still works to re-run reconstruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session reconstruction now occurs automatically when switching conversations, eliminating the need for manual confirmation and streamlining your workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->