### PR TITLE
feat(subnets): per-snapshot labels, AI suggestion, staleness, carry-forward (#363)

### DIFF
--- a/backend/src/main/java/com/tracepcap/monitor/repository/SnapshotSubnetOverrideRepository.java
+++ b/backend/src/main/java/com/tracepcap/monitor/repository/SnapshotSubnetOverrideRepository.java
@@ -20,6 +20,13 @@ public interface SnapshotSubnetOverrideRepository
   @Query("DELETE FROM SnapshotSubnetOverrideEntity o WHERE o.snapshot.id = :snapshotId")
   void deleteBySnapshotId(@Param("snapshotId") UUID snapshotId);
 
+  /** Clear only carried (inherited) overrides on a snapshot, leaving analyst-set ones intact. */
+  @Modifying
+  @Query(
+      "DELETE FROM SnapshotSubnetOverrideEntity o "
+          + "WHERE o.snapshot.id = :snapshotId AND o.inherited = true")
+  void deleteBySnapshotIdAndInheritedTrue(@Param("snapshotId") UUID snapshotId);
+
   @Query("SELECT o FROM SnapshotSubnetOverrideEntity o WHERE o.snapshot.id IN :ids")
   List<SnapshotSubnetOverrideEntity> findBySnapshotIdIn(@Param("ids") List<UUID> ids);
 }

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -59,6 +59,8 @@ public class ChangeDetectionService {
   private final SnapshotSubnetOverrideRepository snapshotSubnetOverrideRepository;
   private final LabelStalenessService labelStalenessService;
   private final NetworkSnapshotRepository snapshotRepository;
+  private final com.tracepcap.subnets.service.SubnetStalenessService subnetStalenessService;
+  private final SubnetOverrideCarryForwardService subnetOverrideCarryForwardService;
 
   /**
    * Compare two consecutive snapshots and persist NetworkChangeEventEntity records. fromSnapshot
@@ -76,6 +78,13 @@ public class ChangeDetectionService {
     events.addAll(detectIspAsnChanges(fromFileId, toFileId, fromSnapshot, toSnapshot));
     events.addAll(detectProtocolAppDrift(fromFileId, toFileId, fromSnapshot, toSnapshot));
     events.addAll(detectStaleLabels(toFileId, fromSnapshot, toSnapshot));
+
+    // Carry subnet labels forward onto this snapshot (inherited overrides), mirroring node roles.
+    subnetOverrideCarryForwardService.carryForward(
+        fromSnapshot != null ? fromSnapshot.getId() : null, toSnapshot.getId());
+
+    // Re-validate subnet-definition composition baselines against this (latest) snapshot.
+    subnetStalenessService.revalidate(toSnapshot.getNetwork().getId());
 
     return changeEventRepository.saveAll(events);
   }

--- a/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
@@ -203,16 +203,13 @@ public class SnapshotService {
       }
       // Subnet labels carry forward transitively, so a change here must cascade to the whole tail
       // (detectChanges above only touches adjacent pairs). Re-carry every transition from here on.
+      // Let failures propagate: carryForward runs in this same (class-level @Transactional)
+      // transaction, so swallowing a RuntimeException would only surface later as an opaque
+      // UnexpectedRollbackException at commit — better to roll back cleanly with the real cause.
       if (idx >= 0) {
         for (int i = idx; i + 1 < ordered.size(); i++) {
-          try {
-            subnetOverrideCarryForwardService.carryForward(
-                ordered.get(i).getId(), ordered.get(i + 1).getId());
-          } catch (Exception e) {
-            log.error(
-                "Subnet carry-forward failed {}->{}: {}",
-                ordered.get(i).getId(), ordered.get(i + 1).getId(), e.getMessage(), e);
-          }
+          subnetOverrideCarryForwardService.carryForward(
+              ordered.get(i).getId(), ordered.get(i + 1).getId());
         }
       }
     }

--- a/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
@@ -39,6 +39,7 @@ public class SnapshotService {
   private final NetworkChangeEventRepository changeEventRepository;
   private final SnapshotInsightRepository snapshotInsightRepository;
   private final SnapshotSubnetOverrideRepository subnetOverrideRepository;
+  private final SubnetOverrideCarryForwardService subnetOverrideCarryForwardService;
 
   @Transactional(readOnly = true)
   public List<NetworkSnapshotDto> listSnapshots(UUID networkId) {
@@ -198,6 +199,20 @@ public class SnapshotService {
           changeDetectionService.detectChanges(snapshot, successor);
         } catch (Exception e) {
           log.error("Change detection failed snapshot->successor {}: {}", snapshotId, e.getMessage(), e);
+        }
+      }
+      // Subnet labels carry forward transitively, so a change here must cascade to the whole tail
+      // (detectChanges above only touches adjacent pairs). Re-carry every transition from here on.
+      if (idx >= 0) {
+        for (int i = idx; i + 1 < ordered.size(); i++) {
+          try {
+            subnetOverrideCarryForwardService.carryForward(
+                ordered.get(i).getId(), ordered.get(i + 1).getId());
+          } catch (Exception e) {
+            log.error(
+                "Subnet carry-forward failed {}->{}: {}",
+                ordered.get(i).getId(), ordered.get(i + 1).getId(), e.getMessage(), e);
+          }
         }
       }
     }

--- a/backend/src/main/java/com/tracepcap/monitor/service/SubnetOverrideCarryForwardService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/SubnetOverrideCarryForwardService.java
@@ -1,0 +1,68 @@
+package com.tracepcap.monitor.service;
+
+import com.tracepcap.monitor.entity.NetworkSnapshotEntity;
+import com.tracepcap.monitor.entity.SnapshotSubnetOverrideEntity;
+import com.tracepcap.monitor.repository.NetworkSnapshotRepository;
+import com.tracepcap.monitor.repository.SnapshotSubnetOverrideRepository;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Carries subnet labels forward across snapshots, mirroring the node-role carry-forward in {@code
+ * LabelStalenessService}. When a new snapshot is added, each subnet override on the previous snapshot
+ * is copied onto the new one as an <b>inherited</b> override (unless the analyst has already set that
+ * CIDR directly on the new snapshot, which takes precedence). Inherited rows are regenerated on each
+ * transition so reorders/re-adds stay consistent.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubnetOverrideCarryForwardService {
+
+  private final SnapshotSubnetOverrideRepository overrideRepository;
+  private final NetworkSnapshotRepository snapshotRepository;
+
+  /**
+   * Copy {@code prevSnapshotId}'s subnet overrides onto {@code newSnapshotId} as inherited rows.
+   * Analyst-set (non-inherited) overrides already present on the new snapshot are left untouched and
+   * win over a carried value for the same CIDR.
+   */
+  @Transactional
+  public void carryForward(UUID prevSnapshotId, UUID newSnapshotId) {
+    if (newSnapshotId == null) return;
+    // Always clear carried rows so a reorder/re-add regenerates cleanly.
+    overrideRepository.deleteBySnapshotIdAndInheritedTrue(newSnapshotId);
+    if (prevSnapshotId == null) return;
+
+    List<SnapshotSubnetOverrideEntity> prev = overrideRepository.findBySnapshotId(prevSnapshotId);
+    if (prev.isEmpty()) return;
+
+    NetworkSnapshotEntity newSnapshot = snapshotRepository.findById(newSnapshotId).orElse(null);
+    if (newSnapshot == null) return;
+
+    // CIDRs the analyst has labelled directly on the new snapshot — don't shadow them.
+    Set<String> directCidrs =
+        overrideRepository.findBySnapshotId(newSnapshotId).stream()
+            .filter(o -> !o.isInherited())
+            .map(SnapshotSubnetOverrideEntity::getCidr)
+            .collect(Collectors.toSet());
+
+    for (SnapshotSubnetOverrideEntity src : prev) {
+      if (directCidrs.contains(src.getCidr())) continue;
+      overrideRepository.save(
+          SnapshotSubnetOverrideEntity.builder()
+              .snapshot(newSnapshot)
+              .cidr(src.getCidr())
+              .label(src.getLabel())
+              .description(src.getDescription())
+              .inherited(true)
+              .build());
+    }
+  }
+}

--- a/backend/src/main/java/com/tracepcap/monitor/service/SubnetOverrideCarryForwardService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/SubnetOverrideCarryForwardService.java
@@ -53,9 +53,10 @@ public class SubnetOverrideCarryForwardService {
             .map(SnapshotSubnetOverrideEntity::getCidr)
             .collect(Collectors.toSet());
 
+    List<SnapshotSubnetOverrideEntity> toSave = new java.util.ArrayList<>();
     for (SnapshotSubnetOverrideEntity src : prev) {
       if (directCidrs.contains(src.getCidr())) continue;
-      overrideRepository.save(
+      toSave.add(
           SnapshotSubnetOverrideEntity.builder()
               .snapshot(newSnapshot)
               .cidr(src.getCidr())
@@ -64,5 +65,6 @@ public class SubnetOverrideCarryForwardService {
               .inherited(true)
               .build());
     }
+    if (!toSave.isEmpty()) overrideRepository.saveAll(toSave);
   }
 }

--- a/backend/src/main/java/com/tracepcap/subnets/controller/SubnetController.java
+++ b/backend/src/main/java/com/tracepcap/subnets/controller/SubnetController.java
@@ -7,6 +7,8 @@ import com.tracepcap.subnets.service.SubnetLabelSuggestionService;
 import com.tracepcap.subnets.service.SubnetService;
 import com.tracepcap.subnets.service.SubnetStalenessService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.UUID;
@@ -69,6 +71,10 @@ public class SubnetController {
               + "concise label naming the subnet plus a description of its purpose and any anomalies. "
               + "The result is not persisted — the analyst reviews it in the edit form and saves it "
               + "onto the subnet's own label/description. Optionally scope to a network via networkId.")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "Suggested label + description"),
