### PR TITLE
refactor(frontend): migrate EntityDetailModal sections to SGDS components

### DIFF
--- a/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
@@ -1,3 +1,6 @@
+import { Table } from '@govtechsg/sgds-react';
+import { Alert } from '@components/common/Alert';
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { useNavigate } from 'react-router-dom';
 import type { EntityHistoryEntry } from '@/features/notes/services/entityNotesService';
 import { formatBytes, formatNumber } from '../format';
@@ -19,29 +22,29 @@ export function CaptureHistoryTable({ history, historyLoading, historyError, onC
       </h6>
       {historyLoading && (
         <div className="text-muted small py-2">
-          <span className="spinner-border spinner-border-sm me-2" role="status" />Loading…
+          <Spinner size="sm" className="me-2" />Loading…
         </div>
       )}
       {historyError && (
-        <div className="alert alert-warning py-2 small">{historyError}</div>
+        <Alert variant="warning" className="py-2 small">{historyError}</Alert>
       )}
       {!historyLoading && !historyError && history.length === 0 && (
         <p className="text-muted small fst-italic">Not seen in any uploaded files.</p>
       )}
       {!historyLoading && !historyError && history.length > 0 && (
-        <div className="table-responsive rounded border overflow-hidden">
-          <table className="table table-sm table-hover mb-0">
-            <thead className="table-light" style={{ fontSize: '0.8rem' }}>
-              <tr>
-                <th className="text-muted fw-normal">File</th>
-                <th className="text-muted fw-normal">Capture Start</th>
-                <th className="text-end text-muted fw-normal">Packets</th>
-                <th className="text-end text-muted fw-normal">Bytes</th>
-              </tr>
-            </thead>
-            <tbody>
+        <div className="rounded border overflow-hidden">
+          <Table size="sm" hover responsive className="mb-0">
+            <Table.Header className="table-light" style={{ fontSize: '0.8rem' }}>
+              <Table.Row>
+                <Table.HeaderCell className="text-muted fw-normal">File</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Capture Start</Table.HeaderCell>
+                <Table.HeaderCell className="text-end text-muted fw-normal">Packets</Table.HeaderCell>
+                <Table.HeaderCell className="text-end text-muted fw-normal">Bytes</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
               {history.map(entry => (
-                <tr
+                <Table.Row
                   key={entry.fileId}
                   style={{ cursor: 'pointer' }}
                   role="button"
@@ -56,20 +59,20 @@ export function CaptureHistoryTable({ history, historyLoading, historyError, onC
                   }}
                   title="Open in analysis"
                 >
-                  <td className="small">{entry.fileName}</td>
-                  <td className="small text-muted">
+                  <Table.DataCell className="small">{entry.fileName}</Table.DataCell>
+                  <Table.DataCell className="small text-muted">
                     {entry.startTime ? new Date(entry.startTime).toLocaleString('en-GB') : '—'}
-                  </td>
-                  <td className="text-end small text-muted">
+                  </Table.DataCell>
+                  <Table.DataCell className="text-end small text-muted">
                     {entry.packetCount != null ? formatNumber(entry.packetCount) : '—'}
-                  </td>
-                  <td className="text-end small text-muted">
+                  </Table.DataCell>
+                  <Table.DataCell className="text-end small text-muted">
                     {entry.totalBytes != null ? formatBytes(entry.totalBytes) : '—'}
-                  </td>
-                </tr>
+                  </Table.DataCell>
+                </Table.Row>
               ))}
-            </tbody>
-          </table>
+            </Table.Body>
+          </Table>
         </div>
       )}
     </div>

--- a/frontend/src/components/common/EntityDetailModal/sections/EntityStatsSection.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/EntityStatsSection.tsx
@@ -1,3 +1,6 @@
+import { Row, Col, Table } from '@govtechsg/sgds-react';
+import { Alert } from '@components/common/Alert';
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { formatBytes, formatNumber } from '../format';
 import type { EntityStats } from '../types';
 
@@ -14,46 +17,46 @@ export function EntityStatsSection({ stats, statsLoading, statsError, onSelectPe
     <>
       {statsLoading && (
         <div className="text-center py-4">
-          <div className="spinner-border spinner-border-sm text-primary" role="status" />
+          <Spinner size="sm" className="text-primary" />
           <p className="text-muted mt-2 small">Loading stats…</p>
         </div>
       )}
       {statsError && (
-        <div className="alert alert-warning py-2 small">{statsError}</div>
+        <Alert variant="warning" className="py-2 small">{statsError}</Alert>
       )}
       {!statsLoading && !statsError && stats && (
         <>
-          <div className="row g-3 mb-4">
-            <div className="col-4 text-center">
+          <Row className="g-3 mb-4">
+            <Col xs={4} className="text-center">
               <div className="fw-bold fs-5">{formatNumber(stats.conversationCount)}</div>
               <small className="text-muted">Conversations</small>
-            </div>
-            <div className="col-4 text-center">
+            </Col>
+            <Col xs={4} className="text-center">
               <div className="fw-bold fs-5">{formatNumber(stats.packetCount)}</div>
               <small className="text-muted">Packets</small>
-            </div>
-            <div className="col-4 text-center">
+            </Col>
+            <Col xs={4} className="text-center">
               <div className="fw-bold fs-5">{formatBytes(stats.totalBytes)}</div>
               <small className="text-muted">Total bytes</small>
-            </div>
-          </div>
+            </Col>
+          </Row>
 
           {stats.topPeers.length > 0 && (
             <>
               <h6 className="border-bottom pb-1 mb-2">
                 Top IPs{stats.topPeers.length === 10 ? ' (top 10)' : ''}
               </h6>
-              <div className="table-responsive rounded border overflow-hidden">
-                <table className="table table-sm table-hover mb-0">
-                  <thead className="table-light" style={{ fontSize: '0.8rem' }}>
-                    <tr>
-                      <th>IP Address</th>
-                      <th className="text-end">Bytes</th>
-                    </tr>
-                  </thead>
-                  <tbody>
+              <div className="rounded border overflow-hidden">
+                <Table size="sm" hover responsive className="mb-0">
+                  <Table.Header className="table-light" style={{ fontSize: '0.8rem' }}>
+                    <Table.Row>
+                      <Table.HeaderCell>IP Address</Table.HeaderCell>
+                      <Table.HeaderCell className="text-end">Bytes</Table.HeaderCell>
+                    </Table.Row>
+                  </Table.Header>
+                  <Table.Body>
                     {stats.topPeers.map(peer => (
-                      <tr
+                      <Table.Row
                         key={peer.ip}
                         style={{ cursor: 'pointer' }}
                         role="button"
@@ -67,12 +70,12 @@ export function EntityStatsSection({ stats, statsLoading, statsError, onSelectPe
                         }}
                         title="View IP details"
                       >
-                        <td className="font-monospace small">{peer.ip}</td>
-                        <td className="text-end small">{formatBytes(peer.bytes)}</td>
-                      </tr>
+                        <Table.DataCell className="font-monospace small">{peer.ip}</Table.DataCell>
+                        <Table.DataCell className="text-end small">{formatBytes(peer.bytes)}</Table.DataCell>
+                      </Table.Row>
                     ))}
-                  </tbody>
-                </table>
+                  </Table.Body>
+                </Table>
               </div>
             </>
           )}

--- a/frontend/src/components/common/EntityDetailModal/sections/HostClassificationSection.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/HostClassificationSection.tsx
@@ -1,3 +1,4 @@
+import { Alert } from '@components/common/Alert';
 import { buildDeviceSignals, confidenceLevel, type DeviceSignalInfo } from '@/utils/deviceType';
 import type { HostClassification } from '../types';
 
@@ -46,24 +47,24 @@ export function HostClassificationSection({ hostClass }: HostClassificationSecti
         )}
       </div>
       {fired.length > 0 && (
-        <div className="border rounded p-2 mb-2" style={{ background: 'var(--tp-bg-subtle)', fontSize: '0.78rem' }}>
+        <Alert variant="info" className="p-2 mb-2" style={{ fontSize: '0.78rem' }}>
           <small className="text-muted fw-semibold d-block mb-1">
             <i className="bi bi-bar-chart-steps me-1" />How this is derived
           </small>
           <ul className="mb-0 ps-3">
             {fired.map((s, i) => <li key={i} className="text-muted">{s}</li>)}
           </ul>
-        </div>
+        </Alert>
       )}
       {missing.length > 0 && (
-        <div className="border rounded p-2" style={{ background: 'var(--bs-warning-bg-subtle, #fff3cd)', borderColor: 'var(--bs-warning-border-subtle, #ffc107)', fontSize: '0.78rem' }}>
-          <small className="fw-semibold d-block mb-1" style={{ color: 'var(--bs-warning-text-emphasis, #664d03)' }}>
+        <Alert variant="warning" className="p-2 mb-0" style={{ fontSize: '0.78rem' }}>
+          <small className="fw-semibold d-block mb-1">
             <i className="bi bi-lightbulb me-1" />What would improve confidence
           </small>
-          <ul className="mb-0 ps-3" style={{ color: 'var(--bs-warning-text-emphasis, #664d03)' }}>
+          <ul className="mb-0 ps-3">
             {missing.map((s, i) => <li key={i}>{s}</li>)}
           </ul>
-        </div>
+        </Alert>
       )}
     </div>
   );

--- a/frontend/src/components/common/EntityDetailModal/sections/NotesTab.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/NotesTab.tsx
@@ -1,3 +1,5 @@
+import { Button, Form } from '@govtechsg/sgds-react';
+import { Spinner } from '@components/common/Spinner/Spinner';
 import type { EntityNote } from '@/features/notes/services/entityNotesService';
 
 interface NotesTabProps {
@@ -31,12 +33,13 @@ export function NotesTab({
       <p className="text-muted small mb-2">
         Notes are saved globally for this {entityLabel} and persist across all captures.
       </p>
-      <label htmlFor="entity-note-textarea" className="visually-hidden">
+      <Form.Label htmlFor="entity-note-textarea" className="visually-hidden">
         Notes for {displayName}
-      </label>
-      <textarea
+      </Form.Label>
+      <Form.Control
+        as="textarea"
         id="entity-note-textarea"
-        className="form-control mb-2"
+        className="mb-2"
         rows={6}
         style={{ fontSize: '0.875rem' }}
         placeholder={`Add notes about ${displayName}…`}
@@ -49,28 +52,30 @@ export function NotesTab({
         </p>
       )}
       <div className="d-flex gap-2">
-        <button
-          className="btn btn-primary btn-sm"
+        <Button
+          variant="primary"
+          size="sm"
           onClick={onSave}
           disabled={noteSaving || noteDeleting || !noteChanged}
         >
           {noteSaving ? (
-            <><span className="spinner-border spinner-border-sm me-1" role="status" />Saving…</>
+            <><Spinner size="sm" className="me-1" />Saving…</>
           ) : (
             <><i className="bi bi-floppy me-1" />Save Note</>
           )}
-        </button>
+        </Button>
         {savedNote && (
-          <button
-            className="btn btn-outline-danger btn-sm"
+          <Button
+            variant="outline-danger"
+            size="sm"
             onClick={onDelete}
             disabled={noteDeleting || noteSaving}
           >
             {noteDeleting
-              ? <span className="spinner-border spinner-border-sm" role="status" />
+              ? <Spinner size="sm" />
               : <><i className="bi bi-trash me-1" />Delete</>
             }
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/frontend/src/components/common/EntityDetailModal/sections/RoleSection.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/RoleSection.tsx
@@ -1,3 +1,6 @@
+import { Badge, Button, Form } from '@govtechsg/sgds-react';
+import { Alert } from '@components/common/Alert';
+import { Spinner } from '@components/common/Spinner/Spinner';
 import type { useEntityRole } from '../hooks/useEntityRole';
 
 interface RoleSectionProps {
@@ -13,34 +16,40 @@ export function RoleSection({ fileId, role: r }: RoleSectionProps) {
         <span>Role</span>
         {!r.roleEditing && !r.roleLoading && (
           <div className="d-flex gap-1">
-            <button
-              className="btn btn-outline-secondary btn-sm py-0"
+            <Button
+              variant="outline-secondary"
+              size="sm"
+              className="py-0"
               style={{ fontSize: '0.75rem' }}
               onClick={r.openEdit}
             >
               <i className="bi bi-pencil me-1" />Edit
-            </button>
+            </Button>
             {fileId && (
               <div className="d-flex align-items-center gap-1">
-                <button
-                  className="btn btn-outline-secondary btn-sm py-0"
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  className="py-0"
                   style={{ fontSize: '0.75rem' }}
                   onClick={r.suggest}
                   disabled={r.roleSuggesting}
                 >
                   {r.roleSuggesting
-                    ? <><span className="spinner-border spinner-border-sm me-1" role="status" />Suggesting…</>
+                    ? <><Spinner size="sm" className="me-1" />Suggesting…</>
                     : <><i className="bi bi-stars me-1" />Suggest with AI</>
                   }
-                </button>
-                <button
-                  className="btn btn-link btn-sm p-0 text-muted"
+                </Button>
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="p-0 text-muted"
                   style={{ fontSize: '0.8rem', lineHeight: 1 }}
                   onClick={() => r.setRoleInfoOpen(o => !o)}
                   title="How does this work?"
                 >
                   <i className="bi bi-info-circle" />
-                </button>
+                </Button>
               </div>
             )}
           </div>
@@ -48,9 +57,9 @@ export function RoleSection({ fileId, role: r }: RoleSectionProps) {
       </h6>
 
       {r.roleInfoOpen && (
-        <div className="p-2 rounded mb-2 small text-muted" style={{ background: 'var(--tp-bg-subtle, #f8f9fa)', border: '1px solid var(--bs-border-color)' }}>
+        <Alert variant="info" className="p-2 mb-2 small">
           <strong>How it works:</strong> The AI analyses traffic signals for this entity — manufacturer OUI, device type, TTL, observed applications and protocols — and suggests an operational role label. If the signals are too sparse or generic to make a meaningful assessment, it will decline rather than guess.
-        </div>
+        </Alert>
       )}
 
       {r.roleLoading && (
@@ -58,10 +67,10 @@ export function RoleSection({ fileId, role: r }: RoleSectionProps) {
       )}
 
       {r.roleSuggestError && (
-        <div className="d-flex align-items-start gap-2 p-2 rounded mb-2 small" style={{ background: 'var(--bs-warning-bg-subtle, #fff3cd)', color: 'var(--bs-warning-text-emphasis, #664d03)', border: '1px solid var(--bs-warning-border-subtle, #ffc107)' }}>
+        <Alert variant="warning" className="d-flex align-items-start gap-2 p-2 mb-2 small">
           <i className="bi bi-exclamation-triangle-fill mt-1 flex-shrink-0" />
           <span>{r.roleSuggestError}</span>
-        </div>
+        </Alert>
       )}
 
       {!r.roleLoading && !r.role && !r.roleEditing && (
@@ -77,14 +86,14 @@ export function RoleSection({ fileId, role: r }: RoleSectionProps) {
           <div className="fw-semibold">
             {r.role.roleLabel || <span className="text-muted fst-italic">No label</span>}
             {r.role.llmSuggested && !r.role.confirmedByHuman && (
-              <span className="badge bg-warning text-dark ms-2" style={{ fontSize: '0.65rem' }}>
+              <Badge bg="warning" text="dark" className="ms-2" style={{ fontSize: '0.65rem' }}>
                 <i className="bi bi-stars me-1" />AI suggested
-              </span>
+              </Badge>
             )}
             {r.role.confirmedByHuman && (
-              <span className="badge bg-secondary ms-2" style={{ fontSize: '0.65rem' }} title="Manually labelled by an analyst. Future deviating behaviour can still be flagged.">
+              <Badge bg="secondary" className="ms-2" style={{ fontSize: '0.65rem' }} title="Manually labelled by an analyst. Future deviating behaviour can still be flagged.">
                 <i className="bi bi-tag me-1" />Manual label
-              </span>
+              </Badge>
             )}
           </div>
           {r.role.roleDescription && (
@@ -92,22 +101,26 @@ export function RoleSection({ fileId, role: r }: RoleSectionProps) {
           )}
           {r.role.llmSuggested && !r.role.confirmedByHuman && (
             <div className="d-flex gap-2 mt-2">
-              <button
-                className="btn btn-success btn-sm py-0"
+              <Button
+                variant="success"
+                size="sm"
+                className="py-0"
                 style={{ fontSize: '0.75rem' }}
                 onClick={r.accept}
                 disabled={r.roleSaving}
               >
                 <i className="bi bi-check-lg me-1" />Accept
-              </button>
-              <button
-                className="btn btn-outline-secondary btn-sm py-0"
+              </Button>
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                className="py-0"
                 style={{ fontSize: '0.75rem' }}
                 onClick={r.discard}
                 disabled={r.roleSaving}
               >
                 <i className="bi bi-x-lg me-1" />Discard
-              </button>
+              </Button>
             </div>
           )}
         </div>
@@ -115,39 +128,46 @@ export function RoleSection({ fileId, role: r }: RoleSectionProps) {
 
       {r.roleEditing && (
         <div>
-          <input
-            className="form-control form-control-sm mb-2"
+          <Form.Control
+            size="sm"
+            className="mb-2"
             placeholder="Role label (e.g. SCADA Controller)"
             value={r.roleLabelDraft}
             onChange={e => r.setRoleLabelDraft(e.target.value)}
           />
-          <textarea
-            className="form-control form-control-sm mb-2"
+          <Form.Control
+            as="textarea"
+            size="sm"
+            className="mb-2"
             rows={2}
             placeholder="Description (optional)"
             value={r.roleDescDraft}
             onChange={e => r.setRoleDescDraft(e.target.value)}
           />
           <div className="d-flex gap-2">
-            <button
-              className="btn btn-primary btn-sm py-0"
+            <Button
+              variant="primary"
+              size="sm"
+              className="py-0"
               style={{ fontSize: '0.75rem' }}
               onClick={r.save}
               disabled={r.roleSaving || !r.roleLabelDraft.trim()}
             >
               {r.roleSaving
-                ? <><span className="spinner-border spinner-border-sm me-1" role="status" />Saving…</>
+                ? <><Spinner size="sm" className="me-1" />Saving…</>
                 : <><i className="bi bi-floppy me-1" />Save</>
               }
-            </button>
-            <button
-              className="btn btn-outline-secondary btn-sm py-0"
+            </Button>
+            <Button
+              variant="outline-secondary"
+              size="sm"
+              className="py-0"
               style={{ fontSize: '0.75rem' }}
               onClick={() => r.setRoleEditing(false)}
               disabled={r.roleSaving}
             >
               Cancel
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
@@ -1,4 +1,5 @@
-import { Badge } from '@govtechsg/sgds-react';
+import { Badge, Table } from '@govtechsg/sgds-react';
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { formatSnapTime, hashBadgeStyle } from '../format';
 import type { IpSnapshotEntry } from '../types';
 
@@ -16,43 +17,43 @@ export function SnapshotHistoryTable({ ipSnapHistory, ipHistoryLoading }: Snapsh
       </h6>
       {ipHistoryLoading && (
         <div className="text-muted small py-2">
-          <span className="spinner-border spinner-border-sm me-2" role="status" />Loading…
+          <Spinner size="sm" className="me-2" />Loading…
         </div>
       )}
       {!ipHistoryLoading && ipSnapHistory.length === 0 && (
         <p className="text-muted small fst-italic">Not seen in any snapshots.</p>
       )}
       {!ipHistoryLoading && ipSnapHistory.length > 0 && (
-        <div className="table-responsive rounded border overflow-hidden">
-          <table className="table table-sm table-hover mb-0">
-            <thead className="table-light" style={{ fontSize: '0.8rem' }}>
-              <tr>
-                <th className="text-muted fw-normal">#</th>
-                <th className="text-muted fw-normal">Snapshot</th>
-                <th className="text-muted fw-normal">MAC Address</th>
-                <th className="text-muted fw-normal">Manufacturer</th>
-                <th className="text-muted fw-normal">Device Type</th>
-                <th className="text-muted fw-normal">Protocols / Apps</th>
-              </tr>
-            </thead>
-            <tbody>
+        <div className="rounded border overflow-hidden">
+          <Table size="sm" hover responsive className="mb-0">
+            <Table.Header className="table-light" style={{ fontSize: '0.8rem' }}>
+              <Table.Row>
+                <Table.HeaderCell className="text-muted fw-normal">#</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Snapshot</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">MAC Address</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Manufacturer</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Device Type</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Protocols / Apps</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
               {ipSnapHistory.map(({ snap, host, protocols, apps }, idx) => (
-                <tr key={snap.id}>
-                  <td><small className="text-muted">{snap.snapshotOrder + 1}</small></td>
-                  <td>
+                <Table.Row key={snap.id}>
+                  <Table.DataCell><small className="text-muted">{snap.snapshotOrder + 1}</small></Table.DataCell>
+                  <Table.DataCell>
                     <small className="text-muted d-block">{formatSnapTime(snap)}</small>
                     <small className="text-muted text-break" style={{ fontSize: '0.7rem' }}>{snap.fileName}</small>
-                  </td>
-                  <td>
+                  </Table.DataCell>
+                  <Table.DataCell>
                     <code style={{ fontSize: '0.75rem' }}>{host?.mac ?? '—'}</code>
                     {idx > 0 && host?.mac && ipSnapHistory[idx - 1].host?.mac &&
                       host.mac !== ipSnapHistory[idx - 1].host!.mac && (
                         <Badge bg="warning" text="dark" className="ms-1" style={{ fontSize: '0.65rem' }}>changed</Badge>
                       )}
-                  </td>
-                  <td><small className="text-muted">{host?.manufacturer ?? '—'}</small></td>
-                  <td><small className="text-muted">{host?.deviceType ?? '—'}</small></td>
-                  <td>
+                  </Table.DataCell>
+                  <Table.DataCell><small className="text-muted">{host?.manufacturer ?? '—'}</small></Table.DataCell>
+                  <Table.DataCell><small className="text-muted">{host?.deviceType ?? '—'}</small></Table.DataCell>
+                  <Table.DataCell>
                     {protocols.length === 0 && apps.length === 0 ? (
                       <small className="text-muted">—</small>
                     ) : (
@@ -65,11 +66,11 @@ export function SnapshotHistoryTable({ ipSnapHistory, ipHistoryLoading }: Snapsh
                         ))}
                       </div>
                     )}
-                  </td>
-                </tr>
+                  </Table.DataCell>
+                </Table.Row>
               ))}
-            </tbody>
-          </table>
+            </Table.Body>
+          </Table>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Replaces raw Bootstrap/HTML markup with `@govtechsg/sgds-react` primitives across all 6 `EntityDetailModal/sections/` files
- `<button>` → `Button`, `<input>`/`<textarea>` → `Form.Control`, `<label>` → `Form.Label`, `<span class="badge">` → `Badge`, alert-styled `<div>` → `Alert`, `<table>` → `Table` (with sub-components), `<div class="row/col">` → `Row`/`Col`, `<span class="spinner-border">` → `Spinner` wrapper
- Behaviour and visuals kept equivalent — no functional changes

Closes #437

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `docker compose up -d --build` succeeds
- [x] All 57 Vitest unit tests pass
- [x] Playwright visual verification of APPLICATION modal (HTTP entity)
- [x] Playwright visual verification of IP modal (203.0.113.1 — Details, Notes, Role Edit, Role Info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated entity detail modal UI components to use a consistent design system, improving visual consistency across tables, forms, buttons, and alerts throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->