### PR TITLE
fix(db): apply intended HikariCP pool size in default deployment (#393)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,12 @@ FILE_RETENTION_ENABLED=true
 # Files are automatically deleted after this many hours (only applies when FILE_RETENTION_ENABLED=true).
 FILE_RETENTION_HOURS=12
 
+# Database Connection Pool (HikariCP)
+# Max pooled connections to Postgres. Default 20 covers concurrent analysis inserts plus request
+# traffic. Keep below Postgres max_connections (default 100), accounting for other pool clients.
+DB_POOL_MAX_SIZE=20
+DB_POOL_MIN_IDLE=5
+
 # Analysis Queue & Reconciliation
 # Analysis runs on an in-memory thread pool (Suricata-dominated, ~50s/file). Keep max-pool-size at
 # or below the host CPU core count. When pool + queue are full, uploads apply back-pressure (run

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -29,8 +29,8 @@ spring.datasource:
   url: ${DATABASE_URL}
   username: ${DATABASE_USERNAME}
   password: ${DATABASE_PASSWORD}
-  hikari:
-    maximum-pool-size: ${DB_POOL_MAX_SIZE:20}
+  # HikariCP pool size (DB_POOL_MAX_SIZE, default 20) is set in base application.yml and
+  # inherited here — no profile-specific override needed.
 
 # Production server configuration
 server:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -30,7 +30,7 @@ spring.datasource:
   username: ${DATABASE_USERNAME}
   password: ${DATABASE_PASSWORD}
   hikari:
-    maximum-pool-size: 20
+    maximum-pool-size: ${DB_POOL_MAX_SIZE:20}
 
 # Production server configuration
 server:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,8 +11,12 @@ spring:
     password: ${DATABASE_PASSWORD:tracepcap_pass}
     driver-class-name: org.postgresql.Driver
     hikari:
-      maximum-pool-size: 10
-      minimum-idle: 5
+      # Sized for concurrent analysis (max-concurrent-analyses batched saveAll inserts) plus
+      # request-serving traffic. Env-overridable so the shipped compose deployment can raise it
+      # regardless of active profile (the dev profile is the default even in prod compose). Keep
+      # below Postgres max_connections (default 100). See #393.
+      maximum-pool-size: ${DB_POOL_MAX_SIZE:20}
+      minimum-idle: ${DB_POOL_MIN_IDLE:5}
       connection-timeout: 30000
       idle-timeout: 600000
       max-lifetime: 1800000

--- a/docker-compose.offline.yml
+++ b/docker-compose.offline.yml
@@ -81,6 +81,9 @@ services:
       DATABASE_URL: jdbc:postgresql://postgres:5432/tracepcap
       DATABASE_USERNAME: tracepcap_user
       DATABASE_PASSWORD: tracepcap_pass
+      # HikariCP connection pool (see #393). Stays under Postgres max_connections (100).
+      DB_POOL_MAX_SIZE: ${DB_POOL_MAX_SIZE:-20}
+      DB_POOL_MIN_IDLE: ${DB_POOL_MIN_IDLE:-5}
       MINIO_ENDPOINT: http://minio:9000
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,10 @@ services:
       DATABASE_URL: jdbc:postgresql://postgres:5432/tracepcap
       DATABASE_USERNAME: tracepcap_user
       DATABASE_PASSWORD: tracepcap_pass
+      # HikariCP connection pool. Sized above the base default so concurrent analysis inserts +
+      # request traffic don't starve the pool. Stays well under Postgres max_connections (100). See #393.
+      DB_POOL_MAX_SIZE: ${DB_POOL_MAX_SIZE:-20}
+      DB_POOL_MIN_IDLE: ${DB_POOL_MIN_IDLE:-5}
       MINIO_ENDPOINT: http://minio:9000
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin


### PR DESCRIPTION
## Problem

Closes #393.

The default compose deployment runs `SPRING_PROFILES_ACTIVE: dev`, and the `dev` profile never overrides the datasource — so the effective HikariCP pool came from base `application.yml` (`maximum-pool-size: 10`). The intended `20` in `application-prod.yml` was **never applied in any shipped deployment**: even `docker-compose.prod.yml` inherits `SPRING_PROFILES_ACTIVE: dev` from the base, so the `prod` profile never activates.

Under concurrent analysis load (`max-concurrent-analyses: 3`, batched `saveAll` inserts) plus request-serving traffic, a 10-connection pool is tight.

## Fix

Make the pool size env-configurable at the **base** so it applies regardless of active profile, rather than relying on a profile the deployments don't use:

- `application.yml`: `maximum-pool-size: ${DB_POOL_MAX_SIZE:20}`, `minimum-idle: ${DB_POOL_MIN_IDLE:5}` (base default raised to 20)
- `application-prod.yml`: uses the same `DB_POOL_MAX_SIZE` knob (single source of truth)
- `docker-compose.yml` / `docker-compose.offline.yml`: pass `DB_POOL_MAX_SIZE` / `DB_POOL_MIN_IDLE`
- `.env.example`: document the knobs

## Verification

Rebuilt with `docker compose up -d --build backend` (succeeded). In the default `docker compose up` deployment (`dev` profile), via `/actuator/metrics`:

- `hikaricp.connections.max` = **20.0** (was 10)
- `hikaricp.connections.min` = 5.0

Postgres `max_connections` = 100 comfortably covers the pool.

## Acceptance
- [x] Effective `HikariCP maximum-pool-size` in the default deployment matches the intended value (20), verified via `/actuator/metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)