### PR TITLE
ci: upgrade Pages actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
         run: make -C docs html
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/_build/html/
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Upgrades `actions/upload-pages-artifact` from v3 to v4 and `actions/deploy-pages` from v4 to v5
- Resolves Node 20 deprecation warnings and fixes GitHub Pages deployment failures on runners defaulting to Node 24

## Test plan
- [ ] Merge and verify the `docs` workflow deploys successfully on the next push to `main` under `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)