### PR TITLE
feat(analysis): aggregate entity-stats across all pages, not page 1 (#436)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/dto/EntityStatsResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/EntityStatsResponse.java
@@ -1,0 +1,40 @@
+package com.tracepcap.analysis.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Authoritative aggregate stats for an APPLICATION or PROTOCOL entity across <em>all</em> matching
+ * conversations in a file (not a single page). Backs the EntityDetailModal stats panel (#436).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EntityStatsResponse {
+
+  /** A single peer IP and the total bytes it accounts for across matching conversations. */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class TopPeer {
+    private String ip;
+    private long bytes;
+  }
+
+  /** Number of matching conversations. */
+  private long conversationCount;
+
+  /** Total packets across all matching conversations. */
+  private long packetCount;
+
+  /** Total bytes across all matching conversations. */
+  private long totalBytes;
+
+  /** Top peer IPs by total bytes (both endpoints counted), capped server-side. */
+  private List<TopPeer> topPeers;
+}

--- a/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
@@ -310,6 +310,68 @@ public interface ConversationRepository
   List<Object[]> findLongSessionsByFileId(
       @Param("fileId") UUID fileId, @Param("thresholdSeconds") long thresholdSeconds);
 
+  // ---------------------------------------------------------------------------
+  // Entity-stats aggregation (#436) — authoritative totals + top peers across ALL
+  // matching conversations for an APPLICATION or PROTOCOL entity, computed in the
+  // DB so the client never fans out page-by-page for large captures.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Aggregate totals for an APPLICATION entity: [conversation_count, packet_count, total_bytes].
+   */
+  @Query(
+      value =
+          "SELECT COUNT(*), COALESCE(SUM(packet_count), 0), COALESCE(SUM(total_bytes), 0)"
+              + " FROM conversations WHERE file_id = :fileId AND app_name = :appName",
+      nativeQuery = true)
+  List<Object[]> aggregateStatsByApp(@Param("fileId") UUID fileId, @Param("appName") String appName);
+
+  /**
+   * Aggregate totals for a PROTOCOL entity: [conversation_count, packet_count, total_bytes]. The
+   * {@code variants} list matches the pre-/post-normalisation forms expanded by {@link #buildSpec}.
+   */
+  @Query(
+      value =
+          "SELECT COUNT(*), COALESCE(SUM(packet_count), 0), COALESCE(SUM(total_bytes), 0)"
+              + " FROM conversations WHERE file_id = :fileId AND tshark_protocol IN (:variants)",
+      nativeQuery = true)
+  List<Object[]> aggregateStatsByL7Protocol(
+      @Param("fileId") UUID fileId, @Param("variants") List<String> variants);
+
+  /**
+   * Top peer IPs by total bytes for an APPLICATION entity. Each conversation contributes its bytes
+   * to both endpoints, mirroring the previous client-side aggregation. Columns: [ip, bytes].
+   */
+  @Query(
+      value =
+          "SELECT ip, SUM(total_bytes) AS bytes FROM ("
+              + "  SELECT src_ip AS ip, total_bytes FROM conversations"
+              + "    WHERE file_id = :fileId AND app_name = :appName"
+              + "  UNION ALL"
+              + "  SELECT dst_ip AS ip, total_bytes FROM conversations"
+              + "    WHERE file_id = :fileId AND app_name = :appName"
+              + ") t WHERE ip IS NOT NULL GROUP BY ip ORDER BY bytes DESC LIMIT :lim",
+      nativeQuery = true)
+  List<Object[]> findTopPeersByApp(
+      @Param("fileId") UUID fileId, @Param("appName") String appName, @Param("lim") int lim);
+
+  /**
+   * Top peer IPs by total bytes for a PROTOCOL entity. Columns: [ip, bytes]. See {@link
+   * #aggregateStatsByL7Protocol} for the {@code variants} semantics.
+   */
+  @Query(
+      value =
+          "SELECT ip, SUM(total_bytes) AS bytes FROM ("
+              + "  SELECT src_ip AS ip, total_bytes FROM conversations"
+              + "    WHERE file_id = :fileId AND tshark_protocol IN (:variants)"
+              + "  UNION ALL"
+              + "  SELECT dst_ip AS ip, total_bytes FROM conversations"
+              + "    WHERE file_id = :fileId AND tshark_protocol IN (:variants)"
+              + ") t WHERE ip IS NOT NULL GROUP BY ip ORDER BY bytes DESC LIMIT :lim",
+      nativeQuery = true)
+  List<Object[]> findTopPeersByL7Protocol(
+      @Param("fileId") UUID fileId, @Param("variants") List<String> variants, @Param("lim") int lim);
+
   /** Build a JPA Specification from the given filter params plus a mandatory fileId constraint. */
   static Specification<ConversationEntity> buildSpec(UUID fileId, ConversationFilterParams params) {
 
@@ -352,19 +414,7 @@ public interface ConversationRepository
       // each value to its common pre-normalisation variants on the Java side so no DB-side function
       // is applied to the column and any index on tshark_protocol remains usable.
       if (params.getL7Protocols() != null && !params.getL7Protocols().isEmpty()) {
-        List<String> variants =
-            params.getL7Protocols().stream()
-                .filter(p -> p != null && !p.isEmpty())
-                .flatMap(
-                    p -> {
-                      String titleCase =
-                          Character.toUpperCase(p.charAt(0)) + p.substring(1).toLowerCase();
-                      return java.util.stream.Stream.of(
-                          p, titleCase, p.toLowerCase(), "The " + titleCase);
-                    })
-                .distinct()
-                .collect(java.util.stream.Collectors.toList());
-        predicates.add(root.get("tsharkProtocol").in(variants));
+        predicates.add(root.get("tsharkProtocol").in(expandL7ProtocolVariants(params.getL7Protocols())));
       }
 
       // Application multi-value
@@ -490,6 +540,25 @@ public interface ConversationRepository
 
       return cb.and(predicates.toArray(new Predicate[0]));
     };
+  }
+
+  /**
+   * Expands each L7 protocol filter value to its common pre-/post-normalisation variants (as-is,
+   * title-case, lower-case, and "The "-prefixed title-case). Kept in one place so the listing
+   * Specification and the entity-stats aggregation ({@code apps}/{@code l7Protocols} in #436) apply
+   * identical matching. Empty input yields an empty list.
+   */
+  static List<String> expandL7ProtocolVariants(List<String> l7Protocols) {
+    if (l7Protocols == null || l7Protocols.isEmpty()) return List.of();
+    return l7Protocols.stream()
+        .filter(p -> p != null && !p.isEmpty())
+        .flatMap(
+            p -> {
+              String titleCase = Character.toUpperCase(p.charAt(0)) + p.substring(1).toLowerCase();
+              return java.util.stream.Stream.of(p, titleCase, p.toLowerCase(), "The " + titleCase);
+            })
+        .distinct()
+        .collect(java.util.stream.Collectors.toList());
   }
 
   /**

--- a/backend/src/main/java/com/tracepcap/conversation/controller/ConversationsController.java
+++ b/backend/src/main/java/com/tracepcap/conversation/controller/ConversationsController.java
@@ -3,6 +3,7 @@ package com.tracepcap.conversation.controller;
 import com.tracepcap.analysis.dto.ConversationDetailResponse;
 import com.tracepcap.analysis.dto.ConversationFilterParams;
 import com.tracepcap.analysis.dto.ConversationResponse;
+import com.tracepcap.analysis.dto.EntityStatsResponse;
 import com.tracepcap.analysis.dto.SessionResponse;
 import com.tracepcap.conversation.service.ConversationQueryService;
 import com.tracepcap.analysis.service.SessionReconstructionService;
@@ -148,6 +149,23 @@ public class ConversationsController {
         sortDir);
 
     return ResponseEntity.ok(conversationQueryService.getConversations(fileId, page, pageSize, params));
+  }
+
+  /**
+   * Authoritative aggregate stats (conversation/packet/byte totals + top peer IPs) for a single
+   * APPLICATION or PROTOCOL entity, computed across ALL matching conversations (#436). Exactly one
+   * of {@code app} or {@code l7Protocol} must be supplied.
+   */
+  @GetMapping("/{fileId}/entity-stats")
+  @Operation(summary = "Aggregate stats for an APPLICATION or PROTOCOL entity across all pages")
+  public ResponseEntity<EntityStatsResponse> getEntityStats(
+      @PathVariable UUID fileId,
+      @Parameter(description = "Application name to aggregate over") @RequestParam(required = false)
+          String app,
+      @Parameter(description = "L7 (tshark) protocol to aggregate over")
+          @RequestParam(required = false)
+          String l7Protocol) {
+    return ResponseEntity.ok(conversationQueryService.getEntityStats(fileId, app, l7Protocol));
   }
 
   /** Returns the distinct detected file types found in packets for this file. */

