### PR TITLE
fix: soften monitoring badges in dark mode (#445)

### DIFF
--- a/frontend/src/assets/styles/sgds-overrides.css
+++ b/frontend/src/assets/styles/sgds-overrides.css
@@ -452,6 +452,43 @@
   color: var(--tp-text);
 }
 
+/* Badges.
+   Bootstrap/SGDS only auto-dim solid badge colors when data-bs-theme="dark"
+   is set, but our dark mode keys off [data-theme='dark']. So solid .badge.bg-*
+   variants would otherwise render at full light-mode saturation and glare
+   against the dark background. Re-color them to muted tones (mirroring the dark
+   alert palette) with a lighter foreground for legibility. The color override
+   also neutralizes the light-mode text="dark" foreground some badges set. */
+[data-theme='dark'] .badge.bg-danger {
+  background-color: #5a2326 !important;
+  color: #f3a6a6 !important;
+}
+
+[data-theme='dark'] .badge.bg-warning {
+  background-color: #4d3a0f !important;
+  color: #f5ca5a !important;
+}
+
+[data-theme='dark'] .badge.bg-info {
+  background-color: #143a52 !important;
+  color: #8fd3f5 !important;
+}
+
+[data-theme='dark'] .badge.bg-success {
+  background-color: #14402a !important;
+  color: #7ee0a8 !important;
+}
+
+[data-theme='dark'] .badge.bg-primary {
+  background-color: #1e3a5a !important;
+  color: #8fbef0 !important;
+}
+
+[data-theme='dark'] .badge.bg-secondary {
+  background-color: var(--tp-bg-subtle) !important;
+  color: var(--tp-text) !important;
+}
+
 /* Misc */
 [data-theme='dark'] hr {
   border-color: var(--tp-border);

--- a/frontend/src/assets/styles/sgds-overrides.css
+++ b/frontend/src/assets/styles/sgds-overrides.css
@@ -489,6 +489,20 @@
   color: var(--tp-text) !important;
 }
 
