### PR TITLE
feat(monitor): Capture Timeline time-slicing view + Manage PCAPs

### DIFF
--- a/frontend/src/components/monitor/ManagePcapsModal/ManagePcapsModal.tsx
+++ b/frontend/src/components/monitor/ManagePcapsModal/ManagePcapsModal.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+import { Button, Modal } from '@govtechsg/sgds-react';
+import { Spinner } from '@components/common/Spinner/Spinner';
+import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
+import { ScrollableTable } from '@/components/common/ScrollableTable';
+import { parseDateTime } from '@/utils/dateUtils';
+
+interface ManagePcapsModalProps {
+  show: boolean;
+  onHide: () => void;
+  snapshots: NetworkSnapshot[];
+  onRemove: (snapshotId: string) => Promise<void>;
+  onAddSnapshot: () => void;
+}
+
+function formatCaptureDate(start: string | null): string {
+  if (!start) return '—';
+  const ms = parseDateTime(start as unknown as string | number[]);
+  return new Date(ms).toLocaleString('en-GB');
+}
+
+function getStartMs(snap: NetworkSnapshot): number {
+  if (!snap.startTime) return 0;
+  return parseDateTime(snap.startTime as unknown as string | number[]);
+}
+
+export const ManagePcapsModal = ({
+  show,
+  onHide,
+  snapshots,
+  onRemove,
+  onAddSnapshot,
+}: ManagePcapsModalProps) => {
+  const [removing, setRemoving] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+
+  const sorted = [...snapshots].sort((a, b) => getStartMs(b) - getStartMs(a));
+
+  const handleRemove = async (snapshotId: string) => {
+    setRemoving(snapshotId);
+    try {
+      await onRemove(snapshotId);
+      setConfirmRemove(null);
+    } finally {
+      setRemoving(null);
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onHide} size="lg" centered>
+      <Modal.Header closeButton>
+        <Modal.Title>
+          <i className="bi bi-collection me-2"></i>Manage PCAPs
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <span className="text-muted">
+            {snapshots.length} PCAP{snapshots.length !== 1 ? 's' : ''} in this network
+          </span>
+          <Button size="sm" variant="primary" onClick={onAddSnapshot}>
+            <i className="bi bi-plus-lg me-1"></i>Add PCAP
+          </Button>
+        </div>
+
+        {snapshots.length === 0 ? (
+          <div className="text-muted text-center py-4">
+            No PCAPs yet. Click "Add PCAP" to get started.
+          </div>
+        ) : (
+          <div className="border rounded overflow-hidden">
+            <ScrollableTable maxHeight="50vh">
+              <table className="table table-hover align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th className="text-muted fw-normal" style={{ whiteSpace: 'nowrap' }}>Captured</th>
+                    <th className="text-muted fw-normal">File</th>
+                    <th className="text-muted fw-normal">Packets</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map(snap => (
+                    <tr key={snap.id}>
+                      <td>
+                        <small className="text-muted">{formatCaptureDate(snap.startTime)}</small>
+                      </td>
+                      <td>
+                        <span className="fw-medium text-break">{snap.fileName}</span>
+                      </td>
+                      <td>
+                        <small className="text-muted">
+                          {snap.packetCount != null ? snap.packetCount.toLocaleString() : '—'}
+                        </small>
+                      </td>
+                      <td className="text-end">
+                        {confirmRemove === snap.id ? (
+                          <span className="d-inline-flex align-items-center gap-2">
+                            <small className="text-muted">Remove?</small>
+                            <Button
+                              size="sm"
+                              variant="outline-secondary"
+                              onClick={() => setConfirmRemove(null)}
+                              disabled={removing !== null}
+                            >
+                              Cancel
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="danger"
+                              onClick={() => handleRemove(snap.id)}
+                              disabled={removing !== null}
+                            >
+                              {removing === snap.id ? (
+                                <Spinner animation="border" size="sm" />
+                              ) : (
+                                'Remove'
+                              )}
+                            </Button>
+                          </span>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="outline-danger"
+                            onClick={() => setConfirmRemove(snap.id)}
+                            disabled={removing !== null}
+                            title="Remove PCAP"
+                          >
+                            <i className="bi bi-trash"></i>
+                          </Button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </ScrollableTable>
+          </div>
+        )}
+
+        <p className="text-muted small mt-3 mb-0">
+          <i className="bi bi-info-circle me-1"></i>
+          Removing a PCAP only detaches it from this network — the original file is not deleted.
+        </p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="outline-secondary" onClick={onHide}>
+          Done
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};

--- a/frontend/src/components/monitor/ManagePcapsModal/ManagePcapsModal.tsx
+++ b/frontend/src/components/monitor/ManagePcapsModal/ManagePcapsModal.tsx
@@ -16,6 +16,7 @@ interface ManagePcapsModalProps {
 function formatCaptureDate(start: string | null): string {
   if (!start) return '—';
   const ms = parseDateTime(start as unknown as string | number[]);
+  if (Number.isNaN(ms) || ms === 0) return '—';
   return new Date(ms).toLocaleString('en-GB');
 }
 
@@ -34,6 +35,12 @@ export const ManagePcapsModal = ({
   const [removing, setRemoving] = useState<string | null>(null);
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
 
+  const handleHide = () => {
+    setRemoving(null);
+    setConfirmRemove(null);
+    onHide();
+  };
+
   const sorted = [...snapshots].sort((a, b) => getStartMs(b) - getStartMs(a));
 
   const handleRemove = async (snapshotId: string) => {
@@ -47,7 +54,7 @@ export const ManagePcapsModal = ({
   };
 
   return (
-    <Modal show={show} onHide={onHide} size="lg" centered>
+    <Modal show={show} onHide={handleHide} size="lg" centered>
       <Modal.Header closeButton>
         <Modal.Title>
           <i className="bi bi-collection me-2"></i>Manage PCAPs
@@ -125,6 +132,7 @@ export const ManagePcapsModal = ({
                             onClick={() => setConfirmRemove(snap.id)}
                             disabled={removing !== null}
                             title="Remove PCAP"
+                            aria-label={`Remove PCAP ${snap.fileName}`}
                           >
                             <i className="bi bi-trash"></i>
                           </Button>
@@ -144,7 +152,7 @@ export const ManagePcapsModal = ({
         </p>
       </Modal.Body>
       <Modal.Footer>
-        <Button variant="outline-secondary" onClick={onHide}>
+        <Button variant="outline-secondary" onClick={handleHide}>
           Done
         </Button>
       </Modal.Footer>

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -258,22 +258,6 @@ export const SnapshotTimeline = ({
           {snapshots.length} snapshot{snapshots.length !== 1 ? 's' : ''}
         </h6>
         <div className="d-flex align-items-center gap-2 flex-wrap">
-          <ButtonGroup size="sm">
-            <Button
-              variant={viewMode === 'file' ? 'primary' : 'outline-primary'}
-              onClick={() => changeMode('file')}
-              title="One row per PCAP file"
-            >
-              By PCAP
-            </Button>
-            <Button
-              variant={viewMode === 'time' ? 'primary' : 'outline-primary'}
-              onClick={() => changeMode('time')}
-              title="Group captures into time intervals"
-            >
-              By Time
-            </Button>
-          </ButtonGroup>
           {viewMode === 'time' && (
             <div className="d-flex align-items-center gap-1">
               <label className="text-muted small mb-0">Interval:</label>
@@ -292,6 +276,22 @@ export const SnapshotTimeline = ({
               </Form.Select>
             </div>
           )}
+          <ButtonGroup size="sm">
+            <Button
+              variant={viewMode === 'file' ? 'primary' : 'outline-primary'}
+              onClick={() => changeMode('file')}
+              title="One row per PCAP file"
+            >
+              By PCAP
+            </Button>
+            <Button
+              variant={viewMode === 'time' ? 'primary' : 'outline-primary'}
+              onClick={() => changeMode('time')}
+              title="Group captures into time intervals"
+            >
+              By Time
+            </Button>
+          </ButtonGroup>
           <Button size="sm" variant="outline-secondary" onClick={onAddSnapshot}>
             <i className="bi bi-plus-lg me-1"></i>Add PCAP
           </Button>

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -1,6 +1,5 @@
-import { Spinner } from '@components/common/Spinner/Spinner';
 import { Fragment, useMemo, useState, type MouseEvent } from 'react';
-import { Badge, Button, ButtonGroup, Form, Modal } from '@govtechsg/sgds-react';
+import { Badge, Button, ButtonGroup, Form } from '@govtechsg/sgds-react';
 import type { NetworkSnapshot, ChangeEvent } from '@/features/monitor/types/monitor.types';
 import { Pagination } from '@/components/common/Pagination';
 import { ScrollableTable } from '@/components/common/ScrollableTable';
@@ -11,8 +10,7 @@ interface SnapshotTimelineProps {
   networkId: string;
   snapshots: NetworkSnapshot[];
   changeEvents: ChangeEvent[];
-  onRemove: (snapshotId: string) => Promise<void>;
-  onAddSnapshot: () => void;
+  onManage: () => void;
   onPatchChange: (eventId: string, patch: { reviewed?: boolean; notes?: string | null }) => Promise<void>;
   onSnapshotUpdated: (updated: NetworkSnapshot) => void;
 }
@@ -93,13 +91,10 @@ export const SnapshotTimeline = ({
   networkId,
   snapshots,
   changeEvents,
-  onRemove,
-  onAddSnapshot,
+  onManage,
   onPatchChange,
   onSnapshotUpdated,
 }: SnapshotTimelineProps) => {
-  const [removing, setRemoving] = useState<string | null>(null);
-  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
   const [detailSnap, setDetailSnap] = useState<NetworkSnapshot | null>(null);
   const [detailInitialTab, setDetailInitialTab] = useState<'diagram' | 'changes' | 'context' | 'insights'>('diagram');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
@@ -108,16 +103,6 @@ export const SnapshotTimeline = ({
   const [viewMode, setViewMode] = useState<ViewMode>('file');
   const [granularity, setGranularity] = useState<Granularity>(3600);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
-
-  const handleRemove = async (snapshotId: string) => {
-    setRemoving(snapshotId);
-    setConfirmRemove(null);
-    try {
-      await onRemove(snapshotId);
-    } finally {
-      setRemoving(null);
-    }
-  };
 
   const toggleSort = () => {
     setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
@@ -237,17 +222,6 @@ export const SnapshotTimeline = ({
           setDetailSnap(snap);
         })}
       </td>
-      <td onClick={e => e.stopPropagation()}>
-        <Button
-          size="sm"
-          variant="outline-danger"
-          onClick={() => setConfirmRemove(snap.id)}
-          disabled={removing !== null}
-          title="Remove snapshot"
-        >
-          <i className="bi bi-trash"></i>
-        </Button>
-      </td>
     </tr>
   );
 
@@ -292,15 +266,15 @@ export const SnapshotTimeline = ({
               By Time
             </Button>
           </ButtonGroup>
-          <Button size="sm" variant="outline-secondary" onClick={onAddSnapshot}>
-            <i className="bi bi-plus-lg me-1"></i>Add PCAP
+          <Button size="sm" variant="outline-secondary" onClick={onManage}>
+            <i className="bi bi-collection me-1"></i>Manage PCAPs
           </Button>
         </div>
       </div>
 
       {snapshots.length === 0 ? (
         <div className="text-muted text-center py-4">
-          No PCAPs added yet. Click "Add PCAP" to get started.
+          No PCAPs added yet. Click "Manage PCAPs" to get started.
         </div>
       ) : (
         <>
@@ -318,7 +292,6 @@ export const SnapshotTimeline = ({
                     <th className="text-muted fw-normal">Duration</th>
                     <th className="text-muted fw-normal">Packets</th>
                     <th className="text-muted fw-normal">Changes</th>
-                    <th></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -405,36 +378,6 @@ export const SnapshotTimeline = ({
           onHide={() => setDetailSnap(null)}
         />
       )}
-
-      <Modal show={!!confirmRemove} onHide={() => setConfirmRemove(null)} centered>
-        <Modal.Header closeButton>
-          <Modal.Title>Remove Snapshot</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <p className="mb-0">
-            Are you sure you want to remove{' '}
-            <strong>{snapshots.find(s => s.id === confirmRemove)?.fileName}</strong>?{' '}
-            The original PCAP file will not be deleted.
-          </p>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button
-            variant="outline-secondary"
-            onClick={() => setConfirmRemove(null)}
-            disabled={removing !== null}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="outline-danger"
-            onClick={() => confirmRemove && handleRemove(confirmRemove)}
-            disabled={removing !== null}
-          >
-            {removing ? <Spinner animation="border" size="sm" className="me-1" /> : null}
-            Remove
-          </Button>
-        </Modal.Footer>
-      </Modal>
     </div>
   );
 };

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -24,12 +24,12 @@ type Granularity = number | 'month';
 
 // Time-interval options for the "By Time" view, mirroring the Traffic Overview chart.
 const GRANULARITY_OPTIONS: { label: string; value: Granularity }[] = [
-  { label: '1m',      value: 60 },
-  { label: '5m',      value: 300 },
-  { label: '30m',     value: 1800 },
-  { label: '1h',      value: 3600 },
-  { label: '1d',      value: 86400 },
-  { label: '1 month', value: 'month' },
+  { label: '1m',  value: 60 },
+  { label: '5m',  value: 300 },
+  { label: '30m', value: 1800 },
+  { label: '1h',  value: 3600 },
+  { label: '1d',  value: 86400 },
+  { label: '1mo', value: 'month' },
 ];
 
 interface TimeBucket {

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
-import { useState } from 'react';
-import { Badge, Button, Modal } from '@govtechsg/sgds-react';
+import { Fragment, useMemo, useState } from 'react';
+import { Badge, Button, ButtonGroup, Form, Modal } from '@govtechsg/sgds-react';
 import type { NetworkSnapshot, ChangeEvent } from '@/features/monitor/types/monitor.types';
 import { Pagination } from '@/components/common/Pagination';
 import { ScrollableTable } from '@/components/common/ScrollableTable';
@@ -18,6 +18,37 @@ interface SnapshotTimelineProps {
 }
 
 type SortDir = 'asc' | 'desc';
+type ViewMode = 'file' | 'time';
+
+// Time-interval options for the "By Time" view, mirroring the Traffic Overview chart.
+const GRANULARITY_OPTIONS: { label: string; seconds: number }[] = [
+  { label: '1m',  seconds: 60 },
+  { label: '5m',  seconds: 300 },
+  { label: '30m', seconds: 1800 },
+  { label: '1h',  seconds: 3600 },
+  { label: '1d',  seconds: 86400 },
+];
+
+interface TimeBucket {
+  key: string;
+  start: number; // bucket start (ms); NaN for the "unknown capture time" group
+  snaps: NetworkSnapshot[];
+  packets: number;
+  changes: number;
+  critical: number;
+}
+
+function formatBucketLabel(startMs: number, granularitySec: number): string {
+  if (Number.isNaN(startMs)) return 'Unknown capture time';
+  const start = new Date(startMs);
+  if (granularitySec >= 86400) {
+    return start.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+  }
+  const end = new Date(startMs + granularitySec * 1000);
+  const timeOpts: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };
+  const dateStr = start.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
+  return `${dateStr}, ${start.toLocaleTimeString('en-GB', timeOpts)}–${end.toLocaleTimeString('en-GB', timeOpts)}`;
+}
 
 function formatCaptureDate(start: string | null): string {
   if (!start) return '—';
@@ -58,6 +89,9 @@ export const SnapshotTimeline = ({
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
+  const [viewMode, setViewMode] = useState<ViewMode>('file');
+  const [granularity, setGranularity] = useState(3600);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   const handleRemove = async (snapshotId: string) => {
     setRemoving(snapshotId);
@@ -74,23 +108,183 @@ export const SnapshotTimeline = ({
     setPage(1);
   };
 
+  const changeMode = (mode: ViewMode) => {
+    setViewMode(mode);
+    setPage(1);
+    setExpanded(new Set());
+  };
+
+  const changeGranularity = (secs: number) => {
+    setGranularity(secs);
+    setPage(1);
+    setExpanded(new Set());
+  };
+
+  const toggleExpand = (key: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
   const sorted = [...snapshots].sort((a, b) => {
     const diff = getStartMs(a) - getStartMs(b);
     return sortDir === 'asc' ? diff : -diff;
   });
 
-  const totalPages = Math.ceil(sorted.length / pageSize);
+  // Group snapshots into time buckets for the "By Time" view (purely client-side).
+  const buckets = useMemo<TimeBucket[]>(() => {
+    const bucketMs = granularity * 1000;
+    const map = new Map<number, NetworkSnapshot[]>();
+    const noTime: NetworkSnapshot[] = [];
+    for (const snap of snapshots) {
+      if (!snap.startTime) {
+        noTime.push(snap);
+        continue;
+      }
+      const start = Math.floor(getStartMs(snap) / bucketMs) * bucketMs;
+      const arr = map.get(start) ?? [];
+      arr.push(snap);
+      map.set(start, arr);
+    }
+    const toBucket = (start: number, snaps: NetworkSnapshot[]): TimeBucket => ({
+      key: Number.isNaN(start) ? 'unknown' : String(start),
+      start,
+      snaps: [...snaps].sort((a, b) => getStartMs(a) - getStartMs(b)),
+      packets: snaps.reduce((s, x) => s + (x.packetCount ?? 0), 0),
+      changes: snaps.reduce((s, x) => s + x.changeCount, 0),
+      critical: snaps.reduce((s, x) => s + x.criticalCount, 0),
+    });
+    const list = [...map.entries()]
+      .map(([start, snaps]) => toBucket(start, snaps))
+      .sort((a, b) => (sortDir === 'asc' ? a.start - b.start : b.start - a.start));
+    if (noTime.length) list.push(toBucket(NaN, noTime));
+    return list;
+  }, [snapshots, granularity, sortDir]);
+
+  const totalItems = viewMode === 'file' ? sorted.length : buckets.length;
+  const totalPages = Math.ceil(totalItems / pageSize);
   const paginated = sorted.slice((page - 1) * pageSize, page * pageSize);
+  const paginatedBuckets = buckets.slice((page - 1) * pageSize, page * pageSize);
+
+  const renderSnapshotRow = (snap: NetworkSnapshot) => (
+    <tr
+      key={snap.id}
+      style={{ cursor: 'pointer' }}
+      onClick={() => { setDetailInitialTab('diagram'); setDetailSnap(snap); }}
+    >
+      <td>
+        <small className="text-muted">{formatCaptureDate(snap.startTime)}</small>
+      </td>
+      <td>
+        <span className="fw-medium text-break">{snap.fileName}</span>
+      </td>
+      <td>
+        <small className="text-muted">{formatDuration(snap.startTime, snap.endTime)}</small>
+      </td>
+      <td>
+        <small className="text-muted">{snap.packetCount != null ? snap.packetCount.toLocaleString() : '—'}</small>
+      </td>
+      <td>
+        {snap.changeCount === 0 ? (
+          <Badge bg="light" text="muted" className="border">No changes</Badge>
+        ) : snap.criticalCount > 0 ? (
+          <Button
+            type="button"
+            variant="danger"
+            size="sm"
+            className="border-0 py-0 px-1"
+            style={{ fontSize: '0.75em' }}
+            onClick={e => { e.stopPropagation(); setDetailInitialTab('changes'); setDetailSnap(snap); }}
+          >
+            {snap.criticalCount} critical
+            {snap.changeCount > snap.criticalCount &&
+              `, ${snap.changeCount - snap.criticalCount} more`}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="warning"
+            size="sm"
+            className="border-0 py-0 px-1"
+            style={{ fontSize: '0.75em' }}
+            onClick={e => { e.stopPropagation(); setDetailInitialTab('changes'); setDetailSnap(snap); }}
+          >
+            {snap.changeCount} change{snap.changeCount !== 1 ? 's' : ''}
+          </Button>
+        )}
+      </td>
+      <td onClick={e => e.stopPropagation()}>
+        <Button
+          size="sm"
+          variant="outline-danger"
+          onClick={() => setConfirmRemove(snap.id)}
+          disabled={removing !== null}
+          title="Remove snapshot"
+        >
+          <i className="bi bi-trash"></i>
+        </Button>
+      </td>
+    </tr>
+  );
+
+  const renderBucketBadge = (b: TimeBucket) => {
+    if (b.changes === 0) return <Badge bg="light" text="muted" className="border">No changes</Badge>;
+    if (b.critical > 0) {
+      return (
+        <Badge bg="danger">
+          {b.critical} critical
+          {b.changes > b.critical && `, ${b.changes - b.critical} more`}
+        </Badge>
+      );
+    }
+    return <Badge bg="warning" text="dark">{b.changes} change{b.changes !== 1 ? 's' : ''}</Badge>;
+  };
 
   return (
     <div>
-      <div className="d-flex justify-content-between align-items-center mb-3">
+      <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
         <h6 className="mb-0 text-muted fw-normal">
           {snapshots.length} snapshot{snapshots.length !== 1 ? 's' : ''}
         </h6>
-        <Button size="sm" variant="outline-secondary" onClick={onAddSnapshot}>
-          <i className="bi bi-plus-lg me-1"></i>Add PCAP
-        </Button>
+        <div className="d-flex align-items-center gap-2 flex-wrap">
+          <ButtonGroup size="sm">
+            <Button
+              variant={viewMode === 'file' ? 'primary' : 'outline-primary'}
+              onClick={() => changeMode('file')}
+              title="One row per PCAP file"
+            >
+              By PCAP
+            </Button>
+            <Button
+              variant={viewMode === 'time' ? 'primary' : 'outline-primary'}
+              onClick={() => changeMode('time')}
+              title="Group captures into time intervals"
+            >
+              By Time
+            </Button>
+          </ButtonGroup>
+          {viewMode === 'time' && (
+            <div className="d-flex align-items-center gap-1">
+              <label className="text-muted small mb-0">Interval:</label>
+              <Form.Select
+                size="sm"
+                style={{ width: 'auto' }}
+                value={String(granularity)}
+                onChange={e => changeGranularity(Number(e.target.value))}
+              >
+                {GRANULARITY_OPTIONS.map(({ label, seconds }) => (
+                  <option key={seconds} value={String(seconds)}>{label}</option>
+                ))}
+              </Form.Select>
+            </div>
+          )}
+          <Button size="sm" variant="outline-secondary" onClick={onAddSnapshot}>
+            <i className="bi bi-plus-lg me-1"></i>Add PCAP
+          </Button>
+        </div>
       </div>
 
       {snapshots.length === 0 ? (
@@ -101,91 +295,79 @@ export const SnapshotTimeline = ({
         <>
           <div className="border rounded overflow-hidden">
           <ScrollableTable maxHeight="50vh">
-            <table className="table table-hover align-middle mb-0">
-              <thead>
-                <tr>
-                  <th className="text-muted fw-normal" style={{ cursor: 'pointer', whiteSpace: 'nowrap' }} onClick={toggleSort}>
-                    Captured{' '}
-                    <i className={`bi bi-arrow-${sortDir === 'asc' ? 'up' : 'down'} ms-1`}></i>
-                  </th>
-                  <th className="text-muted fw-normal">File</th>
-                  <th className="text-muted fw-normal">Duration</th>
-                  <th className="text-muted fw-normal">Packets</th>
-                  <th className="text-muted fw-normal">Changes</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {paginated.map(snap => {
-                  return (
-                    <tr
-                      key={snap.id}
-                      style={{ cursor: 'pointer' }}
-                      onClick={() => { setDetailInitialTab('diagram'); setDetailSnap(snap); }}
-                    >
-                      <td>
-                        <small className="text-muted">{formatCaptureDate(snap.startTime)}</small>
-                      </td>
-                      <td>
-                        <span className="fw-medium text-break">{snap.fileName}</span>
-                      </td>
-                      <td>
-                        <small className="text-muted">{formatDuration(snap.startTime, snap.endTime)}</small>
-                      </td>
-                      <td>
-                        <small className="text-muted">{snap.packetCount != null ? snap.packetCount.toLocaleString() : '—'}</small>
-                      </td>
-                      <td>
-                        {snap.changeCount === 0 ? (
-                          <Badge bg="light" text="muted" className="border">No changes</Badge>
-                        ) : snap.criticalCount > 0 ? (
-                          <Button
-                            type="button"
-                            variant="danger"
-                            size="sm"
-                            className="border-0 py-0 px-1"
-                            style={{ fontSize: '0.75em' }}
-                            onClick={e => { e.stopPropagation(); setDetailInitialTab('changes'); setDetailSnap(snap); }}
-                          >
-                            {snap.criticalCount} critical
-                            {snap.changeCount > snap.criticalCount &&
-                              `, ${snap.changeCount - snap.criticalCount} more`}
-                          </Button>
-                        ) : (
-                          <Button
-                            type="button"
-                            variant="warning"
-                            size="sm"
-                            className="border-0 py-0 px-1"
-                            style={{ fontSize: '0.75em' }}
-                            onClick={e => { e.stopPropagation(); setDetailInitialTab('changes'); setDetailSnap(snap); }}
-                          >
-                            {snap.changeCount} change{snap.changeCount !== 1 ? 's' : ''}
-                          </Button>
+            {viewMode === 'file' ? (
+              <table className="table table-hover align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th className="text-muted fw-normal" style={{ cursor: 'pointer', whiteSpace: 'nowrap' }} onClick={toggleSort}>
+                      Captured{' '}
+                      <i className={`bi bi-arrow-${sortDir === 'asc' ? 'up' : 'down'} ms-1`}></i>
+                    </th>
+                    <th className="text-muted fw-normal">File</th>
+                    <th className="text-muted fw-normal">Duration</th>
+                    <th className="text-muted fw-normal">Packets</th>
+                    <th className="text-muted fw-normal">Changes</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {paginated.map(renderSnapshotRow)}
+                </tbody>
+              </table>
+            ) : (
+              <table className="table table-hover align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th className="text-muted fw-normal" style={{ cursor: 'pointer', whiteSpace: 'nowrap' }} onClick={toggleSort}>
+                      Period{' '}
+                      <i className={`bi bi-arrow-${sortDir === 'asc' ? 'up' : 'down'} ms-1`}></i>
+                    </th>
+                    <th className="text-muted fw-normal">Captures</th>
+                    <th className="text-muted fw-normal">Packets</th>
+                    <th className="text-muted fw-normal">Changes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {paginatedBuckets.map(b => {
+                    const isOpen = expanded.has(b.key);
+                    return (
+                      <Fragment key={b.key}>
+                        <tr style={{ cursor: 'pointer' }} onClick={() => toggleExpand(b.key)}>
+                          <td className="fw-medium" style={{ whiteSpace: 'nowrap' }}>
+                            <i className={`bi bi-chevron-${isOpen ? 'down' : 'right'} me-2 text-muted`}></i>
+                            {formatBucketLabel(b.start, granularity)}
+                          </td>
+                          <td>
+                            <small className="text-muted">{b.snaps.length}</small>
+                          </td>
+                          <td>
+                            <small className="text-muted">{b.packets.toLocaleString()}</small>
+                          </td>
+                          <td>{renderBucketBadge(b)}</td>
+                        </tr>
+                        {isOpen && (
+                          <tr>
+                            <td colSpan={4} className="p-0 bg-light">
+                              <table className="table table-sm table-hover align-middle mb-0">
+                                <tbody>
+                                  {b.snaps.map(renderSnapshotRow)}
+                                </tbody>
+                              </table>
+                            </td>
+                          </tr>
                         )}
-                      </td>
-                      <td onClick={e => e.stopPropagation()}>
-                        <Button
-                          size="sm"
-                          variant="outline-danger"
-                          onClick={() => setConfirmRemove(snap.id)}
-                          disabled={removing !== null}
-                          title="Remove snapshot"
-                        >
-                          <i className="bi bi-trash"></i>
-                        </Button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+                      </Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
           </ScrollableTable>
           <div className="border-top px-3 py-2">
             <Pagination
               currentPage={page}
               totalPages={totalPages}
-              totalItems={snapshots.length}
+              totalItems={totalItems}
               pageSize={pageSize}
               onPageChange={setPage}
               showPageSizeSelector

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState, type MouseEvent } from 'react';
+import { Fragment, useEffect, useMemo, useState, type MouseEvent } from 'react';
 import { Badge, Button, ButtonGroup, Form } from '@govtechsg/sgds-react';
 import type { NetworkSnapshot, ChangeEvent } from '@/features/monitor/types/monitor.types';
 import { Pagination } from '@/components/common/Pagination';
@@ -67,6 +67,7 @@ function formatBucketLabel(startMs: number, granularity: Granularity): string {
 function formatCaptureDate(start: string | null): string {
   if (!start) return '—';
   const ms = parseDateTime(start as unknown as string | number[]);
+  if (Number.isNaN(ms) || ms === 0) return '—';
   return new Date(ms).toLocaleString('en-GB');
 }
 
@@ -140,11 +141,13 @@ export const SnapshotTimeline = ({
     const map = new Map<number, NetworkSnapshot[]>();
     const noTime: NetworkSnapshot[] = [];
     for (const snap of snapshots) {
-      if (!snap.startTime) {
+      const startMs = getStartMs(snap);
+      // Missing or unparseable start times all share the single "unknown" bucket.
+      if (!snap.startTime || Number.isNaN(startMs)) {
         noTime.push(snap);
         continue;
       }
-      const start = bucketStartFor(getStartMs(snap), granularity);
+      const start = bucketStartFor(startMs, granularity);
       const arr = map.get(start) ?? [];
       arr.push(snap);
       map.set(start, arr);
@@ -165,9 +168,14 @@ export const SnapshotTimeline = ({
   }, [snapshots, granularity, sortDir]);
 
   const totalItems = viewMode === 'file' ? sorted.length : buckets.length;
-  const totalPages = Math.ceil(totalItems / pageSize);
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
   const paginated = sorted.slice((page - 1) * pageSize, page * pageSize);
   const paginatedBuckets = buckets.slice((page - 1) * pageSize, page * pageSize);
+
+  // Snapshots can be removed elsewhere (the Manage PCAPs modal); keep page in range.
+  useEffect(() => {
+    setPage(prev => Math.min(prev, totalPages));
+  }, [totalPages]);
 
   // Shared "Changes" cell for both views — always the same Badge pill so the By PCAP
   // rows, the By Time bucket aggregate, and the nested per-PCAP rows look identical.
@@ -333,6 +341,15 @@ export const SnapshotTimeline = ({
                           <tr>
                             <td colSpan={4} className="p-0 bg-light">
                               <table className="table table-sm table-hover align-middle mb-0">
+                                <thead>
+                                  <tr>
+                                    <th className="text-muted fw-normal small border-0">Captured</th>
+                                    <th className="text-muted fw-normal small border-0">File</th>
+                                    <th className="text-muted fw-normal small border-0">Duration</th>
+                                    <th className="text-muted fw-normal small border-0">Packets</th>
+                                    <th className="text-muted fw-normal small border-0">Changes</th>
+                                  </tr>
+                                </thead>
                                 <tbody>
                                   {b.snaps.map(renderSnapshotRow)}
                                 </tbody>

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useMemo, useState, type MouseEvent } from 'react';
 import { Badge, Button, ButtonGroup, Form, Modal } from '@govtechsg/sgds-react';
 import type { NetworkSnapshot, ChangeEvent } from '@/features/monitor/types/monitor.types';
 import { Pagination } from '@/components/common/Pagination';
@@ -19,14 +19,17 @@ interface SnapshotTimelineProps {
 
 type SortDir = 'asc' | 'desc';
 type ViewMode = 'file' | 'time';
+// Fixed-length intervals are stored as seconds; 'month' is a calendar month (variable length).
+type Granularity = number | 'month';
 
 // Time-interval options for the "By Time" view, mirroring the Traffic Overview chart.
-const GRANULARITY_OPTIONS: { label: string; seconds: number }[] = [
-  { label: '1m',  seconds: 60 },
-  { label: '5m',  seconds: 300 },
-  { label: '30m', seconds: 1800 },
-  { label: '1h',  seconds: 3600 },
-  { label: '1d',  seconds: 86400 },
+const GRANULARITY_OPTIONS: { label: string; value: Granularity }[] = [
+  { label: '1m',      value: 60 },
+  { label: '5m',      value: 300 },
+  { label: '30m',     value: 1800 },
+  { label: '1h',      value: 3600 },
+  { label: '1d',      value: 86400 },
+  { label: '1 month', value: 'month' },
 ];
 
 interface TimeBucket {
@@ -38,13 +41,26 @@ interface TimeBucket {
   critical: number;
 }
 
-function formatBucketLabel(startMs: number, granularitySec: number): string {
+// Start (ms) of the bucket a given timestamp falls into for the active granularity.
+function bucketStartFor(ms: number, granularity: Granularity): number {
+  if (granularity === 'month') {
+    const d = new Date(ms);
+    return new Date(d.getFullYear(), d.getMonth(), 1).getTime();
+  }
+  const bucketMs = granularity * 1000;
+  return Math.floor(ms / bucketMs) * bucketMs;
+}
+
+function formatBucketLabel(startMs: number, granularity: Granularity): string {
   if (Number.isNaN(startMs)) return 'Unknown capture time';
   const start = new Date(startMs);
-  if (granularitySec >= 86400) {
+  if (granularity === 'month') {
+    return start.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
+  }
+  if (granularity >= 86400) {
     return start.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
   }
-  const end = new Date(startMs + granularitySec * 1000);
+  const end = new Date(startMs + granularity * 1000);
   const timeOpts: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };
   const dateStr = start.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
   return `${dateStr}, ${start.toLocaleTimeString('en-GB', timeOpts)}–${end.toLocaleTimeString('en-GB', timeOpts)}`;
@@ -90,7 +106,7 @@ export const SnapshotTimeline = ({
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [viewMode, setViewMode] = useState<ViewMode>('file');
-  const [granularity, setGranularity] = useState(3600);
+  const [granularity, setGranularity] = useState<Granularity>(3600);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   const handleRemove = async (snapshotId: string) => {
@@ -114,8 +130,8 @@ export const SnapshotTimeline = ({
     setExpanded(new Set());
   };
 
-  const changeGranularity = (secs: number) => {
-    setGranularity(secs);
+  const changeGranularity = (value: Granularity) => {
+    setGranularity(value);
     setPage(1);
     setExpanded(new Set());
   };
@@ -136,7 +152,6 @@ export const SnapshotTimeline = ({
 
   // Group snapshots into time buckets for the "By Time" view (purely client-side).
   const buckets = useMemo<TimeBucket[]>(() => {
-    const bucketMs = granularity * 1000;
     const map = new Map<number, NetworkSnapshot[]>();
     const noTime: NetworkSnapshot[] = [];
     for (const snap of snapshots) {
@@ -144,7 +159,7 @@ export const SnapshotTimeline = ({
         noTime.push(snap);
         continue;
       }
-      const start = Math.floor(getStartMs(snap) / bucketMs) * bucketMs;
+      const start = bucketStartFor(getStartMs(snap), granularity);
       const arr = map.get(start) ?? [];
       arr.push(snap);
       map.set(start, arr);
@@ -169,6 +184,34 @@ export const SnapshotTimeline = ({
   const paginated = sorted.slice((page - 1) * pageSize, page * pageSize);
   const paginatedBuckets = buckets.slice((page - 1) * pageSize, page * pageSize);
 
+  // Shared "Changes" cell for both views — always the same Badge pill so the By PCAP
+  // rows, the By Time bucket aggregate, and the nested per-PCAP rows look identical.
+  // Pass onClick to make it clickable (per-PCAP rows jump to the changes tab).
+  const renderChangesPill = (
+    changeCount: number,
+    criticalCount: number,
+    onClick?: (e: MouseEvent<HTMLElement>) => void,
+  ) => {
+    if (changeCount === 0) {
+      return <Badge bg="light" text="muted" className="border fw-normal">No changes</Badge>;
+    }
+    const variant = criticalCount > 0 ? 'danger' : 'warning';
+    const label = criticalCount > 0
+      ? `${criticalCount} critical${changeCount > criticalCount ? `, ${changeCount - criticalCount} more` : ''}`
+      : `${changeCount} change${changeCount !== 1 ? 's' : ''}`;
+    return (
+      <Badge
+        bg={variant}
+        text={variant === 'warning' ? 'dark' : undefined}
+        className="fw-normal"
+        style={onClick ? { cursor: 'pointer' } : undefined}
+        onClick={onClick}
+      >
+        {label}
+      </Badge>
+    );
+  };
+
   const renderSnapshotRow = (snap: NetworkSnapshot) => (
     <tr
       key={snap.id}
@@ -188,33 +231,11 @@ export const SnapshotTimeline = ({
         <small className="text-muted">{snap.packetCount != null ? snap.packetCount.toLocaleString() : '—'}</small>
       </td>
       <td>
-        {snap.changeCount === 0 ? (
-          <Badge bg="light" text="muted" className="border">No changes</Badge>
-        ) : snap.criticalCount > 0 ? (
-          <Button
-            type="button"
-            variant="danger"
-            size="sm"
-            className="border-0 py-0 px-1"
-            style={{ fontSize: '0.75em' }}
-            onClick={e => { e.stopPropagation(); setDetailInitialTab('changes'); setDetailSnap(snap); }}
-          >
-            {snap.criticalCount} critical
-            {snap.changeCount > snap.criticalCount &&
-              `, ${snap.changeCount - snap.criticalCount} more`}
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            variant="warning"
-            size="sm"
-            className="border-0 py-0 px-1"
-            style={{ fontSize: '0.75em' }}
-            onClick={e => { e.stopPropagation(); setDetailInitialTab('changes'); setDetailSnap(snap); }}
-          >
-            {snap.changeCount} change{snap.changeCount !== 1 ? 's' : ''}
-          </Button>
-        )}
+        {renderChangesPill(snap.changeCount, snap.criticalCount, e => {
+          e.stopPropagation();
+          setDetailInitialTab('changes');
+          setDetailSnap(snap);
+        })}
       </td>
       <td onClick={e => e.stopPropagation()}>
         <Button
@@ -229,19 +250,6 @@ export const SnapshotTimeline = ({
       </td>
     </tr>
   );
-
-  const renderBucketBadge = (b: TimeBucket) => {
-    if (b.changes === 0) return <Badge bg="light" text="muted" className="border">No changes</Badge>;
-    if (b.critical > 0) {
-      return (
-        <Badge bg="danger">
-          {b.critical} critical
-          {b.changes > b.critical && `, ${b.changes - b.critical} more`}
-        </Badge>
-      );
-    }
-    return <Badge bg="warning" text="dark">{b.changes} change{b.changes !== 1 ? 's' : ''}</Badge>;
-  };
 
   return (
     <div>
@@ -273,10 +281,13 @@ export const SnapshotTimeline = ({
                 size="sm"
                 style={{ width: 'auto' }}
                 value={String(granularity)}
-                onChange={e => changeGranularity(Number(e.target.value))}
+                onChange={e => {
+                  const v = e.target.value;
+                  changeGranularity(v === 'month' ? 'month' : Number(v));
+                }}
               >
-                {GRANULARITY_OPTIONS.map(({ label, seconds }) => (
-                  <option key={seconds} value={String(seconds)}>{label}</option>
+                {GRANULARITY_OPTIONS.map(({ label, value }) => (
+                  <option key={String(value)} value={String(value)}>{label}</option>
                 ))}
               </Form.Select>
             </div>
@@ -343,7 +354,7 @@ export const SnapshotTimeline = ({
                           <td>
                             <small className="text-muted">{b.packets.toLocaleString()}</small>
                           </td>
-                          <td>{renderBucketBadge(b)}</td>
+                          <td>{renderChangesPill(b.changes, b.critical)}</td>
                         </tr>
                         {isOpen && (
                           <tr>

--- a/frontend/src/pages/Monitor/NetworkDetailPage.tsx
+++ b/frontend/src/pages/Monitor/NetworkDetailPage.tsx
@@ -13,6 +13,7 @@ import { ExternalEventsPanel } from '@/components/monitor/ExternalEventsPanel/Ex
 import { NetworkAnnotationsPanel } from '@/components/monitor/NetworkAnnotationsPanel/NetworkAnnotationsPanel';
 import { NetworkInsightsPanel } from '@/components/monitor/NetworkInsightsPanel/NetworkInsightsPanel';
 import { AddSnapshotModal } from '@/components/monitor/AddSnapshotModal/AddSnapshotModal';
+import { ManagePcapsModal } from '@/components/monitor/ManagePcapsModal/ManagePcapsModal';
 import { SnapshotTrafficChart } from '@/components/monitor/SnapshotTrafficChart/SnapshotTrafficChart';
 import { useNetworkDetailData } from './hooks/useNetworkDetailData';
 import { MonitorInfoCard } from './components/MonitorInfoCard';
@@ -31,6 +32,7 @@ export const NetworkDetailPage = () => {
   } = data;
 
   const [showAddSnapshot, setShowAddSnapshot] = useState(false);
+  const [showManage, setShowManage] = useState(false);
 
   const navSections: SectionDef[] = [
     { id: 'sec-timeline', label: 'Capture Timeline', icon: 'bi-clock-history' },
@@ -133,8 +135,7 @@ export const NetworkDetailPage = () => {
                 networkId={network.id}
                 snapshots={snapshots}
                 changeEvents={changeEvents}
-                onRemove={data.handleRemoveSnapshot}
-                onAddSnapshot={() => setShowAddSnapshot(true)}
+                onManage={() => setShowManage(true)}
                 onPatchChange={data.handlePatchChange}
                 onSnapshotUpdated={data.handleSnapshotUpdated}
               />
@@ -362,6 +363,14 @@ export const NetworkDetailPage = () => {
           </Card>
         </Col>
       </Row>
+
+      <ManagePcapsModal
+        show={showManage}
+        onHide={() => setShowManage(false)}
+        snapshots={snapshots}
+        onRemove={data.handleRemoveSnapshot}
+        onAddSnapshot={() => { setShowManage(false); setShowAddSnapshot(true); }}
+      />
 
       <AddSnapshotModal
         show={showAddSnapshot}


### PR DESCRIPTION
## Summary

Reworks the monitor **Capture Timeline** so captures can be sliced by **time interval** as well as by PCAP file, and consolidates add/delete into a single **Manage PCAPs** modal. All changes are frontend-only — no backend or API changes.

## What's included

- **By PCAP / By Time mode toggle** on the Capture Timeline. By PCAP is the original per-file table; By Time groups captures into a selectable interval.
- **Interval selector** (`1m / 5m / 30m / 1h / 1d / 1mo`) — fixed intervals bucket by seconds; `1mo` buckets by calendar month. Bucketing is purely client-side from existing snapshot data.
- **Expandable buckets** — each period row aggregates captures / packets / changes / critical, and expands to list the individual PCAPs (each still opening the snapshot detail modal).
- **Unified Changes badge** — one shared helper renders the same `Badge` pill everywhere (By PCAP rows, bucket aggregates, nested rows); clickable ones just get a pointer cursor.
- **Stationary mode toggle** — the Interval selector sits to the left of the toggle so the By PCAP / By Time buttons don't shift when switching.
- **Manage PCAPs modal** — replaces the inline "Add PCAP" button. Add + inline-confirm delete live here, so the per-row trash icon is gone and the timeline table is view-only.

## Out of scope (by request)

- **Rename** — no backend support today (would need a per-snapshot label + migration, or a file-rename endpoint).
- **Merge** — backend `POST /files/merge` exists but intentionally not surfaced here.

## Verification

- `npx tsc --noEmit` clean; `docker compose up -d --build nginx` succeeds.
- Playwright runs against a seeded 8-snapshot network: mode toggle + interval work, month bucketing groups weekly captures into Jan/Feb 2024, badges render identically across views, toggle stays put across mode switches, timeline rows have no trash icon, and Manage PCAPs lists all captures with working add/delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated PCAP management modal for viewing snapshots, removing a PCAP with confirmation, and starting an add-PCAP flow.
  * Introduced a new timeline view option that lets you browse snapshots either by PCAP file or grouped by time, with expandable time buckets.
  * Added a quick way to jump from a timeline badge directly to the changes view in snapshot details.

* **Bug Fixes**
  * Improved the snapshot management flow so adding a PCAP cleanly switches between dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->