--- a/backend/src/main/java/com/tracepcap/conversation/service/ConversationQueryService.java
+++ b/backend/src/main/java/com/tracepcap/conversation/service/ConversationQueryService.java
@@ -3,6 +3,7 @@ package com.tracepcap.conversation.service;
 import com.tracepcap.analysis.dto.ConversationDetailResponse;
 import com.tracepcap.analysis.dto.ConversationFilterParams;
 import com.tracepcap.analysis.dto.ConversationResponse;
+import com.tracepcap.analysis.dto.EntityStatsResponse;
 import com.tracepcap.analysis.dto.PacketResponse;
 import com.tracepcap.analysis.entity.ConversationEntity;
 import com.tracepcap.analysis.entity.PacketEntity;
@@ -59,6 +60,62 @@ public class ConversationQueryService {
   private static final java.time.format.DateTimeFormatter PCAP_FILENAME_TS =
       java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss")
           .withZone(java.time.ZoneId.of("Asia/Singapore"));
+
+  /** Number of top peer IPs returned by the entity-stats endpoint (#436). */
+  private static final int ENTITY_STATS_TOP_PEERS = 10;
+
+  /**
+   * Authoritative aggregate stats for an APPLICATION or PROTOCOL entity across ALL matching
+   * conversations in a file (#436). Computed in the DB so the displayed count/packets/bytes/top-peers
+   * are always internally consistent, regardless of conversation count, with no client fan-out.
+   *
+   * @param fileId the file to aggregate over
+   * @param appName when non-blank, aggregate conversations whose appName equals this value
+   * @param l7Protocol when non-blank (and appName blank), aggregate by L7 protocol (variant-expanded)
+   */
+  @Transactional(readOnly = true)
+  public EntityStatsResponse getEntityStats(UUID fileId, String appName, String l7Protocol) {
+    boolean byApp = appName != null && !appName.isBlank();
+    boolean byProto = !byApp && l7Protocol != null && !l7Protocol.isBlank();
+    if (!byApp && !byProto) {
+      throw new IllegalArgumentException("Either appName or l7Protocol must be provided");
+    }
+
+    List<String> variants =
+        byProto
+            ? ConversationRepository.expandL7ProtocolVariants(List.of(l7Protocol.trim()))
+            : List.of();
+
+    List<Object[]> totalsRows =
+        byApp
+            ? conversationRepository.aggregateStatsByApp(fileId, appName.trim())
+            : conversationRepository.aggregateStatsByL7Protocol(fileId, variants);
+    // COUNT/SUM aggregates always return exactly one row; guard defensively regardless.
+    Object[] totals = totalsRows.isEmpty() ? new Object[] {0L, 0L, 0L} : totalsRows.get(0);
+
+    List<Object[]> peerRows =
+        byApp
+            ? conversationRepository.findTopPeersByApp(fileId, appName.trim(), ENTITY_STATS_TOP_PEERS)
+            : conversationRepository.findTopPeersByL7Protocol(
+                fileId, variants, ENTITY_STATS_TOP_PEERS);
+
+    List<EntityStatsResponse.TopPeer> topPeers =
+        peerRows.stream()
+            .map(
+                r ->
+                    EntityStatsResponse.TopPeer.builder()
+                        .ip((String) r[0])
+                        .bytes(((Number) r[1]).longValue())
+                        .build())
+            .collect(Collectors.toList());
+
+    return EntityStatsResponse.builder()
+        .conversationCount(((Number) totals[0]).longValue())
+        .packetCount(((Number) totals[1]).longValue())
+        .totalBytes(((Number) totals[2]).longValue())
+        .topPeers(topPeers)
+        .build();
+  }
 
   @Transactional(readOnly = true)
   public PagedResponse<ConversationResponse> getConversations(

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
@@ -1,23 +1,22 @@
 import { useEffect, useState } from 'react';
 import { apiClient } from '@/services/api/client';
+import { API_ENDPOINTS } from '@/services/api/endpoints';
 import type { EntityType } from '@/features/notes/services/entityNotesService';
 import type { EntityStats } from '../types';
 
-interface ConvRow {
-  srcIp: string;
-  dstIp: string;
+/** Server-computed aggregate stats for an APPLICATION/PROTOCOL entity (#436). */
+interface EntityStatsApiResponse {
+  conversationCount: number;
   packetCount: number;
   totalBytes: number;
-}
-
-interface ConvApiResponse {
-  data: ConvRow[];
-  total: number;
+  topPeers: { ip: string; bytes: number }[];
 }
 
 /**
  * Aggregate stats (conversation/packet/byte totals + top peer IPs) for
- * APPLICATION/PROTOCOL entities, derived from the conversations API.
+ * APPLICATION/PROTOCOL entities. The backend aggregates across ALL matching
+ * conversations, so the numbers stay internally consistent regardless of
+ * conversation count and the client never fans out page-by-page (#436).
  */
 export function useEntityStats(entityType: EntityType, entityKey: string, fileId: string) {
   const [stats, setStats] = useState<EntityStats | null>(null);
@@ -32,26 +31,20 @@ export function useEntityStats(entityType: EntityType, entityKey: string, fileId
     setStatsError(null);
     if (!fileId || (entityType !== 'APPLICATION' && entityType !== 'PROTOCOL')) return;
     setStatsLoading(true);
-    const param = entityType === 'APPLICATION' ? `apps=${encodeURIComponent(entityKey)}` : `l7Protocols=${encodeURIComponent(entityKey)}`;
+    const param = entityType === 'APPLICATION' ? 'app' : 'l7Protocol';
     apiClient
-      .get<ConvApiResponse>(`/conversations/${fileId}?${param}&pageSize=500&page=1`)
+      .get<EntityStatsApiResponse>(
+        `${API_ENDPOINTS.ENTITY_STATS(fileId)}?${param}=${encodeURIComponent(entityKey)}`
+      )
       .then(res => {
         if (!active) return;
-        const rows = res.data.data;
-        const total = res.data.total;
-        const packets = rows.reduce((s, r) => s + r.packetCount, 0);
-        const bytes = rows.reduce((s, r) => s + r.totalBytes, 0);
-        // Aggregate bytes per peer IP
-        const peerBytes = new Map<string, number>();
-        for (const r of rows) {
-          peerBytes.set(r.srcIp, (peerBytes.get(r.srcIp) ?? 0) + r.totalBytes);
-          peerBytes.set(r.dstIp, (peerBytes.get(r.dstIp) ?? 0) + r.totalBytes);
-        }
-        const topPeers = Array.from(peerBytes.entries())
-          .sort((a, b) => b[1] - a[1])
-          .slice(0, 10)
-          .map(([ip, b]) => ({ ip, bytes: b }));
-        setStats({ conversationCount: total, packetCount: packets, totalBytes: bytes, topPeers });
+        const d = res.data;
+        setStats({
+          conversationCount: d.conversationCount,
+          packetCount: d.packetCount,
+          totalBytes: d.totalBytes,
+          topPeers: d.topPeers,
+        });
       })
       .catch(() => { if (active) setStatsError('Failed to load details'); })
       .finally(() => { if (active) setStatsLoading(false); });

--- a/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/useEntityStats.ts
@@ -29,7 +29,7 @@ export function useEntityStats(entityType: EntityType, entityKey: string, fileId
     setStats(null);
     setStatsLoading(false);
     setStatsError(null);
-    if (!fileId || (entityType !== 'APPLICATION' && entityType !== 'PROTOCOL')) return;
+    if (!fileId || !entityKey?.trim() || (entityType !== 'APPLICATION' && entityType !== 'PROTOCOL')) return;
     setStatsLoading(true);
     const param = entityType === 'APPLICATION' ? 'app' : 'l7Protocol';
     apiClient

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -18,6 +18,7 @@ export const API_ENDPOINTS = {
 
   // Conversations
   CONVERSATIONS: (fileId: string) => `/conversations/${fileId}`,
+  ENTITY_STATS: (fileId: string) => `/conversations/${fileId}/entity-stats`,
   CONVERSATION_DETAIL: (conversationId: string) => `/conversations/detail/${conversationId}`,
   SECURITY_ALERTS: (fileId: string) => `/files/${fileId}/security-alerts`,
   RISK_TYPES: (fileId: string) => `/conversations/${fileId}/risk-types`,

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -1094,6 +1094,29 @@
         },
         "type": "object"
       },
+      "EntityStatsResponse": {
+        "properties": {
+          "conversationCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "packetCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "topPeers": {
+            "items": {
+              "$ref": "#/components/schemas/TopPeer"
+            },
+            "type": "array"
+          },
+          "totalBytes": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "ExtractedFileResponse": {
         "properties": {
           "conversationId": {
@@ -2812,6 +2835,18 @@
         },
         "type": "object"
       },
+      "TopPeer": {
+        "properties": {
+          "bytes": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "ip": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "TracerExplainResponse": {
         "properties": {
           "conversationId": {
@@ -3516,6 +3551,56 @@
           }
         },
         "summary": "List distinct custom signature rule names for a file",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/api/v1/conversations/{fileId}/entity-stats": {
+      "get": {
+        "operationId": "getEntityStats",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Application name to aggregate over",
+            "in": "query",
+            "name": "app",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "L7 (tshark) protocol to aggregate over",
+            "in": "query",
+            "name": "l7Protocol",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityStatsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Aggregate stats for an APPLICATION or PROTOCOL entity across all pages",
         "tags": [
           "Conversations"
         ]


### PR DESCRIPTION
Closes #436.

## Problem

`EntityDetailModal`'s APPLICATION/PROTOCOL stats derived packet/byte totals and the top-peer table from only the **first 500-row page** of conversations, while `conversationCount` used the global `total`. Once an entity had >500 conversations, the displayed numbers were internally inconsistent (count reflected all rows, the rest reflected page 1). This was pre-existing behaviour carried verbatim through the #424 refactor.

## Approach

Implemented **Option 2** (the preferred one): a dedicated backend aggregation endpoint that returns authoritative totals + top peers, computed in the DB across **all** matching conversations. The client issues a single request — no N-page fan-out.

### Backend
- New DTO `EntityStatsResponse` (totals + top-peer list).
- New native repository queries: `aggregateStatsByApp` / `aggregateStatsByL7Protocol` (COUNT/SUM packets & bytes) and `findTopPeersByApp` / `findTopPeersByL7Protocol` (top-10 peer IPs by bytes via a src/dst `UNION ALL`, capped server-side).
- Extracted L7-protocol variant-expansion into a shared `expandL7ProtocolVariants` helper so the aggregation and the existing listing `Specification` match protocols identically.
- New service method `getEntityStats` (throws → **400** when neither param is supplied).
- New endpoint `GET /api/v1/conversations/{fileId}/entity-stats?app=|l7Protocol=` (id-first convention).

### Frontend
- `useEntityStats` now calls the single aggregation endpoint instead of paging + summing client-side. Added `API_ENDPOINTS.ENTITY_STATS`. Stats section unchanged.

### Contract
- Regenerated + committed `openapi/baseline.json` — purely additive (new path + `EntityStatsResponse`/`TopPeer` schemas), no churn to existing endpoints.

## Testing

- Frontend `tsc --noEmit` clean; backend + full stack build via `docker compose up -d --build`.
- Live-verified against a 669-conversation file: endpoint totals match a full all-pages scan **exactly** (TLS: 105 conv / 630 pkts / 37065 bytes).
- `l7Protocol=HTTP` matches more rows (102) than `app=HTTP` (79) — confirms variant expansion.
- Zero-match returns clean zeros; missing params returns **400**.
- Playwright screenshot of the live modal confirms the stats panel + "Top IPs (top 10)" render correctly with no console errors.

## Acceptance
- [x] Stats are consistent regardless of conversation count.
- [x] No N-page client fan-out for large captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)