+/* Per-entity hash badges (hashBadgeStyle in the drift panels / entity modal).
+   The inline style sets a --badge-hue plus light-mode HSL values that read fine
+   on a light background. In dark mode, recolor from that same hue to muted tones.
+   We target [style*='--badge-hue'] so every current and future consumer stays in
+   sync without a shared class; var(--badge-hue) resolves on the element itself
+   (where it's declared inline), and !important beats the inline declarations.
+   Plain custom properties (no light-dark()) keep this compatible with older
+   browsers. */
+[data-theme='dark'] [style*='--badge-hue'] {
+  background-color: hsl(var(--badge-hue), 30%, 22%) !important;
+  color: hsl(var(--badge-hue), 65%, 78%) !important;
+  border-color: hsl(var(--badge-hue), 28%, 38%) !important;
+}
+
 /* Misc */
 [data-theme='dark'] hr {
   border-color: var(--tp-border);

--- a/frontend/src/components/common/EntityDetailModal/format.ts
+++ b/frontend/src/components/common/EntityDetailModal/format.ts
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
 import { parseDateTime } from '@/utils/dateUtils';
 
@@ -27,11 +28,12 @@ export function stringHue(s: string): number {
   return Math.abs(h) % 360;
 }
 
-export function hashBadgeStyle(s: string) {
+export function hashBadgeStyle(s: string): CSSProperties {
   const hue = stringHue(s);
   return {
-    background: `light-dark(hsl(${hue}, 40%, 88%), hsl(${hue}, 30%, 22%))`,
-    color: `light-dark(hsl(${hue}, 50%, 28%), hsl(${hue}, 65%, 78%))`,
-    border: `1px solid light-dark(hsl(${hue}, 35%, 72%), hsl(${hue}, 28%, 38%))`,
-  };
+    '--badge-hue': hue,
+    background: `hsl(${hue}, 40%, 88%)`,
+    color: `hsl(${hue}, 50%, 28%)`,
+    border: `1px solid hsl(${hue}, 35%, 72%)`,
+  } as CSSProperties;
 }

--- a/frontend/src/components/common/EntityDetailModal/format.ts
+++ b/frontend/src/components/common/EntityDetailModal/format.ts
@@ -30,8 +30,8 @@ export function stringHue(s: string): number {
 export function hashBadgeStyle(s: string) {
   const hue = stringHue(s);
   return {
-    background: `hsl(${hue}, 40%, 88%)`,
-    color: `hsl(${hue}, 50%, 28%)`,
-    border: `1px solid hsl(${hue}, 35%, 72%)`,
+    background: `light-dark(hsl(${hue}, 40%, 88%), hsl(${hue}, 30%, 22%))`,
+    color: `light-dark(hsl(${hue}, 50%, 28%), hsl(${hue}, 65%, 78%))`,
+    border: `1px solid light-dark(hsl(${hue}, 35%, 72%), hsl(${hue}, 28%, 38%))`,
   };
 }

--- a/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
+++ b/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
@@ -20,10 +20,11 @@ function stringHue(s: string): number {
 function hashBadgeStyle(s: string): CSSProperties {
   const hue = stringHue(s);
   return {
-    background: `light-dark(hsl(${hue}, 40%, 88%), hsl(${hue}, 30%, 22%))`,
-    color: `light-dark(hsl(${hue}, 50%, 28%), hsl(${hue}, 65%, 78%))`,
-    border: `1px solid light-dark(hsl(${hue}, 35%, 72%), hsl(${hue}, 28%, 38%))`,
-  };
+    '--badge-hue': hue,
+    background: `hsl(${hue}, 40%, 88%)`,
+    color: `hsl(${hue}, 50%, 28%)`,
+    border: `1px solid hsl(${hue}, 35%, 72%)`,
+  } as CSSProperties;
 }
 
 interface DeviceDriftPanelProps {

--- a/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
+++ b/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
@@ -20,9 +20,9 @@ function stringHue(s: string): number {
 function hashBadgeStyle(s: string): CSSProperties {
   const hue = stringHue(s);
   return {
-    background: `hsl(${hue}, 40%, 88%)`,
-    color: `hsl(${hue}, 50%, 28%)`,
-    border: `1px solid hsl(${hue}, 35%, 72%)`,
+    background: `light-dark(hsl(${hue}, 40%, 88%), hsl(${hue}, 30%, 22%))`,
+    color: `light-dark(hsl(${hue}, 50%, 28%), hsl(${hue}, 65%, 78%))`,
+    border: `1px solid light-dark(hsl(${hue}, 35%, 72%), hsl(${hue}, 28%, 38%))`,
   };
 }
 

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -62,10 +62,11 @@ function stringHue(s: string): number {
 function hashBadgeStyle(s: string): CSSProperties {
   const hue = stringHue(s);
   return {
-    background: `light-dark(hsl(${hue}, 40%, 88%), hsl(${hue}, 30%, 22%))`,
-    color: `light-dark(hsl(${hue}, 50%, 28%), hsl(${hue}, 65%, 78%))`,
-    border: `1px solid light-dark(hsl(${hue}, 35%, 72%), hsl(${hue}, 28%, 38%))`,
-  };
+    '--badge-hue': hue,
+    background: `hsl(${hue}, 40%, 88%)`,
+    color: `hsl(${hue}, 50%, 28%)`,
+    border: `1px solid hsl(${hue}, 35%, 72%)`,
+  } as CSSProperties;
 }
 
 function IpBadgeGroup({

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -62,9 +62,9 @@ function stringHue(s: string): number {
 function hashBadgeStyle(s: string): CSSProperties {
   const hue = stringHue(s);
   return {
-    background: `hsl(${hue}, 40%, 88%)`,
-    color: `hsl(${hue}, 50%, 28%)`,
-    border: `1px solid hsl(${hue}, 35%, 72%)`,
+    background: `light-dark(hsl(${hue}, 40%, 88%), hsl(${hue}, 30%, 22%))`,
+    color: `light-dark(hsl(${hue}, 50%, 28%), hsl(${hue}, 65%, 78%))`,
+    border: `1px solid light-dark(hsl(${hue}, 35%, 72%), hsl(${hue}, 28%, 38%))`,
   };
 }
 

--- a/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
+++ b/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
@@ -18,9 +18,9 @@ function stringHue(s: string): number {
 function hashBadgeStyle(s: string): CSSProperties {
   const hue = stringHue(s);
   return {
-    background: `hsl(${hue}, 40%, 88%)`,
-    color: `hsl(${hue}, 50%, 28%)`,
-    border: `1px solid hsl(${hue}, 35%, 72%)`,
+    background: `light-dark(hsl(${hue}, 40%, 88%), hsl(${hue}, 30%, 22%))`,
+    color: `light-dark(hsl(${hue}, 50%, 28%), hsl(${hue}, 65%, 78%))`,
+    border: `1px solid light-dark(hsl(${hue}, 35%, 72%), hsl(${hue}, 28%, 38%))`,
   };
 }
 

--- a/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
+++ b/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
@@ -18,10 +18,11 @@ function stringHue(s: string): number {
 function hashBadgeStyle(s: string): CSSProperties {
   const hue = stringHue(s);
   return {
-    background: `light-dark(hsl(${hue}, 40%, 88%), hsl(${hue}, 30%, 22%))`,
-    color: `light-dark(hsl(${hue}, 50%, 28%), hsl(${hue}, 65%, 78%))`,
-    border: `1px solid light-dark(hsl(${hue}, 35%, 72%), hsl(${hue}, 28%, 38%))`,
-  };
+    '--badge-hue': hue,
+    background: `hsl(${hue}, 40%, 88%)`,
+    color: `hsl(${hue}, 50%, 28%)`,
+    border: `1px solid hsl(${hue}, 35%, 72%)`,
+  } as CSSProperties;
 }
 
 interface ProtocolDriftPanelProps {


### PR DESCRIPTION
## Summary

Fixes #445. In Monitoring mode, the solid Bootstrap badge colors (`CRITICAL`, `WARNING`, `INFO`, `Active`, `AI suggested`, etc.) kept their full light-mode saturation in dark mode and glared against the dark background.

The app's dark mode keys off a custom `[data-theme='dark']` attribute, not Bootstrap's `data-bs-theme="dark"`, so the built-in badge dimming never kicked in.

## Approach

Chose **option 2** from the issue — dark-mode overrides in `sgds-overrides.css`. This keeps all component markup unchanged and applies consistently across every affected badge.

Added muted dark-mode variants for `.badge.bg-danger / bg-warning / bg-info / bg-success / bg-primary / bg-secondary`, mirroring the existing dark **alert** palette (muted background + lighter foreground). The `color` override also neutralizes the light-mode `text="dark"` foreground that some badges set.

## Affected badges (all covered)

- `MonitorInfoCard.tsx` — danger/warning/info legend badges
- `ChangeEventsSection.tsx` — CRITICAL/WARNING/INFO + secondary count
- `DeviceDriftPanel.tsx` — `Active` (success), `AI suggested` / note count (warning), `changed`, secondary labels
- `IpDriftPanel.tsx` — secondary count badge
- `NetworkInsightsPanel.tsx` — primary "custom" badge

## Verification

- `docker compose up -d --build nginx` — builds clean.
- Playwright computed-style check + screenshots in both themes:
  - **Light mode unchanged** (full Bootstrap colors).
  - **Dark mode** badges now render muted with legible light text.

## Acceptance criteria

- [x] Severity/status badges visibly softer (no glare) in dark mode, still legible.
- [x] Light mode appearance unchanged.
- [x] Consistent across all affected badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)