### PR TITLE
docs: document PUBLIC_URL in .env.example (prod overlay / OIDC)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,16 @@ APP_MEMORY_MB=2048
 # Change if port 80 is already in use on your system
 NGINX_PORT=80
 
+# Public Origin (prod overlay only — docker-compose.prod.yml / OIDC auth)
+# Only used when running with the production overlay that enables Keycloak auth:
+#   PUBLIC_URL=https://app.example.com docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+# Must be the EXACT origin you browse to (scheme + host + port). It pins Keycloak's
+# token issuer and the backend's issuer check, so the browser must load the app via
+# this same origin. Include the port only if it's non-standard (e.g. :8888); omit it
+# for standard 80/443 (e.g. behind a TLS reverse proxy or Tailscale serve on 443).
+# Ignored by the base stack. Defaults to http://localhost:8888 if unset.
+# PUBLIC_URL=https://app.example.com
+
 # File Retention Configuration
 # Set to false to keep files indefinitely (no automatic deletion).
 FILE_RETENTION_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,10 @@ NGINX_PORT=80
 # token issuer and the backend's issuer check, so the browser must load the app via
 # this same origin. Include the port only if it's non-standard (e.g. :8888); omit it
 # for standard 80/443 (e.g. behind a TLS reverse proxy or Tailscale serve on 443).
-# Ignored by the base stack. Defaults to http://localhost:8888 if unset.
+# Ignored by the base stack. Defaults to http://localhost:8888 if unset — note this
+# does NOT track NGINX_PORT, so for a default local prod run (NGINX_PORT=80) you MUST
+# set PUBLIC_URL to match your actual port (e.g. http://localhost), or Keycloak will
+# reject the redirect_uri / fail the issuer check.
 # PUBLIC_URL=https://app.example.com
 
 # File Retention Configuration


### PR DESCRIPTION
## Summary

`PUBLIC_URL` is consumed only by `docker-compose.prod.yml` (the Keycloak/OIDC prod overlay) and was never documented in `.env.example`. Anyone enabling the prod overlay behind a reverse proxy or Tailscale serve had no discoverable hint that it must match their exact browse origin (scheme + host + port) — a mismatch produces a Keycloak `Invalid parameter: redirect_uri` error, since the realm client uses a relative `redirectUris: ["/*"]` resolved against `PUBLIC_URL`.

Adds a commented-out, documented entry under `NGINX_PORT`.

## Notes

- Commented out + no behaviour change: the base stack ignores it, and the prod overlay still defaults to `http://localhost:8888` when unset.
- Documents the port nuance (include `:8888` for the dev default; omit for standard 80/443 behind TLS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guidance for configuring the browser origin in the example environment file.
  * Clarified how to set the public URL for production use, including support for non-standard ports and default behavior when unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->