### PR TITLE
refactor(entity): scoped Lombok on JPA entities (#410)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/entity/AnalysisResultEntity.java
+++ b/backend/src/main/java/com/tracepcap/analysis/entity/AnalysisResultEntity.java
@@ -7,8 +7,11 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -16,16 +19,21 @@ import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "analysis_results")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class AnalysisResultEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id", nullable = false)
   private FileEntity file;

--- a/backend/src/main/java/com/tracepcap/analysis/entity/ConversationEntity.java
+++ b/backend/src/main/java/com/tracepcap/analysis/entity/ConversationEntity.java
@@ -6,13 +6,19 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "conversations")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -25,10 +31,12 @@ public class ConversationEntity {
   public static final int PROTOCOL_MAX_LENGTH = 100;
   public static final int SURICATA_ALERT_MAX_LENGTH = 512;
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id", nullable = false)
   private FileEntity file;

--- a/backend/src/main/java/com/tracepcap/analysis/entity/HostClassificationEntity.java
+++ b/backend/src/main/java/com/tracepcap/analysis/entity/HostClassificationEntity.java
@@ -5,23 +5,31 @@ import jakarta.persistence.*;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(
     name = "host_classifications",
     indexes = {@Index(name = "idx_host_class_file_id", columnList = "file_id")})
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class HostClassificationEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id", nullable = false)
   private FileEntity file;

--- a/backend/src/main/java/com/tracepcap/analysis/entity/IpGeoInfoEntity.java
+++ b/backend/src/main/java/com/tracepcap/analysis/entity/IpGeoInfoEntity.java
@@ -4,19 +4,26 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "ip_geo_cache")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class IpGeoInfoEntity {
 
   /** The IP address is the primary key — one row per unique IP, shared across all files. */
+  @EqualsAndHashCode.Include
   @Id
   @Column(length = 45)
   private String ip;
@@ -44,12 +51,10 @@ public class IpGeoInfoEntity {
   private String city;
 
   /** Approximate latitude of the city/location. */
-  @Column
-  private Double lat;
+  @Column private Double lat;
 
   /** Approximate longitude of the city/location. */
-  @Column
-  private Double lon;
+  @Column private Double lon;
 
   /** Source of this geo result: "ipinfo" (live API) or "mmdb" (offline DB-IP database). */
   @Column(name = "geo_source", length = 10, nullable = false)

--- a/backend/src/main/java/com/tracepcap/analysis/entity/PacketEntity.java
+++ b/backend/src/main/java/com/tracepcap/analysis/entity/PacketEntity.java
@@ -6,26 +6,35 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "packets")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class PacketEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id", nullable = false)
   private FileEntity file;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "conversation_id")
   private ConversationEntity conversation;

--- a/backend/src/main/java/com/tracepcap/extraction/entity/ExtractedFileEntity.java
+++ b/backend/src/main/java/com/tracepcap/extraction/entity/ExtractedFileEntity.java
@@ -7,26 +7,35 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "extracted_files")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ExtractedFileEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id", nullable = false)
   private FileEntity file;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "conversation_id")
   private ConversationEntity conversation;

--- a/backend/src/main/java/com/tracepcap/file/entity/FileEntity.java
+++ b/backend/src/main/java/com/tracepcap/file/entity/FileEntity.java
@@ -5,21 +5,27 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 /** Entity representing an uploaded PCAP file */
 @Entity
 @Table(name = "files")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class FileEntity {
 
-  @Id private UUID id;
+  @EqualsAndHashCode.Include @Id private UUID id;
 
   @Column(name = "file_name", nullable = false)
   private String fileName;

--- a/backend/src/main/java/com/tracepcap/hostlog/entity/DnsQueryLogEntity.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/entity/DnsQueryLogEntity.java
@@ -5,8 +5,11 @@ import jakarta.persistence.*;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * One aggregated DNS query/response row for a DNS-server host in a capture (#362).
@@ -19,16 +22,21 @@ import lombok.NoArgsConstructor;
 @Table(
     name = "dns_query_log",
     indexes = {@Index(name = "idx_dns_query_log_file_server", columnList = "file_id, server_ip")})
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class DnsQueryLogEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id", nullable = false)
   private FileEntity file;

--- a/backend/src/main/java/com/tracepcap/hostlog/entity/HttpEndpointLogEntity.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/entity/HttpEndpointLogEntity.java
@@ -5,12 +5,15 @@ import jakarta.persistence.*;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
- * One aggregated HTTP endpoint row for a web/API-server host in a capture — the web/API equivalent of
- * {@link DnsQueryLogEntity}. Rows are aggregated per {@code (file, serverIp, method, path)}. See
+ * One aggregated HTTP endpoint row for a web/API-server host in a capture — the web/API equivalent
+ * of {@link DnsQueryLogEntity}. Rows are aggregated per {@code (file, serverIp, method, path)}. See
  * {@code WebServerLogExtractor}.
  */
 @Entity
@@ -19,16 +22,21 @@ import lombok.NoArgsConstructor;
     indexes = {
       @Index(name = "idx_http_endpoint_log_file_server", columnList = "file_id, server_ip")
     })
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class HttpEndpointLogEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id", nullable = false)
   private FileEntity file;

--- a/backend/src/main/java/com/tracepcap/insights/entity/NetworkAnnotationEntity.java
+++ b/backend/src/main/java/com/tracepcap/insights/entity/NetworkAnnotationEntity.java
@@ -7,28 +7,37 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "network_annotations")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class NetworkAnnotationEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "network_id", nullable = false)
   private NetworkEntity network;
 
   /** Optional association with a specific snapshot. */
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "snapshot_id")
   private NetworkSnapshotEntity snapshot;