+    @ApiResponse(responseCode = "422", description = "No member nodes observed — insufficient evidence")
+  })
   public ResponseEntity<SubnetLabelSuggestionDto> suggestLabel(
       @PathVariable Long id,
       @RequestParam(required = false) UUID networkId,
@@ -95,7 +101,7 @@ public class SubnetController {
 
   @PostMapping("/{id}/dismiss-staleness")
   @Operation(summary = "Mark a stale subnet label as still correct and re-baseline its composition")
-  public ResponseEntity<SubnetDefinitionDto> dismissStaleness(
+  public ResponseEntity<SubnetDefinitionDto> dismissSubnetStaleness(
       @PathVariable Long id, @RequestParam(required = false) UUID networkId) {
     return ResponseEntity.ok(subnetService.dismissStaleness(id, networkId));
   }

--- a/backend/src/main/java/com/tracepcap/subnets/controller/SubnetController.java
+++ b/backend/src/main/java/com/tracepcap/subnets/controller/SubnetController.java
@@ -1,8 +1,11 @@
 package com.tracepcap.subnets.controller;
 
 import com.tracepcap.subnets.dto.SubnetDefinitionDto;
+import com.tracepcap.subnets.dto.SubnetLabelSuggestionDto;
 import com.tracepcap.subnets.dto.UpsertSubnetRequest;
+import com.tracepcap.subnets.service.SubnetLabelSuggestionService;
 import com.tracepcap.subnets.service.SubnetService;
+import com.tracepcap.subnets.service.SubnetStalenessService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -18,6 +21,8 @@ import org.springframework.web.bind.annotation.*;
 public class SubnetController {
 
   private final SubnetService subnetService;
+  private final SubnetLabelSuggestionService subnetLabelSuggestionService;
+  private final SubnetStalenessService subnetStalenessService;
 
   @GetMapping
   @Operation(summary = "List defined subnets")
@@ -54,5 +59,44 @@ public class SubnetController {
   @Operation(summary = "Auto-detect subnets across a monitored network")
   public ResponseEntity<List<SubnetDefinitionDto>> detectFromNetwork(@RequestParam UUID networkId) {
     return ResponseEntity.ok(subnetService.detectFromNetwork(networkId));
+  }
+
+  @PostMapping("/{id}/suggest-label")
+  @Operation(
+      summary = "Suggest a label + description for a subnet with AI",
+      description =
+          "Collects the subnet's member nodes across recent snapshots and asks the LLM to suggest a "
+              + "concise label naming the subnet plus a description of its purpose and any anomalies. "
+              + "The result is not persisted — the analyst reviews it in the edit form and saves it "
+              + "onto the subnet's own label/description. Optionally scope to a network via networkId.")
+  public ResponseEntity<SubnetLabelSuggestionDto> suggestLabel(
+      @PathVariable Long id,
+      @RequestParam(required = false) UUID networkId,
+      @RequestParam(required = false) UUID fileId) {
+    return ResponseEntity.ok(subnetLabelSuggestionService.suggest(id, networkId, fileId));
+  }
+
+  @GetMapping("/{id}/history")
+  @Operation(
+      summary = "Per-snapshot composition history for a subnet",
+      description =
+          "For each snapshot of the given network where the subnet had members, returns the member "
+              + "count and dominant device types + protocols — the basis for staleness detection.")
+  public ResponseEntity<List<SubnetStalenessService.CompositionHistoryEntry>> history(
+      @PathVariable Long id, @RequestParam UUID networkId) {
+    return subnetService
+        .find(id)
+        .map(s -> ResponseEntity.ok(subnetStalenessService.history(s.getCidr(), networkId)))
+        .orElseThrow(
+            () ->
+                new com.tracepcap.common.exception.ResourceNotFoundException(
+                    "Subnet not found: " + id));
+  }
+
+  @PostMapping("/{id}/dismiss-staleness")
+  @Operation(summary = "Mark a stale subnet label as still correct and re-baseline its composition")
+  public ResponseEntity<SubnetDefinitionDto> dismissStaleness(
+      @PathVariable Long id, @RequestParam(required = false) UUID networkId) {
+    return ResponseEntity.ok(subnetService.dismissStaleness(id, networkId));
   }
 }

--- a/backend/src/main/java/com/tracepcap/subnets/dto/SubnetDefinitionDto.java
+++ b/backend/src/main/java/com/tracepcap/subnets/dto/SubnetDefinitionDto.java
@@ -1,6 +1,7 @@
 package com.tracepcap.subnets.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 
@@ -17,6 +18,9 @@ public class SubnetDefinitionDto {
   private Double densityScore;     // observed hosts / subnet capacity (0–1)
   private Integer snapshotsSeen;   // cross-snapshot consensus fields
   private Integer totalSnapshots;
+  private LocalDateTime labeledAt; // when the label was last confirmed (staleness baseline time)
+  private LocalDateTime staleSince; // null = not stale
+  private List<String> staleFields; // what drifted since the label baseline
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/com/tracepcap/subnets/dto/SubnetLabelSuggestionDto.java
+++ b/backend/src/main/java/com/tracepcap/subnets/dto/SubnetLabelSuggestionDto.java
@@ -1,0 +1,25 @@
+package com.tracepcap.subnets.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * An AI-suggested label + description for a subnet, inferred from the behaviour of its member nodes
+ * (#363). Not persisted — the analyst reviews it in the edit form and saves it onto the subnet
+ * definition's own {@code label}/{@code description} fields.
+ */
+@Data
+@Builder
+public class SubnetLabelSuggestionDto {
+  /** Short subnet name, e.g. "IoT sensor cluster". */
+  private String label;
+
+  /** Longer description: purpose reasoning, key observations, anomalies. */
+  private String description;
+
+  /** How many member nodes the suggestion was based on. */
+  private int memberCount;
+
+  /** How many snapshots were scanned. */
+  private int snapshotCount;
+}

--- a/backend/src/main/java/com/tracepcap/subnets/dto/UpsertSubnetRequest.java
+++ b/backend/src/main/java/com/tracepcap/subnets/dto/UpsertSubnetRequest.java
@@ -1,5 +1,6 @@
 package com.tracepcap.subnets.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -8,4 +9,10 @@ public class UpsertSubnetRequest {
   private String label;
   private String description;
   private boolean confirmed;
+
+  /**
+   * Optional Monitor network context. When present and the label is confirmed, the subnet's
+   * composition baseline is captured from this network's latest snapshot for staleness detection.
+   */
+  private UUID networkId;
 }

--- a/backend/src/main/java/com/tracepcap/subnets/entity/SubnetDefinitionEntity.java
+++ b/backend/src/main/java/com/tracepcap/subnets/entity/SubnetDefinitionEntity.java
@@ -2,6 +2,9 @@ package com.tracepcap.subnets.entity;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -10,7 +13,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "subnet_definitions")
@@ -44,6 +49,28 @@ public class SubnetDefinitionEntity {
   @Builder.Default
   @Column(nullable = false)
   private boolean confirmed = false;
+
+  // ── Staleness baseline (#363) ─────────────────────────────────────────────
+  // Captured when an analyst confirms the label: the subnet's composition (dominant member device
+  // types + protocols) at that moment. Each new snapshot is compared against this; drift sets
+  // staleSince/staleFields until the analyst re-labels or dismisses.
+
+  @Column(name = "labeled_at")
+  private LocalDateTime labeledAt;
+
+  @Column(name = "baseline_file_id")
+  private UUID baselineFileId;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "baseline_composition", columnDefinition = "jsonb")
+  private Map<String, Object> baselineComposition;
+
+  @Column(name = "stale_since")
+  private LocalDateTime staleSince;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "stale_fields", columnDefinition = "jsonb")
+  private List<String> staleFields;
 
   @CreationTimestamp
   @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/tracepcap/subnets/service/CidrRange.java
+++ b/backend/src/main/java/com/tracepcap/subnets/service/CidrRange.java
@@ -1,0 +1,26 @@
+package com.tracepcap.subnets.service;
+
+/** Small shared helpers for IPv4 CIDR range maths, used by the subnet services. */
+final class CidrRange {
+
+  private CidrRange() {}
+
+  /** Inclusive {@code [network, broadcast]} integer range for an IPv4 CIDR (e.g. "10.0.1.0/24"). */
+  static long[] of(String cidr) {
+    String[] parts = cidr.split("/");
+    long base = ipToLong(parts[0]);
+    int prefix = Integer.parseInt(parts[1]);
+    long mask = prefix == 0 ? 0L : (0xFFFFFFFFL << (32 - prefix)) & 0xFFFFFFFFL;
+    long network = base & mask;
+    long broadcast = network | (~mask & 0xFFFFFFFFL);
+    return new long[] {network, broadcast};
+  }
+
+  /** Dotted-quad IPv4 string to its 32-bit integer value. */
+  static long ipToLong(String ip) {
+    String[] o = ip.split("\\.");
+    long v = 0;
+    for (String part : o) v = (v << 8) | Integer.parseInt(part);
+    return v;
+  }
+}

--- a/backend/src/main/java/com/tracepcap/subnets/service/SubnetLabelSuggestionService.java
+++ b/backend/src/main/java/com/tracepcap/subnets/service/SubnetLabelSuggestionService.java
@@ -1,0 +1,355 @@
+package com.tracepcap.subnets.service;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tracepcap.common.exception.InsufficientEvidenceException;
+import com.tracepcap.common.exception.ResourceNotFoundException;
+import com.tracepcap.monitor.entity.NetworkSnapshotEntity;
+import com.tracepcap.monitor.repository.NetworkSnapshotRepository;
+import com.tracepcap.subnets.dto.SubnetLabelSuggestionDto;
+import com.tracepcap.subnets.entity.SubnetDefinitionEntity;
+import com.tracepcap.subnets.repository.SubnetDefinitionRepository;
+import com.tracepcap.story.service.LlmClient;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Suggests a label + description for a subnet from the observed behaviour of its member nodes (#363).
+ * Collects the member nodes of a subnet's CIDR across the most recent snapshots, summarises each
+ * node's behaviour (device type, role label, dominant protocols, external orgs), and asks the LLM for
+ * a concise subnet name plus a description of its purpose and any anomalies. The result is <b>not</b>
+ * persisted — the analyst reviews it in the edit form and saves it onto the subnet's own fields.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubnetLabelSuggestionService {
+
+  /** How many recent snapshots to scan when scoped to a network. */
+  private static final int MAX_SNAPSHOTS = 5;
+
+  /** Cap on member nodes fed to the LLM, to keep the prompt within context. */
+  private static final int MAX_MEMBERS = 40;
+
+  private static final ObjectMapper LENIENT_MAPPER =
+      new ObjectMapper().enable(JsonParser.Feature.ALLOW_COMMENTS);
+
+  private final SubnetDefinitionRepository subnetRepo;
+  private final NetworkSnapshotRepository snapshotRepo;
+  private final LlmClient llmClient;
+  private final org.springframework.jdbc.core.JdbcTemplate jdbc;
+
+  /**
+   * Ask the LLM to suggest a label + description for a subnet from its member nodes' behaviour. If
+   * {@code networkId} is provided the scan is scoped to that network's most recent snapshots;
+   * otherwise all captures are considered. Nothing is persisted.
+   */
+  public SubnetLabelSuggestionDto suggest(Long subnetId, UUID networkId, UUID fileId) {
+    SubnetDefinitionEntity subnet =
+        subnetRepo
+            .findById(subnetId)
+            .orElseThrow(() -> new ResourceNotFoundException("Subnet not found: " + subnetId));
+
+    long[] range = cidrRange(subnet.getCidr());
+    // A specific fileId scopes the suggestion to that one snapshot's traffic (per-snapshot AI);
+    // otherwise fall back to the network's recent snapshots.
+    List<UUID> fileIds = fileId != null ? List.of(fileId) : resolveFileIds(networkId);
+
+    List<MemberNode> members = collectMembers(fileIds, range[0], range[1]);
+    if (members.isEmpty()) {
+      throw new InsufficientEvidenceException(
+          "No member nodes were observed in " + subnet.getCidr() + " across the scanned captures.");
+    }
+
+    String context = buildContext(members);
+    String raw = llmClient.generateCompletion(buildSystemPrompt(), buildUserPrompt(subnet.getCidr(), context));
+    Suggestion parsed = parse(raw);
+
+    return SubnetLabelSuggestionDto.builder()
+        .label(parsed.label())
+        .description(parsed.description())
+        .memberCount(members.size())
+        .snapshotCount(fileIds.size())
+        .build();
+  }
+
+  // ── data collection ─────────────────────────────────────────────────────────
+
+  /** File ids to scan: a network's most recent N snapshots, or all files when unscoped. */
+  private List<UUID> resolveFileIds(UUID networkId) {
+    if (networkId != null) {
+      List<NetworkSnapshotEntity> snaps =
+          snapshotRepo.findByNetworkIdOrderBySnapshotOrderAsc(networkId);
+      return snaps.stream()
+          .filter(s -> s.getFile() != null)
+          .sorted(Comparator.comparingInt(NetworkSnapshotEntity::getSnapshotOrder).reversed())
+          .limit(MAX_SNAPSHOTS)
+          .map(s -> s.getFile().getId())
+          .collect(Collectors.toList());
+    }
+    // Unscoped: every file we have host classifications for.
+    return jdbc.query(
+        "SELECT DISTINCT file_id FROM host_classifications",
+        (rs, i) -> (UUID) rs.getObject("file_id"));
+  }
+
+  /** One member node with its behavioural summary, aggregated across the scanned files. */
+  private record MemberNode(
+      String ip,
+      String deviceType,
+      Integer confidence,
+      String manufacturer,
+      String roleLabel,
+      List<String> protocols,
+      List<String> externalOrgs) {}
+
+  private List<MemberNode> collectMembers(List<UUID> fileIds, long lo, long hi) {
+    if (fileIds.isEmpty()) return List.of();
+
+    // IPs inside the CIDR, with their best host classification across the scanned files.
+    String hostSql =
+        """
+        SELECT DISTINCT ON (hc.ip) hc.ip, hc.device_type, hc.confidence, hc.manufacturer
+        FROM host_classifications hc
+        WHERE hc.file_id = ANY(?)
+          AND ip_to_int(hc.ip) BETWEEN ? AND ?
+        ORDER BY hc.ip, hc.confidence DESC
+        """;
+
+    List<MemberNode> members = new ArrayList<>();
+    UUID[] fileIdArray = fileIds.toArray(new UUID[0]);
+    List<Object[]> rows;
+    try {
+      rows =
+          jdbc.query(
+              con -> {
+                var ps = con.prepareStatement(hostSql);
+                ps.setArray(1, con.createArrayOf("uuid", fileIdArray));
+                ps.setLong(2, lo);
+                ps.setLong(3, hi);
+                return ps;
+              },
+              (rs, i) ->
+                  new Object[] {
+                    rs.getString("ip"),
+                    rs.getString("device_type"),
+                    (Integer) rs.getObject("confidence"),
+                    rs.getString("manufacturer")
+                  });
+    } catch (Exception e) {
+      log.warn("Failed to enumerate subnet members: {}", e.getMessage());
+      return List.of();
+    }
+
+    for (Object[] row : rows) {
+      if (members.size() >= MAX_MEMBERS) break;
+      String ip = (String) row[0];
+      members.add(
+          new MemberNode(
+              ip,
+              (String) row[1],
+              (Integer) row[2],
+              (String) row[3],
+              lookupRoleLabel(fileIds, ip),
+              lookupProtocols(fileIds, ip),
+              lookupExternalOrgs(fileIds, ip, lo, hi)));
+    }
+    return members;
+  }
+
+  private String lookupRoleLabel(List<UUID> fileIds, String ip) {
+    try {
+      List<String> labels =
+          jdbc.query(
+              con -> {
+                var ps =
+                    con.prepareStatement(
+                        """
+                        SELECT role_label FROM node_roles
+                        WHERE file_id = ANY(?) AND entity_type = 'IP' AND entity_key = ?
+                          AND role_label IS NOT NULL
+                        ORDER BY confirmed_by_human DESC, updated_at DESC LIMIT 1
+                        """);
+                ps.setArray(1, con.createArrayOf("uuid", fileIds.toArray(new UUID[0])));
+                ps.setString(2, ip);
+                return ps;
+              },
+              (rs, i) -> rs.getString("role_label"));
+      return labels.isEmpty() ? null : labels.get(0);
+    } catch (Exception e) {
+      log.debug("Role label lookup failed for {}: {}", ip, e.getMessage());
+      return null;
+    }
+  }
+
+  private List<String> lookupProtocols(List<UUID> fileIds, String ip) {
+    try {
+      return jdbc.query(
+          con -> {
+            var ps =
+                con.prepareStatement(
+                    """
+                    SELECT tshark_protocol FROM conversations
+                    WHERE file_id = ANY(?) AND (src_ip = ? OR dst_ip = ?)
+                      AND tshark_protocol IS NOT NULL
+                    GROUP BY tshark_protocol ORDER BY COUNT(*) DESC LIMIT 6
+                    """);
+            ps.setArray(1, con.createArrayOf("uuid", fileIds.toArray(new UUID[0])));
+            ps.setString(2, ip);
+            ps.setString(3, ip);
+            return ps;
+          },
+          (rs, i) -> rs.getString("tshark_protocol"));
+    } catch (Exception e) {
+      log.debug("Protocol lookup failed for {}: {}", ip, e.getMessage());
+      return List.of();
+    }
+  }
+
+  /** Top external orgs this member talked to (dst outside the subnet, joined to geo cache). */
+  private List<String> lookupExternalOrgs(List<UUID> fileIds, String ip, long lo, long hi) {
+    try {
+      return jdbc.query(
+          con -> {
+            var ps =
+                con.prepareStatement(
+                    """
+                    SELECT g.org FROM conversations c
+                    JOIN ip_geo_cache g ON g.ip = c.dst_ip
+                    WHERE c.file_id = ANY(?) AND c.src_ip = ?
+                      AND g.org IS NOT NULL
+                      AND (ip_to_int(c.dst_ip) IS NULL
+                           OR ip_to_int(c.dst_ip) NOT BETWEEN ? AND ?)
+                    GROUP BY g.org ORDER BY COUNT(*) DESC LIMIT 4
+                    """);
+            ps.setArray(1, con.createArrayOf("uuid", fileIds.toArray(new UUID[0])));
+            ps.setString(2, ip);
+            ps.setLong(3, lo);
+            ps.setLong(4, hi);
+            return ps;
+          },
+          (rs, i) -> rs.getString("org"));
+    } catch (Exception e) {
+      log.debug("External org lookup failed for {}: {}", ip, e.getMessage());
+      return List.of();
+    }
+  }
+
+  // ── prompt building ─────────────────────────────────────────────────────────
+
+  private String buildContext(List<MemberNode> members) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Member nodes (").append(members.size()).append("):\n");
+    for (MemberNode m : members) {
+      sb.append("- ").append(m.ip());
+      if (m.deviceType() != null) {
+        sb.append(" | type: ").append(m.deviceType());
+        if (m.confidence() != null) sb.append(" (").append(m.confidence()).append("%)");
+      }
+      if (m.manufacturer() != null) sb.append(" | vendor: ").append(m.manufacturer());
+      if (m.roleLabel() != null) sb.append(" | role: ").append(m.roleLabel());
+      if (!m.protocols().isEmpty()) {
+        sb.append(" | protocols: ").append(String.join(", ", m.protocols()));
+      }
+      if (!m.externalOrgs().isEmpty()) {
+        sb.append(" | talks to: ").append(String.join(", ", m.externalOrgs()));
+      }
+      sb.append("\n");
+    }
+    return sb.toString();
+  }
+
+  private String buildSystemPrompt() {
+    return """
+        You are a network analyst. Given the observed behaviour of the member hosts of a single
+        subnet, suggest a concise LABEL naming what the subnet is (e.g. "IoT sensor cluster",
+        "Corporate user workstations", "DMZ / public-facing services", "Server / datacentre segment",
+        "OT / ICS control network", "Guest / BYOD network"), and a DESCRIPTION covering its likely
+        purpose, key observations, and any anomalies (e.g. a spoofing indicator, an unexpected device
+        type, or traffic to an unusual external org).
+        Base your answer ONLY on the evidence given — this is observational, not a full inventory.
+        The label should be 2-6 words. The description should be 2-5 sentences of plain prose.
+        Respond ONLY with valid JSON in the format:
+        {"label": "...", "description": "..."}
+        If the evidence is too sparse to say anything meaningful, respond with:
+        {"label": null, "description": "Not enough evidence to characterise this subnet."}
+        Do not add any text outside the JSON.
+        """;
+  }
+
+  private String buildUserPrompt(String cidr, String context) {
+    return String.format(
+        """
+        ## Subnet
+        CIDR: %s
+
+        ## Observed member behaviour
+        %s
+
+        Suggest a label and description for this subnet.
+        Respond ONLY with valid JSON: {"label": "...", "description": "..."}
+        """,
+        cidr, context);
+  }
+
+  private record Suggestion(String label, String description) {}
+
+  private Suggestion parse(String raw) {
+    String json = extractJson(raw);
+    try {
+      Map<String, Object> data = LENIENT_MAPPER.readValue(json, new TypeReference<>() {});
+      Object labelRaw = data.get("label");
+      Object descRaw = data.get("description");
+      String description = descRaw != null ? descRaw.toString().trim() : "";
+      if (description.isBlank() && (labelRaw == null || labelRaw.toString().isBlank())) {
+        throw new InsufficientEvidenceException(
+            "The model returned an empty suggestion for this subnet.");
+      }
+      String label =
+          labelRaw != null && !labelRaw.toString().isBlank() ? labelRaw.toString().trim() : null;
+      return new Suggestion(label, description);
+    } catch (InsufficientEvidenceException e) {
+      throw e;
+    } catch (Exception e) {
+      log.warn("Failed to parse LLM subnet label suggestion: {}", e.getMessage());
+      throw new RuntimeException("Failed to parse LLM subnet label suggestion", e);
+    }
+  }
+
+  private String extractJson(String content) {
+    if (content == null || content.isBlank()) throw new RuntimeException("Empty LLM response");
+    content = content.replaceAll("```json\\s*", "").replaceAll("```\\s*", "");
+    int start = content.indexOf('{');
+    int end = content.lastIndexOf('}');
+    if (start >= 0 && end > start) return content.substring(start, end + 1);
+    return content;
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  /** Inclusive [network, broadcast] integer range for an IPv4 CIDR. */
+  private static long[] cidrRange(String cidr) {
+    String[] parts = cidr.split("/");
+    long base = ipToLong(parts[0]);
+    int prefix = Integer.parseInt(parts[1]);
+    long mask = prefix == 0 ? 0L : (0xFFFFFFFFL << (32 - prefix)) & 0xFFFFFFFFL;
+    long network = base & mask;
+    long broadcast = network | (~mask & 0xFFFFFFFFL);
+    return new long[] {network, broadcast};
+  }
+
+  private static long ipToLong(String ip) {
+    String[] o = ip.split("\\.");
+    long v = 0;
+    for (String part : o) v = (v << 8) | Integer.parseInt(part);
+    return v;
+  }
+}

--- a/backend/src/main/java/com/tracepcap/subnets/service/SubnetLabelSuggestionService.java
+++ b/backend/src/main/java/com/tracepcap/subnets/service/SubnetLabelSuggestionService.java
@@ -58,7 +58,7 @@ public class SubnetLabelSuggestionService {
             .findById(subnetId)
             .orElseThrow(() -> new ResourceNotFoundException("Subnet not found: " + subnetId));
 
-    long[] range = cidrRange(subnet.getCidr());
+    long[] range = CidrRange.of(subnet.getCidr());
     // A specific fileId scopes the suggestion to that one snapshot's traffic (per-snapshot AI);
     // otherwise fall back to the network's recent snapshots.
     List<UUID> fileIds = fileId != null ? List.of(fileId) : resolveFileIds(networkId);
@@ -333,23 +333,4 @@ public class SubnetLabelSuggestionService {
     return content;
   }
 
-  // ── helpers ───────────────────────────────────────────────────────────────
-
-  /** Inclusive [network, broadcast] integer range for an IPv4 CIDR. */
-  private static long[] cidrRange(String cidr) {
-    String[] parts = cidr.split("/");
-    long base = ipToLong(parts[0]);
-    int prefix = Integer.parseInt(parts[1]);
-    long mask = prefix == 0 ? 0L : (0xFFFFFFFFL << (32 - prefix)) & 0xFFFFFFFFL;
-    long network = base & mask;
-    long broadcast = network | (~mask & 0xFFFFFFFFL);
-    return new long[] {network, broadcast};
-  }
-
-  private static long ipToLong(String ip) {
-    String[] o = ip.split("\\.");
-    long v = 0;
-    for (String part : o) v = (v << 8) | Integer.parseInt(part);
-    return v;
-  }
 }

--- a/backend/src/main/java/com/tracepcap/subnets/service/SubnetService.java
+++ b/backend/src/main/java/com/tracepcap/subnets/service/SubnetService.java
@@ -25,12 +25,18 @@ public class SubnetService {
   private final SubnetDefinitionRepository subnetRepo;
   private final HostClassificationRepository hostClassRepo;
   private final NetworkSnapshotRepository snapshotRepo;
+  private final SubnetStalenessService stalenessService;
 
   public List<SubnetDefinitionDto> list() {
     return subnetRepo.findAll().stream()
         .sorted(Comparator.comparing(SubnetDefinitionEntity::getCidr))
         .map(this::toDto)
         .collect(Collectors.toList());
+  }
+
+  /** The raw subnet entity by id, for callers that need its CIDR (e.g. history lookups). */
+  public Optional<SubnetDefinitionEntity> find(Long id) {
+    return subnetRepo.findById(id);
   }
 
   @Transactional
@@ -41,10 +47,29 @@ public class SubnetService {
             .findByCidr(cidr)
             .orElseGet(
                 () -> SubnetDefinitionEntity.builder().cidr(cidr).source("MANUAL").build());
+    boolean labelChanged = !java.util.Objects.equals(entity.getLabel(), req.getLabel());
     entity.setLabel(req.getLabel());
     entity.setDescription(req.getDescription());
     entity.setConfirmed(req.isConfirmed());
     if (entity.getId() == null) entity.setSource("MANUAL");
+    // Confirming a (new or changed) label re-baselines the composition and clears any stale flag.
+    if (req.isConfirmed() && (labelChanged || entity.getLabeledAt() == null)) {
+      stalenessService.captureBaseline(entity, req.getNetworkId());
+    }
+    return toDto(subnetRepo.save(entity));
+  }
+
+  /** Dismiss a subnet's stale flag and re-baseline its composition against the latest snapshot. */
+  @Transactional
+  public SubnetDefinitionDto dismissStaleness(Long id, UUID networkId) {
+    SubnetDefinitionEntity entity =
+        subnetRepo
+            .findById(id)
+            .orElseThrow(
+                () ->
+                    new com.tracepcap.common.exception.ResourceNotFoundException(
+                        "Subnet not found: " + id));
+    stalenessService.captureBaseline(entity, networkId);
     return toDto(subnetRepo.save(entity));
   }
 
@@ -250,6 +275,9 @@ public class SubnetService {
         .description(e.getDescription())
         .source(e.getSource())
         .confirmed(e.isConfirmed())
+        .labeledAt(e.getLabeledAt())
+        .staleSince(e.getStaleSince())
+        .staleFields(e.getStaleFields())
         .createdAt(e.getCreatedAt())
         .updatedAt(e.getUpdatedAt())
         .build();

--- a/backend/src/main/java/com/tracepcap/subnets/service/SubnetStalenessService.java
+++ b/backend/src/main/java/com/tracepcap/subnets/service/SubnetStalenessService.java
@@ -97,7 +97,7 @@ public class SubnetStalenessService {
 
     long[] range;
     try {
-      range = cidrRange(cidr);
+      range = CidrRange.of(cidr);
     } catch (Exception e) {
       return comp;
     }
@@ -280,21 +280,4 @@ public class SubnetStalenessService {
         .orElse(null);
   }
 
-  /** Inclusive [network, broadcast] integer range for an IPv4 CIDR. */
-  private static long[] cidrRange(String cidr) {
-    String[] parts = cidr.split("/");
-    long base = ipToLong(parts[0]);
-    int prefix = Integer.parseInt(parts[1]);
-    long mask = prefix == 0 ? 0L : (0xFFFFFFFFL << (32 - prefix)) & 0xFFFFFFFFL;
-    long network = base & mask;
-    long broadcast = network | (~mask & 0xFFFFFFFFL);
-    return new long[] {network, broadcast};
-  }
-
-  private static long ipToLong(String ip) {
-    String[] o = ip.split("\\.");
-    long v = 0;
-    for (String part : o) v = (v << 8) | Integer.parseInt(part);
-    return v;
-  }
 }

--- a/backend/src/main/java/com/tracepcap/subnets/service/SubnetStalenessService.java
+++ b/backend/src/main/java/com/tracepcap/subnets/service/SubnetStalenessService.java
@@ -169,7 +169,7 @@ public class SubnetStalenessService {
           },
           (rs, i) -> rs.getString("ip"));
     } catch (Exception e) {
-      log.debug("member IP lookup failed: {}", e.getMessage());
+      log.warn("member IP lookup failed: {}", e.getMessage());
       return List.of();
     }
   }
@@ -194,7 +194,7 @@ public class SubnetStalenessService {
           },
           (rs, i) -> rs.getString("device_type"));
     } catch (Exception e) {
-      log.debug("device-type composition failed: {}", e.getMessage());
+      log.warn("device-type composition failed: {}", e.getMessage());
       return List.of();
     }
   }