--- a/backend/src/main/java/com/tracepcap/insights/entity/NetworkExternalEventEntity.java
+++ b/backend/src/main/java/com/tracepcap/insights/entity/NetworkExternalEventEntity.java
@@ -6,22 +6,30 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "network_external_events")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class NetworkExternalEventEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "network_id", nullable = false)
   private NetworkEntity network;

--- a/backend/src/main/java/com/tracepcap/insights/entity/NetworkInsightEntity.java
+++ b/backend/src/main/java/com/tracepcap/insights/entity/NetworkInsightEntity.java
@@ -6,24 +6,32 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "network_insights")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class NetworkInsightEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "network_id", nullable = false)
   private NetworkEntity network;

--- a/backend/src/main/java/com/tracepcap/insights/entity/NodeRoleEntity.java
+++ b/backend/src/main/java/com/tracepcap/insights/entity/NodeRoleEntity.java
@@ -7,8 +7,11 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -18,12 +21,16 @@ import org.hibernate.type.SqlTypes;
 @Table(
     name = "node_roles",
     uniqueConstraints = @UniqueConstraint(columnNames = {"file_id", "entity_type", "entity_key"}))
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class NodeRoleEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/backend/src/main/java/com/tracepcap/insights/entity/SnapshotInsightEntity.java
+++ b/backend/src/main/java/com/tracepcap/insights/entity/SnapshotInsightEntity.java
@@ -6,24 +6,32 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "snapshot_insights")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SnapshotInsightEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "snapshot_id", nullable = false)
   private NetworkSnapshotEntity snapshot;

--- a/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
@@ -4,17 +4,24 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "custom_private_ranges")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class CustomPrivateRangeEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -22,8 +29,7 @@ public class CustomPrivateRangeEntity {
   @Column(nullable = false, unique = true)
   private String cidr;
 
-  @Column
-  private String label;
+  @Column private String label;
 
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;

--- a/backend/src/main/java/com/tracepcap/intelligence/entity/IpOrgRuleEntity.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/entity/IpOrgRuleEntity.java
@@ -4,17 +4,24 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "ip_org_rules")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class IpOrgRuleEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/backend/src/main/java/com/tracepcap/monitor/entity/BaselineDefinitionEntity.java
+++ b/backend/src/main/java/com/tracepcap/monitor/entity/BaselineDefinitionEntity.java
@@ -5,22 +5,30 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "baseline_definitions")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class BaselineDefinitionEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "network_id", nullable = false)
   private NetworkEntity network;

--- a/backend/src/main/java/com/tracepcap/monitor/entity/NetworkChangeEventEntity.java
+++ b/backend/src/main/java/com/tracepcap/monitor/entity/NetworkChangeEventEntity.java
@@ -6,32 +6,42 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "network_change_events")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class NetworkChangeEventEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "network_id", nullable = false)
   private NetworkEntity network;
 
   /** Null when comparing the first snapshot against a manual baseline. */
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "from_snapshot_id")
   private NetworkSnapshotEntity fromSnapshot;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "to_snapshot_id", nullable = false)
   private NetworkSnapshotEntity toSnapshot;

--- a/backend/src/main/java/com/tracepcap/monitor/entity/NetworkEntity.java
+++ b/backend/src/main/java/com/tracepcap/monitor/entity/NetworkEntity.java
@@ -5,19 +5,26 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "networks")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class NetworkEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;