@@ -227,7 +227,7 @@ public class SubnetStalenessService {
           .map(String::toUpperCase)
           .collect(Collectors.toList());
     } catch (Exception e) {
-      log.debug("protocol composition failed: {}", e.getMessage());
+      log.warn("protocol composition failed: {}", e.getMessage());
       return List.of();
     }
   }

--- a/backend/src/main/java/com/tracepcap/subnets/service/SubnetStalenessService.java
+++ b/backend/src/main/java/com/tracepcap/subnets/service/SubnetStalenessService.java
@@ -1,0 +1,300 @@
+package com.tracepcap.subnets.service;
+
+import com.tracepcap.monitor.entity.NetworkSnapshotEntity;
+import com.tracepcap.monitor.repository.NetworkSnapshotRepository;
+import com.tracepcap.subnets.entity.SubnetDefinitionEntity;
+import com.tracepcap.subnets.repository.SubnetDefinitionRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Composition-based staleness for subnet definitions (#363), mirroring the node-role model (#369).
+ * A subnet's "composition" is the set of dominant member device types + protocols observed in a
+ * file. When an analyst confirms a subnet's label we snapshot this composition as the baseline; each
+ * new snapshot's composition is compared against it, and a drift (device types or protocols
+ * appearing/leaving) flags the label stale until re-labelled or dismissed.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubnetStalenessService {
+
+  /** Distinct device types / protocols to keep as the subnet's dominant signature. */
+  private static final int TOP_DEVICE_TYPES = 6;
+  private static final int TOP_PROTOCOLS = 8;
+
+  private final SubnetDefinitionRepository subnetRepo;
+  private final NetworkSnapshotRepository snapshotRepo;
+  private final JdbcTemplate jdbc;
+
+  /** One snapshot's view of a subnet: composition + the snapshot's identity. */
+  public record CompositionHistoryEntry(
+      UUID snapshotId,
+      UUID fileId,
+      String fileName,
+      int snapshotOrder,
+      int memberCount,
+      List<String> deviceTypes,
+      List<String> protocols) {}
+
+  /**
+   * Per-snapshot composition history for a subnet across a network's snapshots — only the snapshots
+   * where the subnet had members. Feeds the subnet Snapshot History table (analogous to the IP one).
+   */
+  public List<CompositionHistoryEntry> history(String cidr, UUID networkId) {
+    if (networkId == null) return List.of();
+    List<CompositionHistoryEntry> out = new ArrayList<>();
+    // Fetch-join the file so getFileName() works outside a session (this method isn't @Transactional).
+    for (NetworkSnapshotEntity snap :
+        snapshotRepo.findByNetworkIdWithFileOrderBySnapshotOrderAsc(networkId)) {
+      if (snap.getFile() == null) continue;
+      Map<String, Object> comp = computeComposition(cidr, snap.getFile().getId());
+      if (!Boolean.TRUE.equals(comp.get("observed"))) continue;
+      out.add(
+          new CompositionHistoryEntry(
+              snap.getId(),
+              snap.getFile().getId(),
+              snap.getFile().getFileName(),
+              snap.getSnapshotOrder(),
+              (int) comp.getOrDefault("memberCount", 0),
+              asList(comp.get("deviceTypes")),
+              asList(comp.get("protocols"))));
+    }
+    return out;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> asList(Object raw) {
+    return raw instanceof List<?> l
+        ? l.stream().filter(o -> o != null).map(Object::toString).collect(Collectors.toList())
+        : List.of();
+  }
+
+  /**
+   * Snapshot a subnet's composition from a file: dominant member device types + protocols and the
+   * member count. {@code observed} is true when any member host appears in the file.
+   */
+  public Map<String, Object> computeComposition(String cidr, UUID fileId) {
+    Map<String, Object> comp = new HashMap<>();
+    comp.put("observed", false);
+    comp.put("deviceTypes", List.of());
+    comp.put("protocols", List.of());
+    comp.put("memberCount", 0);
+    if (fileId == null) return comp;
+
+    long[] range;
+    try {
+      range = cidrRange(cidr);
+    } catch (Exception e) {
+      return comp;
+    }
+
+    List<String> memberIps = memberIps(fileId, range[0], range[1]);
+    if (memberIps.isEmpty()) return comp;
+
+    comp.put("observed", true);
+    comp.put("memberCount", memberIps.size());
+    comp.put("deviceTypes", dominantDeviceTypes(fileId, range[0], range[1]));
+    comp.put("protocols", dominantProtocols(fileId, range[0], range[1]));
+    return comp;
+  }
+
+  /**
+   * Capture the current composition of a subnet as its staleness baseline, using the most recent
+   * snapshot of the network (or a specific file). Called when an analyst confirms the label.
+   */
+  @Transactional
+  public void captureBaseline(SubnetDefinitionEntity subnet, UUID networkId) {
+    UUID fileId = latestFileId(networkId);
+    Map<String, Object> comp = fileId != null ? computeComposition(subnet.getCidr(), fileId) : null;
+    subnet.setLabeledAt(LocalDateTime.now());
+    subnet.setBaselineFileId(fileId);
+    subnet.setBaselineComposition(
+        comp != null && Boolean.TRUE.equals(comp.get("observed")) ? comp : null);
+    subnet.setStaleSince(null);
+    subnet.setStaleFields(null);
+  }
+
+  /**
+   * Re-validate every labelled subnet against the latest snapshot of a network: recompute each
+   * subnet's composition and, if it has drifted from the baseline, flag it stale. Called after a
+   * snapshot is added/reordered. No-op for subnets without a baseline.
+   */
+  @Transactional
+  public void revalidate(UUID networkId) {
+    UUID fileId = latestFileId(networkId);
+    if (fileId == null) return;
+    for (SubnetDefinitionEntity subnet : subnetRepo.findAll()) {
+      if (subnet.getBaselineComposition() == null || subnet.getLabeledAt() == null) continue;
+      Map<String, Object> current = computeComposition(subnet.getCidr(), fileId);
+      if (!Boolean.TRUE.equals(current.get("observed"))) continue; // subnet absent in this snapshot
+      List<String> changes = diff(subnet.getBaselineComposition(), current);
+      if (!changes.isEmpty()) {
+        if (subnet.getStaleSince() == null) subnet.setStaleSince(LocalDateTime.now());
+        subnet.setStaleFields(changes);
+        subnetRepo.save(subnet);
+      }
+    }
+  }
+
+  // ── composition queries ─────────────────────────────────────────────────────
+
+  private List<String> memberIps(UUID fileId, long lo, long hi) {
+    try {
+      return jdbc.query(
+          con -> {
+            var ps =
+                con.prepareStatement(
+                    """
+                    SELECT DISTINCT ip FROM host_classifications
+                    WHERE file_id = ? AND ip_to_int(ip) BETWEEN ? AND ?
+                    """);
+            ps.setObject(1, fileId);
+            ps.setLong(2, lo);
+            ps.setLong(3, hi);
+            return ps;
+          },
+          (rs, i) -> rs.getString("ip"));
+    } catch (Exception e) {
+      log.debug("member IP lookup failed: {}", e.getMessage());
+      return List.of();
+    }
+  }
+
+  private List<String> dominantDeviceTypes(UUID fileId, long lo, long hi) {
+    try {
+      return jdbc.query(
+          con -> {
+            var ps =
+                con.prepareStatement(
+                    """
+                    SELECT device_type FROM host_classifications
+                    WHERE file_id = ? AND ip_to_int(ip) BETWEEN ? AND ?
+                      AND device_type IS NOT NULL
+                    GROUP BY device_type ORDER BY COUNT(*) DESC LIMIT ?
+                    """);
+            ps.setObject(1, fileId);
+            ps.setLong(2, lo);
+            ps.setLong(3, hi);
+            ps.setInt(4, TOP_DEVICE_TYPES);
+            return ps;
+          },
+          (rs, i) -> rs.getString("device_type"));
+    } catch (Exception e) {
+      log.debug("device-type composition failed: {}", e.getMessage());
+      return List.of();
+    }
+  }
+
+  private List<String> dominantProtocols(UUID fileId, long lo, long hi) {
+    try {
+      return jdbc
+          .query(
+              con -> {
+                var ps =
+                    con.prepareStatement(
+                        """
+                        SELECT tshark_protocol FROM conversations
+                        WHERE file_id = ?
+                          AND (ip_to_int(src_ip) BETWEEN ? AND ? OR ip_to_int(dst_ip) BETWEEN ? AND ?)
+                          AND tshark_protocol IS NOT NULL
+                        GROUP BY tshark_protocol ORDER BY COUNT(*) DESC LIMIT ?
+                        """);
+                ps.setObject(1, fileId);
+                ps.setLong(2, lo);
+                ps.setLong(3, hi);
+                ps.setLong(4, lo);
+                ps.setLong(5, hi);
+                ps.setInt(6, TOP_PROTOCOLS);
+                return ps;
+              },
+              (rs, i) -> rs.getString("tshark_protocol"))
+          .stream()
+          .filter(p -> p != null && !p.isBlank())
+          .map(String::toUpperCase)
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      log.debug("protocol composition failed: {}", e.getMessage());
+      return List.of();
+    }
+  }
+
+  // ── drift ─────────────────────────────────────────────────────────────────
+
+  /** Human-readable list of composition changes between a baseline and current snapshot. */
+  @SuppressWarnings("unchecked")
+  private List<String> diff(Map<String, Object> baseline, Map<String, Object> current) {
+    List<String> changes = new ArrayList<>();
+    changes.addAll(
+        setDiff(
+            "device type",
+            asStrings(baseline.get("deviceTypes")),
+            asStrings(current.get("deviceTypes"))));
+    changes.addAll(
+        setDiff(
+            "protocol",
+            asStrings(baseline.get("protocols")),
+            asStrings(current.get("protocols"))));
+    return changes;
+  }
+
+  private List<String> setDiff(String noun, Set<String> base, Set<String> now) {
+    List<String> out = new ArrayList<>();
+    Set<String> added = new LinkedHashSet<>(now);
+    added.removeAll(base);
+    Set<String> removed = new LinkedHashSet<>(base);
+    removed.removeAll(now);
+    for (String a : added) out.add(noun + " appeared: " + a);
+    for (String r : removed) out.add(noun + " gone: " + r);
+    return out;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Set<String> asStrings(Object raw) {
+    if (!(raw instanceof List<?> list)) return Set.of();
+    return list.stream().filter(o -> o != null).map(Object::toString).collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────────
+
+  /** File id of the most recent snapshot of a network, or null. */
+  private UUID latestFileId(UUID networkId) {
+    if (networkId == null) return null;
+    return snapshotRepo.findByNetworkIdOrderBySnapshotOrderAsc(networkId).stream()
+        .filter(s -> s.getFile() != null)
+        .max(Comparator.comparingInt(NetworkSnapshotEntity::getSnapshotOrder))
+        .map(s -> s.getFile().getId())
+        .orElse(null);
+  }
+
+  /** Inclusive [network, broadcast] integer range for an IPv4 CIDR. */
+  private static long[] cidrRange(String cidr) {
+    String[] parts = cidr.split("/");
+    long base = ipToLong(parts[0]);
+    int prefix = Integer.parseInt(parts[1]);
+    long mask = prefix == 0 ? 0L : (0xFFFFFFFFL << (32 - prefix)) & 0xFFFFFFFFL;
+    long network = base & mask;
+    long broadcast = network | (~mask & 0xFFFFFFFFL);
+    return new long[] {network, broadcast};
+  }
+
+  private static long ipToLong(String ip) {
+    String[] o = ip.split("\\.");
+    long v = 0;
+    for (String part : o) v = (v << 8) | Integer.parseInt(part);
+    return v;
+  }
+}

--- a/backend/src/main/resources/db/migration/V27__subnet_assessments.sql
+++ b/backend/src/main/resources/db/migration/V27__subnet_assessments.sql
@@ -1,0 +1,18 @@
+-- Convert a dotted-quad IPv4 string to its 32-bit integer value, for range/CIDR membership tests.
+-- Returns NULL for anything that isn't a well-formed IPv4 literal (e.g. IPv6, hostnames), so callers
+-- must guard with a format check or treat NULL as "not in range". Used by the subnet label-suggestion
+-- feature (#363) to find the member hosts of a CIDR.
+CREATE OR REPLACE FUNCTION ip_to_int(ip TEXT) RETURNS BIGINT AS $$
+    SELECT CASE
+        WHEN ip ~ '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
+             AND split_part(ip, '.', 1)::int <= 255
+             AND split_part(ip, '.', 2)::int <= 255
+             AND split_part(ip, '.', 3)::int <= 255
+             AND split_part(ip, '.', 4)::int <= 255
+        THEN split_part(ip, '.', 1)::bigint * 16777216
+           + split_part(ip, '.', 2)::bigint * 65536
+           + split_part(ip, '.', 3)::bigint * 256
+           + split_part(ip, '.', 4)::bigint
+        ELSE NULL
+    END
+$$ LANGUAGE sql IMMUTABLE;

--- a/backend/src/main/resources/db/migration/V28__subnet_definition_staleness.sql
+++ b/backend/src/main/resources/db/migration/V28__subnet_definition_staleness.sql
@@ -1,0 +1,13 @@
+-- ── subnet_definitions staleness baseline (#363) ─────────────────────────────
+-- Mirrors the node-role staleness model (V24): when an analyst confirms a subnet's label we
+-- snapshot the subnet's COMPOSITION at that moment (dominant member device types + protocols).
+-- On each new snapshot the current composition is compared against this baseline; if the mix
+-- drifts (new device types, protocols appearing/leaving) the label is flagged stale so the analyst
+-- can re-confirm or update it. Composition drift — not membership churn — is the trigger.
+
+ALTER TABLE subnet_definitions
+    ADD COLUMN labeled_at            TIMESTAMP,   -- when the human confirmed the label
+    ADD COLUMN baseline_file_id      UUID,        -- file the baseline composition was computed from
+    ADD COLUMN baseline_composition  JSONB,       -- { deviceTypes:[], protocols:[], memberCount } at label time
+    ADD COLUMN stale_since           TIMESTAMP,   -- first time drift was detected (null = not stale)
+    ADD COLUMN stale_fields          JSONB;       -- human-readable list of what changed since the baseline

--- a/docs/features/label-staleness.rst
+++ b/docs/features/label-staleness.rst
@@ -1,0 +1,168 @@
+Label Staleness Detection
+=========================
+
+TracePcap lets analysts attach **labels** to three kinds of entities:
+
+- **IP addresses** — an operational *role* (e.g. "Domain Controller").
+- **Devices (MAC addresses)** — an operational *role* (e.g. "Site PLC").
+- **Subnet definitions** — a *label + description* naming a CIDR (e.g. "IoT sensor
+  cluster").
+
+A label is only as good as the moment it was written. As a network is observed
+across successive captures, the thing behind a label can change — a host starts
+speaking new protocols, a CIDR fills up with a different class of device. When
+that happens, TracePcap automatically flags the label **stale** so an analyst can
+re-confirm or update it, rather than silently trusting a label that no longer
+fits what the traffic shows.
+
+This page documents exactly how that flag is raised. The short version:
+
+.. note::
+
+   Staleness is **fully deterministic**. It is a plain set-difference between two
+   point-in-time snapshots of *observed* properties. There is **no LLM, no machine
+   learning, no scoring, and no hardcoded list of "significant" protocols**. Any
+   protocol can trigger a flag; none is privileged.
+
+.. important::
+
+   Staleness only exists in **Monitor mode**, where a network has an ordered
+   series of snapshots to compare across. A single PCAP analysed on its own has
+   nothing to drift against.
+
+
+How it works
+------------
+
+The mechanism has three moving parts, identical in shape for all three entity
+types:
+
+1. **Baseline capture.** When an analyst *confirms* a label, TracePcap snapshots
+   the entity's key *observed properties* at that moment and stores them as the
+   **baseline** (alongside the file the baseline was computed from and a
+   timestamp).
+
+2. **Re-validation.** Each time a new snapshot is added to the network (or the
+   snapshot chain is reordered/recomputed), the entity's *current* properties are
+   recomputed from the newest capture and compared against the stored baseline.
+
+3. **Drift → stale.** If the current properties differ from the baseline, the
+   label is marked stale: a ``stale_since`` timestamp is set and a human-readable
+   ``stale_fields`` list records *what* changed. The flag persists across later
+   snapshots until the analyst resolves it — it does not clear just because a
+   still-later snapshot happens to match again.
+
+Resolving a stale flag is an explicit analyst action:
+
+- **Update the label** — re-labelling re-captures a fresh baseline.
+- **Dismiss ("still correct")** — keeps the label and re-baselines against the
+  current composition, accepting the new behaviour as expected.
+
+
+What "properties" means per entity type
+---------------------------------------
+
+The comparison is a set-difference, but *which sets* are compared depends on the
+entity. "Dominant" always means **most frequent by observed count**, taken as the
+top-N via ``GROUP BY … ORDER BY COUNT(*) DESC LIMIT N`` over that capture. It is
+**not** an allow-list of interesting protocols — it is simply whatever was most
+common in the traffic.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 44 20 18
+
+   * - Entity
+     - Properties compared
+     - "Dominant" cutoff
+     - Flags on
+   * - **IP address**
+     - MAC address · top protocols · external organisations contacted
+     - top 5 protocols
+     - additions only
+   * - **Device (MAC)**
+     - Device type · top protocols · external organisations contacted
+     - top 5 protocols
+     - additions only
+   * - **Subnet (CIDR)**
+     - Dominant member **device types** · dominant member **protocols**
+     - top 6 device types, top 8 protocols
+     - additions **and** removals
+
+.. note::
+
+   **Direction asymmetry.** For IP and device roles, only *new* signals raise a
+   flag — a new protocol, a new external org, or a changed MAC. A protocol simply
+   *disappearing* does not, on its own, mark a role stale. For subnet definitions,
+   both directions count: a device type or protocol **appearing** *or* **going
+   away** is treated as composition drift, because a subnet's purpose is about the
+   mix of what lives in it.
+
+External organisations (IP/device roles) are resolved from the geo cache — the
+distinct set of orgs the entity's peers belong to — and behave like protocols: a
+*new* org contacted since label time is drift.
+
+
+Worked example — subnet composition drift
+------------------------------------------
+
+Suppose an analyst labels ``10.0.1.0/24`` as **"IoT LAN"** while looking at week 1,
+where its members are all IoT sensors:
+
+.. code-block:: text
+
+   baseline (captured at label time, from week 1):
+     deviceTypes = [IOT]
+     protocols   = [TLS]
+
+By week 8, workstations have appeared in the same CIDR and are speaking Windows
+networking and mail protocols:
+
+.. code-block:: text
+
+   current (week 8, the latest snapshot):
+     deviceTypes = [IOT, SERVER, MOBILE, ROUTER]
+     protocols   = [TLS, HTTP, NBSS, SMTP, IMAP]
+
+The set-difference yields the ``stale_fields``:
+
+.. code-block:: text
+
+   device type appeared: SERVER
+   device type appeared: MOBILE
+   device type appeared: ROUTER
+   protocol appeared: HTTP
+   protocol appeared: NBSS
+   protocol appeared: SMTP
+   protocol appeared: IMAP
+
+The subnet's "IoT LAN" label is flagged **Stale**, and these exact lines are shown
+to the analyst so they can see *why* before deciding to update or dismiss it.
+
+
+Where it surfaces in the UI
+---------------------------
+
+- **IP / Device roles.** In the entity detail modal, a confirmed-but-stale role
+  shows a **Stale** badge with the drifted fields, plus **Update label** and
+  **Dismiss — label is still correct** actions. In Monitor mode, stale labels are
+  also raised as a **Change Event** ("Manual label staleness") in the change feed.
+- **Subnet definitions.** In the Subnet Definitions panel, a stale subnet shows a
+  **Stale** badge on its row. Opening it reveals a stale banner listing the
+  drifted device types / protocols, a **Dismiss** action, and a **Snapshot
+  History** table showing the subnet's member count, dominant device types, and
+  protocols in every snapshot it appeared in — so the drift is visible at a glance.
+
+
+What it is *not*
+----------------
+
+- It is **not** anomaly detection or threat scoring. A stale flag means "the label
+  no longer matches observed behaviour," not "something is wrong." Benign changes
+  (a new service deployed, DHCP reassignment bringing in different hosts) will
+  legitimately raise it.
+- It does **not** use the AI/LLM. AI is only involved when an analyst *asks* for a
+  suggested role or subnet label; the staleness comparison that follows is
+  entirely rule-based.
+- It does **not** rank protocols by importance. "Dominant" is a frequency cutoff,
+  not a curated list of security-relevant protocols.

--- a/docs/features/network-monitor.rst
+++ b/docs/features/network-monitor.rst
@@ -35,7 +35,8 @@ Overview
 - Devices and IP addresses can be annotated with **role labels** (manually or
   via AI suggestion) to provide operational context. Confirmed labels are
   automatically flagged **stale** when the underlying node's behaviour later
-  drifts from what it was at label time.
+  drifts from what it was at label time. Subnet definitions work the same way.
+  See :doc:`label-staleness` for exactly how the flag is raised.
 - **External Events** log real-world events (maintenance windows, firmware
   upgrades) with timestamps for correlation against network changes.
 - **Analyst Annotations** record free-text notes that feed into AI insight

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Designed for air-gapped and offline deployments — GeoIP lookups use a bundled 
    features/custom-signatures
    features/report-export
    features/network-monitor
+   features/label-staleness
    features/streaming-upload
 
 .. toctree::

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetDetailModal.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetDetailModal.tsx
@@ -1,6 +1,9 @@
-import { useMemo } from 'react';
-import { Badge, Modal } from '@govtechsg/sgds-react';
+import { useMemo, useState } from 'react';
+import { Badge, Button, Modal } from '@govtechsg/sgds-react';
+import { Alert } from '@components/common/Alert';
+import { Spinner } from '@components/common/Spinner/Spinner';
 import { SubnetSnapshotHistory } from '@components/monitor/SubnetsPanel/SubnetSnapshotHistory';
+import { subnetService } from '@/features/subnets/services/subnetService';
 import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
 import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
 
@@ -19,6 +22,24 @@ interface SubnetDetailModalProps {
  */
 export function SubnetDetailModal({ subnet, networkId, snapshots, onClose }: SubnetDetailModalProps) {
   const canScan = snapshots.length > 0 && subnet.id !== null;
+
+  // Local copy of the stale state so Dismiss can clear the banner without a full reload.
+  const [staleSince, setStaleSince] = useState(subnet.staleSince ?? null);
+  const [dismissing, setDismissing] = useState(false);
+  const staleFields = subnet.staleFields ?? [];
+
+  const dismiss = async () => {
+    if (subnet.id === null) return;
+    setDismissing(true);
+    try {
+      await subnetService.dismissStaleness(subnet.id, networkId);
+      setStaleSince(null);
+    } catch {
+      /* leave the banner up on failure */
+    } finally {
+      setDismissing(false);
+    }
+  };
 
   // Present-day = the latest snapshot's per-snapshot override label for this CIDR (read-only).
   const presentDayLabel = useMemo(() => {
@@ -43,11 +64,42 @@ export function SubnetDetailModal({ subnet, networkId, snapshots, onClose }: Sub
           <h6 className="border-bottom pb-1 mb-2">
             Label <span className="text-muted fw-normal" style={{ fontSize: '0.75rem' }}>· present-day (latest snapshot)</span>
           </h6>
+          {staleSince && (
+            <Alert variant="warning" className="p-2 mb-2 small">
+              <div className="d-flex align-items-start gap-2">
+                <i className="bi bi-exclamation-triangle-fill mt-1 flex-shrink-0" />
+                <div>
+                  <strong>This label may be stale.</strong> The subnet's composition has drifted since
+                  it was labelled.
+                  {staleFields.length > 0 && (
+                    <ul className="mb-0 mt-1 ps-3">
+                      {staleFields.slice(0, 6).map((f, i) => <li key={i}>{f}</li>)}
+                    </ul>
+                  )}
+                </div>
+              </div>
+              <div className="mt-2">
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  className="py-0"
+                  style={{ fontSize: '0.75rem' }}
+                  onClick={dismiss}
+                  disabled={dismissing}
+                  title="Mark the label as still correct and reset the composition baseline"
+                >
+                  {dismissing
+                    ? <><Spinner size="sm" className="me-1" />Dismissing…</>
+                    : <><i className="bi bi-check-lg me-1" />Dismiss — label is still correct</>}
+                </Button>
+              </div>
+            </Alert>
+          )}
           {presentDayLabel ? (
             <div className="p-2 rounded small bg-light">
               <div className="fw-semibold">
                 {presentDayLabel}
-                {subnet.staleSince && (
+                {staleSince && (
                   <Badge bg="warning" text="dark" className="ms-2" style={{ fontSize: '0.6rem' }}>
                     <i className="bi bi-exclamation-triangle me-1" />Stale
                   </Badge>

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetDetailModal.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetDetailModal.tsx
@@ -41,11 +41,12 @@ export function SubnetDetailModal({ subnet, networkId, snapshots, onClose }: Sub
     }
   };
 
-  // Present-day = the latest snapshot's per-snapshot override label for this CIDR (read-only).
+  // Present-day = the latest snapshot's per-snapshot override label for this CIDR, falling back to
+  // the subnet's global label when no per-snapshot override has been set (read-only).
   const presentDayLabel = useMemo(() => {
     const latest = [...snapshots].sort((a, b) => b.snapshotOrder - a.snapshotOrder)[0];
-    return latest?.subnetOverrides?.find(o => o.cidr === subnet.cidr)?.label ?? null;
-  }, [snapshots, subnet.cidr]);
+    return latest?.subnetOverrides?.find(o => o.cidr === subnet.cidr)?.label ?? subnet.label ?? null;
+  }, [snapshots, subnet.cidr, subnet.label]);
 
   return (
     <Modal show onHide={onClose} size="lg" centered>

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetDetailModal.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetDetailModal.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { Badge, Modal } from '@govtechsg/sgds-react';
+import { SubnetSnapshotHistory } from '@components/monitor/SubnetsPanel/SubnetSnapshotHistory';
+import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
+import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
+
+interface SubnetDetailModalProps {
+  subnet: SubnetDefinition;
+  networkId: string;
+  snapshots: NetworkSnapshot[];
+  onClose: () => void;
+}
+
+/**
+ * Subnet detail modal, structured exactly like the IP/DEVICE {@code EntityDetailModal}: a
+ * <em>read-only</em> present-day summary of the label at the top, then a Snapshot History table
+ * where the label is set <em>per snapshot</em>. There is no separate global-label editor — the
+ * present-day label is simply the latest snapshot's label, mirroring how node roles work.
+ */
+export function SubnetDetailModal({ subnet, networkId, snapshots, onClose }: SubnetDetailModalProps) {
+  const canScan = snapshots.length > 0 && subnet.id !== null;
+
+  // Present-day = the latest snapshot's per-snapshot override label for this CIDR (read-only).
+  const presentDayLabel = useMemo(() => {
+    const latest = [...snapshots].sort((a, b) => b.snapshotOrder - a.snapshotOrder)[0];
+    return latest?.subnetOverrides?.find(o => o.cidr === subnet.cidr)?.label ?? null;
+  }, [snapshots, subnet.cidr]);
+
+  return (
+    <Modal show onHide={onClose} size="lg" centered>
+      <Modal.Header closeButton>
+        <Modal.Title className="h6 mb-0">
+          <i className="bi bi-diagram-2 me-2" />
+          <span className="font-monospace">{subnet.cidr}</span>
+          {subnet.source === 'AUTO'
+            ? <Badge bg="info" text="dark" className="ms-2" style={{ fontSize: '0.6rem' }}>Detected</Badge>
+            : <Badge bg="secondary" className="ms-2" style={{ fontSize: '0.6rem' }}>Manual</Badge>}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {/* ── Present-day label (read-only) ─────────────────────────────── */}
+        <div className="mb-2">
+          <h6 className="border-bottom pb-1 mb-2">
+            Label <span className="text-muted fw-normal" style={{ fontSize: '0.75rem' }}>· present-day (latest snapshot)</span>
+          </h6>
+          {presentDayLabel ? (
+            <div className="p-2 rounded small bg-light">
+              <div className="fw-semibold">
+                {presentDayLabel}
+                {subnet.staleSince && (
+                  <Badge bg="warning" text="dark" className="ms-2" style={{ fontSize: '0.6rem' }}>
+                    <i className="bi bi-exclamation-triangle me-1" />Stale
+                  </Badge>
+                )}
+              </div>
+            </div>
+          ) : (
+            <p className="text-muted small fst-italic mb-0">
+              No label assigned. Set one per snapshot in the history below.
+            </p>
+          )}
+        </div>
+
+        {/* ── Per-snapshot history (where labels are set) ───────────────── */}
+        {canScan && subnet.id !== null && (
+          <SubnetSnapshotHistory
+            subnetId={subnet.id}
+            cidr={subnet.cidr}
+            networkId={networkId}
+            snapshots={snapshots}
+          />
+        )}
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetSnapshotEditModal.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetSnapshotEditModal.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { Button, Form, Modal } from '@govtechsg/sgds-react';
+import { Alert } from '@components/common/Alert';
+import { Spinner } from '@components/common/Spinner/Spinner';
+import { insightsService } from '@/features/insights/services/insightsService';
+import { subnetService } from '@/features/subnets/services/subnetService';
+import type { NetworkSnapshot, SubnetOverrideInput } from '@/features/monitor/types/monitor.types';
+
+interface SubnetSnapshotEditModalProps {
+  subnetId: number;
+  networkId: string;
+  cidr: string;
+  snapshot: NetworkSnapshot;
+  onClose: () => void;
+  /** Called after a successful save with the label that was set for this snapshot (or null). */
+  onSaved: (label: string | null) => void;
+}
+
+/**
+ * Per-snapshot subnet label editor (the subnet analog of {@link RoleEditModal}). Opened from a
+ * Snapshot History row; sets this subnet's label/description *for that snapshot only* via a
+ * snapshot subnet override, leaving the global definition and other snapshots untouched.
+ */
+export function SubnetSnapshotEditModal({ subnetId, networkId, cidr, snapshot, onClose, onSaved }: SubnetSnapshotEditModalProps) {
+  const existing = (snapshot.subnetOverrides ?? []).find(o => o.cidr === cidr);
+  const [label, setLabel] = useState(existing?.label ?? '');
+  const [description, setDescription] = useState(existing?.description ?? '');
+  const [saving, setSaving] = useState(false);
+  const [suggesting, setSuggesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const suggest = async () => {
+    setSuggesting(true);
+    setError(null);
+    try {
+      // Scope the suggestion to THIS snapshot's traffic (per-snapshot AI, like the role editor).
+      const s = await subnetService.suggestLabel(subnetId, networkId, snapshot.fileId);
+      if (s.label) setLabel(s.label);
+      if (s.description) setDescription(s.description);
+    } catch (err: unknown) {
+      const apiMsg = (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
+      setError(apiMsg ?? (err instanceof Error ? err.message : 'Suggestion failed. Check that the LLM server is reachable (LLM_BASE_URL).'));
+    } finally {
+      setSuggesting(false);
+    }
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      // patchSnapshot replaces the whole override set, so merge this CIDR into the existing rows.
+      const others: SubnetOverrideInput[] = (snapshot.subnetOverrides ?? [])
+        .filter(o => o.cidr !== cidr)
+        .map(o => ({ cidr: o.cidr, label: o.label, description: o.description, inherited: o.inherited }));
+      const merged: SubnetOverrideInput[] = [
+        ...others,
+        { cidr, label: label.trim() || null, description: description.trim() || null, inherited: false },
+      ];
+      await insightsService.patchSnapshot(networkId, snapshot.id, { subnetOverrides: merged });
+      onSaved(label.trim() || null);
+      onClose();
+    } catch {
+      setError('Failed to save the per-snapshot label.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal show onHide={onClose} centered>
+      <Modal.Header closeButton>
+        <Modal.Title style={{ fontSize: '1rem' }}>
+          Edit label for this snapshot
+          <span className="text-muted fw-normal ms-2" style={{ fontSize: '0.8rem' }}>· {snapshot.fileName}</span>
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p className="text-muted small mb-2">
+          Sets <code className="font-monospace">{cidr}</code>'s label for this snapshot only. It
+          overrides the present-day label here without changing the global definition or other
+          snapshots. Leave blank to fall back to the global label.
+        </p>
+        {error && (
+          <Alert variant="warning" className="p-2 mb-2 small d-flex align-items-start gap-2">
+            <i className="bi bi-exclamation-triangle-fill mt-1 flex-shrink-0" /><span>{error}</span>
+          </Alert>
+        )}
+        <Form.Label className="small mb-1">Label</Form.Label>
+        <Form.Control
+          size="sm"
+          className="mb-2"
+          placeholder="e.g. IoT sensor cluster"
+          value={label}
+          onChange={e => setLabel(e.target.value)}
+          autoFocus
+        />
+        <Form.Label className="small mb-1">Description (optional)</Form.Label>
+        <Form.Control
+          as="textarea"
+          size="sm"
+          className="mb-2"
+          rows={3}
+          placeholder="What this subnet was in this snapshot"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+        />
+        <Button
+          variant="outline-primary"
+          size="sm"
+          onClick={suggest}
+          disabled={suggesting || saving}
+          title="Ask the AI to infer this subnet's label from this snapshot's member behaviour"
+        >
+          {suggesting
+            ? <><Spinner size="sm" className="me-1" />Suggesting…</>
+            : <><i className="bi bi-stars me-1" />Suggest with AI</>}
+        </Button>
+      </Modal.Body>
+      <Modal.Footer className="d-flex justify-content-end gap-2">
+        <Button variant="outline-secondary" size="sm" onClick={onClose} disabled={saving}>Cancel</Button>
+        <Button variant="primary" size="sm" onClick={save} disabled={saving}>
+          {saving ? <><Spinner size="sm" className="me-1" />Saving…</> : 'Save'}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetSnapshotEditModal.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetSnapshotEditModal.tsx
@@ -53,10 +53,17 @@ export function SubnetSnapshotEditModal({ subnetId, networkId, cidr, snapshot, o
       const others: SubnetOverrideInput[] = (snapshot.subnetOverrides ?? [])
         .filter(o => o.cidr !== cidr)
         .map(o => ({ cidr: o.cidr, label: o.label, description: o.description, inherited: o.inherited }));
-      const merged: SubnetOverrideInput[] = [
-        ...others,
-        { cidr, label: label.trim() || null, description: description.trim() || null, inherited: false },
-      ];
+      // Clearing both fields removes the direct override entirely, so the subnet falls back to a
+      // carried-forward label (or the global definition) rather than pinning a blank direct override.
+      const merged: SubnetOverrideInput[] = [...others];
+      if (label.trim() || description.trim()) {
+        merged.push({
+          cidr,
+          label: label.trim() || null,
+          description: description.trim() || null,
+          inherited: false,
+        });
+      }
       await insightsService.patchSnapshot(networkId, snapshot.id, { subnetOverrides: merged });
       onSaved(label.trim() || null);
       onClose();

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetSnapshotHistory.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetSnapshotHistory.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import { Badge, Button, Table } from '@govtechsg/sgds-react';
+import { Spinner } from '@components/common/Spinner/Spinner';
+import { SubnetSnapshotEditModal } from '@components/monitor/SubnetsPanel/SubnetSnapshotEditModal';
+import { hashBadgeStyle } from '@components/common/EntityDetailModal/format';
+import { subnetService } from '@/features/subnets/services/subnetService';
+import type { SubnetCompositionHistoryEntry } from '@/features/subnets/types/subnet.types';
+import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
+
+interface SubnetSnapshotHistoryProps {
+  subnetId: number;
+  cidr: string;
+  networkId: string;
+  snapshots: NetworkSnapshot[];
+}
+
+/**
+ * Per-snapshot composition + label history for a subnet — the analog of the IP/DEVICE Snapshot
+ * History. Each row shows the subnet's member count and dominant device types / protocols for that
+ * snapshot, plus its per-snapshot label (a subnet override) which can be edited inline via a modal.
+ */
+export function SubnetSnapshotHistory({ subnetId, cidr, networkId, snapshots }: SubnetSnapshotHistoryProps) {
+  const [rows, setRows] = useState<SubnetCompositionHistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editSnap, setEditSnap] = useState<NetworkSnapshot | null>(null);
+  // Per-snapshot override for this CIDR, keyed by snapshot id. Seeded from the parent's snapshots and
+  // updated locally on save (the parent's prop only refreshes on its next poll). `inherited` marks a
+  // label carried forward from an earlier snapshot rather than set directly here.
+  type OverrideView = { label: string | null; inherited: boolean };
+  const [overrides, setOverrides] = useState<Record<string, OverrideView>>(() =>
+    Object.fromEntries(
+      snapshots.map(s => {
+        const o = s.subnetOverrides?.find(ov => ov.cidr === cidr);
+        return [s.id, { label: o?.label ?? null, inherited: o?.inherited ?? false }];
+      }),
+    ),
+  );
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    subnetService
+      .history(subnetId, networkId)
+      .then(r => { if (active) setRows(r); })
+      .catch(() => { if (active) setRows([]); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [subnetId, networkId]);
+
+  const overrideFor = (snapshotId: string): OverrideView =>
+    overrides[snapshotId] ?? { label: null, inherited: false };
+
+  return (
+    <div className="mt-3">
+      <h6 className="text-muted fw-semibold mb-2">
+        <i className="bi bi-clock-history me-1" />Snapshot History
+      </h6>
+      {loading && (
+        <div className="text-muted small py-2"><Spinner size="sm" className="me-2" />Loading…</div>
+      )}
+      {!loading && rows.length === 0 && (
+        <p className="text-muted small fst-italic mb-0">Not seen in any snapshots.</p>
+      )}
+      {!loading && rows.length > 0 && (
+        <div className="rounded border overflow-hidden">
+          <Table size="sm" hover responsive className="mb-0">
+            <Table.Header className="table-light" style={{ fontSize: '0.8rem' }}>
+              <Table.Row>
+                <Table.HeaderCell className="text-muted fw-normal">#</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Snapshot</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Members</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Device Types</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Protocols</Table.HeaderCell>
+                <Table.HeaderCell className="text-muted fw-normal">Label</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {rows.map(r => {
+                const snap = snapshots.find(s => s.id === r.snapshotId);
+                const ov = overrideFor(r.snapshotId);
+                return (
+                  <Table.Row key={r.snapshotId}>
+                    <Table.DataCell><small className="text-muted">{r.snapshotOrder + 1}</small></Table.DataCell>
+                    <Table.DataCell>
+                      <small className="text-muted text-break" style={{ fontSize: '0.72rem' }}>{r.fileName}</small>
+                    </Table.DataCell>
+                    <Table.DataCell><small>{r.memberCount}</small></Table.DataCell>
+                    <Table.DataCell>
+                      {r.deviceTypes.length === 0 ? (
+                        <small className="text-muted">—</small>
+                      ) : (
+                        <div className="d-flex flex-wrap gap-1">
+                          {r.deviceTypes.map((d, i) => (
+                            <Badge key={`dt-${d}-${i}`} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(d) }}>{d}</Badge>
+                          ))}
+                        </div>
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      {r.protocols.length === 0 ? (
+                        <small className="text-muted">—</small>
+                      ) : (
+                        <div className="d-flex flex-wrap gap-1">
+                          {r.protocols.map((p, i) => (
+                            <Badge key={`p-${p}-${i}`} style={{ fontSize: '0.65rem', fontWeight: 400, ...hashBadgeStyle(p) }}>{p}</Badge>
+                          ))}
+                        </div>
+                      )}
+                    </Table.DataCell>
+                    <Table.DataCell>
+                      <div className="d-flex align-items-center gap-1">
+                        {ov.label ? <small>{ov.label}</small> : <small className="text-muted fst-italic">—</small>}
+                        {ov.label && ov.inherited && (
+                          <Badge
+                            bg="light"
+                            text="secondary"
+                            className="border"
+                            style={{ fontSize: '0.55rem', fontWeight: 400 }}
+                            title="Inherited from an earlier snapshot (carried forward), not set here"
+                          >
+                            carried
+                          </Badge>
+                        )}
+                        {snap && (
+                          <Button
+                            variant="link"
+                            size="sm"
+                            className="p-0 ms-1 text-muted"
+                            style={{ fontSize: '0.75rem', lineHeight: 1 }}
+                            title="Edit this subnet's label for this snapshot"
+                            onClick={() => setEditSnap(snap)}
+                          >
+                            <i className="bi bi-pencil" />
+                          </Button>
+                        )}
+                      </div>
+                    </Table.DataCell>
+                  </Table.Row>
+                );
+              })}
+            </Table.Body>
+          </Table>
+        </div>
+      )}
+
+      {editSnap && (
+        <SubnetSnapshotEditModal
+          subnetId={subnetId}
+          networkId={networkId}
+          cidr={cidr}
+          snapshot={editSnap}
+          onClose={() => setEditSnap(null)}
+          onSaved={label => setOverrides(prev => ({ ...prev, [editSnap.id]: { label, inherited: false } }))}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetSnapshotHistory.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetSnapshotHistory.tsx
@@ -22,6 +22,7 @@ interface SubnetSnapshotHistoryProps {
 export function SubnetSnapshotHistory({ subnetId, cidr, networkId, snapshots }: SubnetSnapshotHistoryProps) {
   const [rows, setRows] = useState<SubnetCompositionHistoryEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [editSnap, setEditSnap] = useState<NetworkSnapshot | null>(null);
   // Per-snapshot override for this CIDR, keyed by snapshot id. Seeded from the parent's snapshots and
   // updated locally on save (the parent's prop only refreshes on its next poll). `inherited` marks a
@@ -39,10 +40,11 @@ export function SubnetSnapshotHistory({ subnetId, cidr, networkId, snapshots }: 
   useEffect(() => {
     let active = true;
     setLoading(true);
+    setError(false);
     subnetService
       .history(subnetId, networkId)
       .then(r => { if (active) setRows(r); })
-      .catch(() => { if (active) setRows([]); })
+      .catch(() => { if (active) { setRows([]); setError(true); } })
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
   }, [subnetId, networkId]);
@@ -58,7 +60,12 @@ export function SubnetSnapshotHistory({ subnetId, cidr, networkId, snapshots }: 
       {loading && (
         <div className="text-muted small py-2"><Spinner size="sm" className="me-2" />Loading…</div>
       )}
-      {!loading && rows.length === 0 && (
+      {!loading && error && (
+        <p className="text-danger small mb-0">
+          <i className="bi bi-exclamation-triangle me-1" />Failed to load snapshot history.
+        </p>
+      )}
+      {!loading && !error && rows.length === 0 && (
         <p className="text-muted small fst-italic mb-0">Not seen in any snapshots.</p>
       )}
       {!loading && rows.length > 0 && (

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetsPanel.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Form } from '@govtechsg/sgds-react';
+import { Badge, Button, Form } from '@govtechsg/sgds-react';
 import { Spinner } from '@components/common/Spinner/Spinner';
 import { SubnetDiagramModal } from '@components/monitor/SubnetDiagramModal/SubnetDiagramModal';
 import { SubnetDetailModal } from '@components/monitor/SubnetsPanel/SubnetDetailModal';
@@ -40,7 +40,7 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
     if (!addCidr.trim()) return;
     setAddSaving(true);
     try {
-      const saved = await subnetService.upsert(addCidr.trim(), addLabel.trim(), addDesc.trim(), true);
+      const saved = await subnetService.upsert(addCidr.trim(), addLabel.trim(), addDesc.trim(), true, networkId);
       onSaved(saved);
       setAddCidr(''); setAddLabel(''); setAddDesc('');
       setShowAddForm(false);
@@ -126,13 +126,14 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
                         <div className="d-flex align-items-center gap-1">
                           {subnet.label || <span className="text-muted fst-italic">—</span>}
                           {subnet.staleSince && (
-                            <span
-                              className="badge bg-warning text-dark"
+                            <Badge
+                              bg="warning"
+                              text="dark"
                               style={{ fontSize: '0.6rem' }}
                               title="Composition drifted since this label was set — open to review"
                             >
                               <i className="bi bi-exclamation-triangle me-1" />Stale
-                            </span>
+                            </Badge>
                           )}
                         </div>
                       </td>

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetsPanel.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetsPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Button, Form } from '@govtechsg/sgds-react';
 import { Spinner } from '@components/common/Spinner/Spinner';
 import { SubnetDiagramModal } from '@components/monitor/SubnetDiagramModal/SubnetDiagramModal';
+import { SubnetDetailModal } from '@components/monitor/SubnetsPanel/SubnetDetailModal';
 import { subnetService } from '@/features/subnets/services/subnetService';
 import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
 import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types';
@@ -14,13 +15,6 @@ interface SubnetsPanelProps {
   onDeleted: (id: number) => void;
 }
 
-interface EditState {
-  id: number | null;
-  cidr: string;
-  label: string;
-  description: string;
-}
-
 export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted }: SubnetsPanelProps) => {
   const [showAddForm, setShowAddForm] = useState(false);
   const [addCidr, setAddCidr] = useState('');
@@ -28,8 +22,7 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
   const [addDesc, setAddDesc] = useState('');
   const [addSaving, setAddSaving] = useState(false);
 
-  const [editState, setEditState] = useState<EditState | null>(null);
-  const [editSaving, setEditSaving] = useState(false);
+  const [detailSubnet, setDetailSubnet] = useState<SubnetDefinition | null>(null);
 
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [diagramSubnet, setDiagramSubnet] = useState<SubnetDefinition | null>(null);
@@ -53,18 +46,6 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
       setShowAddForm(false);
     } finally {
       setAddSaving(false);
-    }
-  };
-
-  const handleEditSave = async () => {
-    if (!editState) return;
-    setEditSaving(true);
-    try {
-      const saved = await subnetService.upsert(editState.cidr.trim(), editState.label.trim(), editState.description.trim(), true);
-      onSaved(saved);
-      setEditState(null);
-    } finally {
-      setEditSaving(false);
     }
   };
 
@@ -134,55 +115,34 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
             </thead>
             <tbody>
               {subnets.map(subnet => (
-                <tr key={subnet.id}>
-                  {editState?.id === subnet.id ? (
-                    <>
-                      <td>
-                        <Form.Control
-                          size="sm"
-                          value={editState.cidr}
-                          onChange={e => setEditState({ ...editState, cidr: e.target.value })}
-                        />
-                      </td>
-                      <td>
-                        <Form.Control
-                          size="sm"
-                          value={editState.label}
-                          onChange={e => setEditState({ ...editState, label: e.target.value })}
-                          placeholder="e.g. Corporate LAN"
-                        />
-                      </td>
-                      <td>
-                        <Form.Control
-                          size="sm"
-                          value={editState.description}
-                          onChange={e => setEditState({ ...editState, description: e.target.value })}
-                          placeholder="Optional description"
-                        />
-                      </td>
-                      <td></td>
-                      <td>
-                        <div className="d-flex gap-1">
-                          <Button size="sm" variant="primary" onClick={handleEditSave} disabled={editSaving || !editState.cidr.trim()}>
-                            {editSaving ? <Spinner animation="border" size="sm" /> : <i className="bi bi-floppy" />}
-                          </Button>
-                          <Button size="sm" variant="outline-secondary" onClick={() => setEditState(null)} disabled={editSaving}>
-                            <i className="bi bi-x-lg" />
-                          </Button>
+                <tr
+                  key={subnet.id}
+                  onClick={() => setDetailSubnet(subnet)}
+                  style={{ cursor: 'pointer' }}
+                  title="Open subnet details"
+                >
+                      <td className="small font-monospace">{subnet.cidr}</td>
+                      <td className="small">
+                        <div className="d-flex align-items-center gap-1">
+                          {subnet.label || <span className="text-muted fst-italic">—</span>}
+                          {subnet.staleSince && (
+                            <span
+                              className="badge bg-warning text-dark"
+                              style={{ fontSize: '0.6rem' }}
+                              title="Composition drifted since this label was set — open to review"
+                            >
+                              <i className="bi bi-exclamation-triangle me-1" />Stale
+                            </span>
+                          )}
                         </div>
                       </td>
-                    </>
-                  ) : (
-                    <>
-                      <td className="font-monospace small">{subnet.cidr}</td>
-                      <td className="small">{subnet.label || <span className="text-muted fst-italic">—</span>}</td>
                       <td className="small text-muted">{subnet.description || '—'}</td>
                       <td>
                         <span className={`badge ${subnet.source === 'AUTO' ? 'bg-info text-dark' : 'bg-secondary'}`} style={{ fontSize: '0.65rem' }}>
                           {subnet.source === 'AUTO' ? 'Detected' : 'Manual'}
                         </span>
                       </td>
-                      <td>
+                      <td onClick={e => e.stopPropagation()}>
                         <div className="d-flex gap-1">
                           {snapshots.length > 0 && (
                             <Button
@@ -196,13 +156,6 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
                           )}
                           <Button
                             size="sm"
-                            variant="outline-secondary"
-                            onClick={() => setEditState({ id: subnet.id, cidr: subnet.cidr, label: subnet.label ?? '', description: subnet.description ?? '' })}
-                          >
-                            <i className="bi bi-pencil" />
-                          </Button>
-                          <Button
-                            size="sm"
                             variant="outline-danger"
                             onClick={() => subnet.id !== null && handleDelete(subnet.id)}
                             disabled={deletingId === subnet.id}
@@ -213,8 +166,6 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
                           </Button>
                         </div>
                       </td>
-                    </>
-                  )}
                 </tr>
               ))}
             </tbody>
@@ -395,6 +346,15 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
           snapshots={snapshots}
           onHide={() => setDiagramSubnet(null)}
           defaultSnapId={diagramDefaultSnapId}
+        />
+      )}
+
+      {detailSubnet && (
+        <SubnetDetailModal
+          subnet={detailSubnet}
+          networkId={networkId}
+          snapshots={snapshots}
+          onClose={() => setDetailSubnet(null)}
         />
       )}
 

--- a/frontend/src/features/subnets/services/subnetService.ts
+++ b/frontend/src/features/subnets/services/subnetService.ts
@@ -1,14 +1,20 @@
 import { apiClient } from '@/services/api/client';
 import { SUBNET_ENDPOINTS } from '@/services/api/endpoints';
-import type { SubnetDefinition } from '../types/subnet.types';
+import type {
+  SubnetDefinition,
+  SubnetLabelSuggestion,
+  SubnetCompositionHistoryEntry,
+} from '../types/subnet.types';
 
 export const subnetService = {
   list: () =>
     apiClient.get<SubnetDefinition[]>(SUBNET_ENDPOINTS.SUBNETS).then(r => r.data),
 
-  upsert: (cidr: string, label: string, description: string, confirmed: boolean) =>
+  // networkId (optional) lets the backend capture the staleness baseline from that network's
+  // latest snapshot when a label is confirmed.
+  upsert: (cidr: string, label: string, description: string, confirmed: boolean, networkId?: string) =>
     apiClient
-      .post<SubnetDefinition>(SUBNET_ENDPOINTS.SUBNETS, { cidr, label, description, confirmed })
+      .post<SubnetDefinition>(SUBNET_ENDPOINTS.SUBNETS, { cidr, label, description, confirmed, networkId })
       .then(r => r.data),
 
   saveDetected: (cidr: string, label: string, description: string) =>
@@ -32,5 +38,24 @@ export const subnetService = {
   detectFromNetwork: (networkId: string) =>
     apiClient
       .get<SubnetDefinition[]>(SUBNET_ENDPOINTS.SUBNET_DETECT_NETWORK(networkId))
+      .then(r => r.data),
+
+  // Ask the AI to suggest a label + description from the subnet's member-node behaviour. Not
+  // persisted — the caller fills the edit form with the result and saves it via upsert.
+  suggestLabel: (id: number, networkId?: string, fileId?: string) =>
+    apiClient
+      .post<SubnetLabelSuggestion>(SUBNET_ENDPOINTS.SUBNET_SUGGEST_LABEL(id, networkId, fileId))
+      .then(r => r.data),
+
+  // Per-snapshot composition history for the subnet, for the Snapshot History table.
+  history: (id: number, networkId: string) =>
+    apiClient
+      .get<SubnetCompositionHistoryEntry[]>(SUBNET_ENDPOINTS.SUBNET_HISTORY(id, networkId))
+      .then(r => r.data),
+
+  // Mark a stale label still-correct and re-baseline the composition.
+  dismissStaleness: (id: number, networkId?: string) =>
+    apiClient
+      .post<SubnetDefinition>(SUBNET_ENDPOINTS.SUBNET_DISMISS_STALENESS(id, networkId))
       .then(r => r.data),
 };

--- a/frontend/src/features/subnets/types/subnet.types.ts
+++ b/frontend/src/features/subnets/types/subnet.types.ts
@@ -9,6 +9,27 @@ export interface SubnetDefinition {
   densityScore?: number;
   snapshotsSeen?: number;
   totalSnapshots?: number;
+  labeledAt?: string | null;
+  staleSince?: string | null;
+  staleFields?: string[] | null;
   createdAt?: string;
   updatedAt?: string;
+}
+
+export interface SubnetLabelSuggestion {
+  label: string | null;
+  description: string | null;
+  memberCount: number;
+  snapshotCount: number;
+}
+
+/** One snapshot's view of a subnet's composition, for the Snapshot History table. */
+export interface SubnetCompositionHistoryEntry {
+  snapshotId: string;
+  fileId: string;
+  fileName: string;
+  snapshotOrder: number;
+  memberCount: number;
+  deviceTypes: string[];
+  protocols: string[];
 }

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -118,6 +118,17 @@ export const SUBNET_ENDPOINTS = {
   SUBNET_DETECT: (fileId: string) => `/subnets/detect?fileId=${fileId}`,
   SUBNET_DETECT_NETWORK: (networkId: string) => `/subnets/detect/network?networkId=${networkId}`,
   SUBNET_SAVE_DETECTED: '/subnets/detected',
+  SUBNET_SUGGEST_LABEL: (id: number, networkId?: string, fileId?: string) => {
+    const p = new URLSearchParams();
+    if (networkId) p.set('networkId', networkId);
+    if (fileId) p.set('fileId', fileId);
+    const q = p.toString();
+    return `/subnets/${id}/suggest-label${q ? `?${q}` : ''}`;
+  },
+  SUBNET_HISTORY: (id: number, networkId: string) =>
+    `/subnets/${id}/history?networkId=${networkId}`,
+  SUBNET_DISMISS_STALENESS: (id: number, networkId?: string) =>
+    `/subnets/${id}/dismiss-staleness${networkId ? `?networkId=${networkId}` : ''}`,
 };
 
 export const INSIGHTS_ENDPOINTS = {

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -493,6 +493,42 @@
         },
         "type": "object"
       },
+      "CompositionHistoryEntry": {
+        "properties": {
+          "deviceTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "fileId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "memberCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "protocols": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "snapshotId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "snapshotOrder": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "ConversationDetailResponse": {
         "properties": {
           "appName": {
@@ -2712,11 +2748,25 @@
           "label": {
             "type": "string"
           },
+          "labeledAt": {
+            "format": "date-time",
+            "type": "string"
+          },
           "snapshotsSeen": {
             "format": "int32",
             "type": "integer"
           },
           "source": {
+            "type": "string"
+          },
+          "staleFields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "staleSince": {
+            "format": "date-time",
             "type": "string"
           },
           "totalSnapshots": {
@@ -2726,6 +2776,25 @@
           "updatedAt": {
             "format": "date-time",
             "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SubnetLabelSuggestionDto": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "memberCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "snapshotCount": {
+            "format": "int32",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -3057,6 +3126,10 @@
             "type": "string"
           },
           "label": {
+            "type": "string"
+          },
+          "networkId": {
+            "format": "uuid",
             "type": "string"
           }
         },
@@ -6577,7 +6650,7 @@
     "/api/v1/node-roles/dismiss-staleness": {
       "post": {
         "description": "Clears the staleness flag for a confirmed label and records the current file's node properties as the new drift baseline.",
-        "operationId": "dismissStaleness",
+        "operationId": "dismissStaleness_1",
         "parameters": [
           {
             "in": "query",
@@ -7148,6 +7221,143 @@
           }
         },
         "summary": "Delete a subnet definition",
+        "tags": [
+          "Subnets"
+        ]
+      }
+    },
+    "/api/v1/subnets/{id}/dismiss-staleness": {
+      "post": {
+        "operationId": "dismissStaleness",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "networkId",
+            "required": false,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubnetDefinitionDto"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Mark a stale subnet label as still correct and re-baseline its composition",
+        "tags": [
+          "Subnets"
+        ]
+      }
+    },
+    "/api/v1/subnets/{id}/history": {
+      "get": {
+        "description": "For each snapshot of the given network where the subnet had members, returns the member count and dominant device types + protocols — the basis for staleness detection.",
+        "operationId": "history",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "networkId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CompositionHistoryEntry"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Per-snapshot composition history for a subnet",
+        "tags": [
+          "Subnets"
+        ]
+      }
+    },
+    "/api/v1/subnets/{id}/suggest-label": {
+      "post": {
+        "description": "Collects the subnet's member nodes across recent snapshots and asks the LLM to suggest a concise label naming the subnet plus a description of its purpose and any anomalies. The result is not persisted — the analyst reviews it in the edit form and saves it onto the subnet's own label/description. Optionally scope to a network via networkId.",
+        "operationId": "suggestLabel",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "networkId",
+            "required": false,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fileId",
+            "required": false,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubnetLabelSuggestionDto"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Suggest a label + description for a subnet with AI",
         "tags": [
           "Subnets"
         ]

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -6650,7 +6650,7 @@
     "/api/v1/node-roles/dismiss-staleness": {
       "post": {
         "description": "Clears the staleness flag for a confirmed label and records the current file's node properties as the new drift baseline.",
-        "operationId": "dismissStaleness_1",
+        "operationId": "dismissStaleness",
         "parameters": [
           {
             "in": "query",
@@ -7228,7 +7228,7 @@
     },
     "/api/v1/subnets/{id}/dismiss-staleness": {
       "post": {
-        "operationId": "dismissStaleness",
+        "operationId": "dismissSubnetStaleness",
         "parameters": [
           {
             "in": "path",
@@ -7354,7 +7354,17 @@
                 }
               }
             },
-            "description": "OK"
+            "description": "Suggested label + description"
+          },
+          "422": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubnetLabelSuggestionDto"
+                }
+              }
+            },
+            "description": "No member nodes observed — insufficient evidence"
           }
         },
         "summary": "Suggest a label + description for a subnet with AI",


### PR DESCRIPTION
Closes #363.

Reworks **subnet definitions** to behave like IP / device node roles, so a CIDR's label is scoped **per capture** rather than being one global value that silently goes stale in dynamic networks.

## What changed

### Frontend — Monitor › Subnet Definitions
- **Rows are clickable** and open a detail modal structured like `EntityDetailModal`: a **read-only present-day summary** (the latest snapshot's label) at the top, then a **Snapshot History** table where labels are set **per snapshot**.
- **Per-snapshot label editing** via `SubnetSnapshotEditModal` (the subnet analog of `RoleEditModal`), writing `snapshot_subnet_overrides`. Includes **Suggest with AI** scoped to that snapshot's own traffic.
- **"carried" badge** on labels inherited from an earlier snapshot; **Stale badge** + drift details on the present-day summary.
- **Dark-mode fix**: history badges now use the shared `hashBadgeStyle` so they honour the `--badge-hue` dark-mode override (previously rendered light-on-light in dark mode).

### Backend
- **`SubnetLabelSuggestionService`** — LLM suggests a label + description from a subnet's member-node behaviour (device types, roles, protocols, external orgs). Optional `fileId` scopes it to one snapshot. Not persisted.
- **`SubnetStalenessService`** — composition-based staleness (dominant member device types + protocols), baseline captured on label confirm and re-validated each snapshot. Deterministic set-difference; no LLM, no protocol allow-list. (migration V28)
- **`SubnetOverrideCarryForwardService`** — carries subnet labels forward across snapshots as `inherited` overrides, **cascading through the whole tail** on edit (mirrors `LabelStalenessService.carryForwardAndValidate` + `propagateRoleChange`).
- New endpoints: `POST /subnets/{id}/suggest-label`, `GET /subnets/{id}/history`, `POST /subnets/{id}/dismiss-staleness`.

### Docs
- `features/label-staleness.rst` — documents the deterministic staleness mechanism for IP, device, and subnet labels (per-entity properties, the frequency-based "dominant" cutoff, the additions-vs-additions+removals direction asymmetry, worked example).

## ⚠️ Known limitation — duplicate CIDRs

Subnet identity is **CIDR-only** (`subnet_definitions.cidr` is globally UNIQUE; overrides/carry-forward key on `(snapshot_id, cidr)`). RFC 1918 ranges are non-unique by design, so a single capture point can observe **two different L2 networks sharing the same range** (multi-site NAT, VLANs, VPN overlays). Today these **collapse into one subnet** — a label meant for one network applies to the other, and composition/staleness blends both into one mix.

This is correct for the common single-site capture, and out of scope for this PR. Follow-ups:

- **#461** — detect & warn on overlapping/duplicate CIDRs (heuristic: disjoint MAC sets / multiple gateways).
- **#462** — model disambiguation: subnet identity becomes `(CIDR + segment key)`.

Note: **VLAN is not parsed or stored** anywhere in the pipeline today, and is only present in trunk-port captures — so it can't serve as the disambiguator without a separate parser change. The near-term disambiguator is a MAC/gateway-derived segment key (#461 → #462).

## Verification
- Full stack rebuilt; migrations V27 (adds `ip_to_int` helper) + V28 (staleness baseline) apply cleanly.
- Staleness: labelling captures a baseline; a drifted composition sets `stale_since` + human-readable `stale_fields`; Dismiss re-baselines.
- Carry-forward: a label set on an early snapshot cascades to **every** later snapshot as `inherited=true`; a direct override on a later snapshot is never shadowed; idempotent (unique `(snapshot_id, cidr)` holds).
- Present-day summary is read-only; per-snapshot editor carries AI-suggest; "carried" badge renders; dark-mode badges verified.
- `tsc --noEmit` clean; OpenAPI baseline regenerated (no duplicate operationIds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subnet label suggestions, including an option to review AI-generated labels and descriptions before saving.
  * Added subnet history views showing composition changes across snapshots.
  * Added a subnet details modal with stale-status indicators and present-day label display.

* **Bug Fixes**
  * Improved subnet label tracking so labels can be re-baselined and kept in sync after snapshot updates.
  * Added clearer stale-label handling and dismissal support for subnets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->