--- a/backend/src/main/java/com/tracepcap/monitor/entity/NetworkSnapshotEntity.java
+++ b/backend/src/main/java/com/tracepcap/monitor/entity/NetworkSnapshotEntity.java
@@ -6,26 +6,35 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "network_snapshots")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class NetworkSnapshotEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "network_id", nullable = false)
   private NetworkEntity network;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "file_id", nullable = false)
   private FileEntity file;

--- a/backend/src/main/java/com/tracepcap/monitor/entity/SnapshotSubnetOverrideEntity.java
+++ b/backend/src/main/java/com/tracepcap/monitor/entity/SnapshotSubnetOverrideEntity.java
@@ -3,21 +3,29 @@ package com.tracepcap.monitor.entity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "snapshot_subnet_overrides")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SnapshotSubnetOverrideEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @ToString.Exclude
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "snapshot_id", nullable = false)
   private NetworkSnapshotEntity snapshot;

--- a/backend/src/main/java/com/tracepcap/notes/entity/EntityNoteEntity.java
+++ b/backend/src/main/java/com/tracepcap/notes/entity/EntityNoteEntity.java
@@ -4,8 +4,11 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -13,12 +16,16 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Table(
     name = "entity_notes",
     uniqueConstraints = @UniqueConstraint(columnNames = {"entity_type", "entity_key"}))
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class EntityNoteEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/backend/src/main/java/com/tracepcap/story/entity/StoryEntity.java
+++ b/backend/src/main/java/com/tracepcap/story/entity/StoryEntity.java
@@ -5,19 +5,25 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /** Entity representing a generated story/narrative for a PCAP file */
 @Entity
 @Table(name = "stories")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class StoryEntity {
 
-  @Id private UUID id;
+  @EqualsAndHashCode.Include @Id private UUID id;
 
   @Column(name = "file_id", nullable = false)
   private UUID fileId;

--- a/backend/src/main/java/com/tracepcap/subnets/entity/SubnetDefinitionEntity.java
+++ b/backend/src/main/java/com/tracepcap/subnets/entity/SubnetDefinitionEntity.java
@@ -4,19 +4,26 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(name = "subnet_definitions")
-@Data
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SubnetDefinitionEntity {
 
+  @EqualsAndHashCode.Include
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;


### PR DESCRIPTION
Closes #410.

## Problem
All 24 JPA `@Entity` classes used Lombok `@Data`, which generates `toString()`/`equals()`/`hashCode()` over **all** fields — including lazy `@ManyToOne` associations (`file`, `network`, `snapshot`, …). Calling any of those outside an active persistence context (logging, serialization, a debugger, a `Set`/`Map` of entities) could trigger a lazy load and throw `LazyInitializationException`. All-field `equals`/`hashCode` is also a JPA anti-pattern.

## Change
Consistent sweep across every `@Entity`:
- `@Data` → `@Getter` + `@Setter`
- `@ToString` with `@ToString.Exclude` on every lazy association field
- `@EqualsAndHashCode(onlyExplicitlyIncluded = true)` with `@EqualsAndHashCode.Include` on the `@Id` field only

`@Builder`/`@NoArgsConstructor`/`@AllArgsConstructor` and all JPA mapping annotations are unchanged.

## Entities touched (24)
`AnalysisResultEntity`, `ConversationEntity`, `HostClassificationEntity`, `IpGeoInfoEntity`, `PacketEntity`, `ExtractedFileEntity`, `FileEntity`, `DnsQueryLogEntity`, `HttpEndpointLogEntity`, `NetworkAnnotationEntity`, `NetworkExternalEventEntity`, `NetworkInsightEntity`, `NodeRoleEntity`, `SnapshotInsightEntity`, `CustomPrivateRangeEntity`, `IpOrgRuleEntity`, `BaselineDefinitionEntity`, `NetworkChangeEventEntity`, `NetworkEntity`, `NetworkSnapshotEntity`, `SnapshotSubnetOverrideEntity`, `EntityNoteEntity`, `StoryEntity`, `SubnetDefinitionEntity`.

## Acceptance criteria
- [x] No entity's `toString`/`equals`/`hashCode` dereferences a lazy association.
- [x] `equals`/`hashCode` based on the id only.
- [x] Behaviour unchanged elsewhere — the one place an entity is used as a map key (`Map<ConversationEntity, StreamInfo>` in `FileExtractionService`) uses persisted conversations with non-null ids, so id-based keys are correct.

## Verification
- `docker compose build backend` — success.
- `mvn test` — **86 tests, 0 failures** (incl. the full-pipeline `PipelineIntegrationTest` that persists these entities).
- Backend boots clean (Hibernate schema validation passes), `/actuator/health` → 200, no `LazyInitializationException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)