### PR TITLE
feat(monitor): two-way public/private classification override for IPs

### DIFF
--- a/backend/src/main/java/com/tracepcap/intelligence/dto/CustomPrivateRangeDto.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/dto/CustomPrivateRangeDto.java
@@ -1,5 +1,6 @@
 package com.tracepcap.intelligence.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,6 +13,8 @@ import lombok.NoArgsConstructor;
 public class CustomPrivateRangeDto {
   private Long id;
   private String cidr;
+
   /** "PRIVATE" (treat as internal) or "PUBLIC" (treat as external). Defaults to PRIVATE. */
+  @Schema(allowableValues = {"PRIVATE", "PUBLIC"}, defaultValue = "PRIVATE")
   private String classification;
 }

--- a/backend/src/main/java/com/tracepcap/intelligence/dto/CustomPrivateRangeDto.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/dto/CustomPrivateRangeDto.java
@@ -13,4 +13,6 @@ public class CustomPrivateRangeDto {
   private Long id;
   private String cidr;
   private String label;
+  /** "PRIVATE" (treat as internal) or "PUBLIC" (treat as external). Defaults to PRIVATE. */
+  private String classification;
 }

--- a/backend/src/main/java/com/tracepcap/intelligence/dto/CustomPrivateRangeDto.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/dto/CustomPrivateRangeDto.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 public class CustomPrivateRangeDto {
   private Long id;
   private String cidr;
-  private String label;
   /** "PRIVATE" (treat as internal) or "PUBLIC" (treat as external). Defaults to PRIVATE. */
   private String classification;
 }

--- a/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
@@ -29,9 +29,10 @@ public class CustomPrivateRangeEntity {
   @Column(nullable = false, unique = true)
   private String cidr;
 
-  /** Whether matching IPs are forced to "PRIVATE" (internal) or "PUBLIC" (external). */
+  /** Whether matching IPs are forced to PRIVATE (internal) or PUBLIC (external). */
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false)
-  private String classification;
+  private IpClassification classification;
 
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;

--- a/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
@@ -31,6 +31,10 @@ public class CustomPrivateRangeEntity {
 
   @Column private String label;
 
+  /** Whether matching IPs are forced to "PRIVATE" (internal) or "PUBLIC" (external). */
+  @Column(nullable = false)
+  private String classification;
+
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/entity/CustomPrivateRangeEntity.java
@@ -29,8 +29,6 @@ public class CustomPrivateRangeEntity {
   @Column(nullable = false, unique = true)
   private String cidr;
 
-  @Column private String label;
-
   /** Whether matching IPs are forced to "PRIVATE" (internal) or "PUBLIC" (external). */
   @Column(nullable = false)
   private String classification;

--- a/backend/src/main/java/com/tracepcap/intelligence/entity/IpClassification.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/entity/IpClassification.java
@@ -1,0 +1,7 @@
+package com.tracepcap.intelligence.entity;
+
+/** How a custom range's IPs should be treated: internal (PRIVATE) or external (PUBLIC). */
+public enum IpClassification {
+  PRIVATE,
+  PUBLIC
+}

--- a/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
@@ -42,7 +42,6 @@ public class CustomPrivateRangeService {
     return CustomPrivateRangeDto.builder()
         .id(e.getId())
         .cidr(e.getCidr())
-        .label(e.getLabel())
         .classification(e.getClassification())
         .build();
   }
@@ -80,14 +79,9 @@ public class CustomPrivateRangeService {
     } catch (Exception e) {
       throw new IllegalArgumentException("Invalid IP address in CIDR: " + cidr);
     }
-    String label = dto.getLabel() != null && !dto.getLabel().isBlank() ? dto.getLabel().trim() : null;
-    if (label != null && label.length() > 255) {
-      throw new IllegalArgumentException("Label cannot exceed 255 characters");
-    }
     String classification = normaliseClassification(dto.getClassification());
     CustomPrivateRangeEntity entity = CustomPrivateRangeEntity.builder()
         .cidr(cidr)
-        .label(label)
         .classification(classification)
         .createdAt(LocalDateTime.now())
         .build();

--- a/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
@@ -21,6 +21,9 @@ public class CustomPrivateRangeService {
 
   private final CustomPrivateRangeRepository repository;
 
+  public static final String PRIVATE = "PRIVATE";
+  public static final String PUBLIC = "PUBLIC";
+
   private record ParsedCidr(byte[] networkBytes, int prefixLen) {}
   private final ConcurrentHashMap<String, Optional<ParsedCidr>> cidrCache =
       new ConcurrentHashMap<>();
@@ -31,8 +34,17 @@ public class CustomPrivateRangeService {
 
   public List<CustomPrivateRangeDto> list() {
     return repository.findAllByOrderByCreatedAtDesc().stream()
-        .map(e -> CustomPrivateRangeDto.builder().id(e.getId()).cidr(e.getCidr()).label(e.getLabel()).build())
+        .map(CustomPrivateRangeService::toDto)
         .collect(Collectors.toList());
+  }
+
+  private static CustomPrivateRangeDto toDto(CustomPrivateRangeEntity e) {
+    return CustomPrivateRangeDto.builder()
+        .id(e.getId())
+        .cidr(e.getCidr())
+        .label(e.getLabel())
+        .classification(e.getClassification())
+        .build();
   }
 
   public CustomPrivateRangeDto create(CustomPrivateRangeDto dto) {
@@ -72,14 +84,26 @@ public class CustomPrivateRangeService {
     if (label != null && label.length() > 255) {
       throw new IllegalArgumentException("Label cannot exceed 255 characters");
     }
+    String classification = normaliseClassification(dto.getClassification());
     CustomPrivateRangeEntity entity = CustomPrivateRangeEntity.builder()
         .cidr(cidr)
         .label(label)
+        .classification(classification)
         .createdAt(LocalDateTime.now())
         .build();
     entity = repository.save(entity);
     cidrCache.clear();
-    return CustomPrivateRangeDto.builder().id(entity.getId()).cidr(entity.getCidr()).label(entity.getLabel()).build();
+    return toDto(entity);
+  }
+
+  /** Defaults to PRIVATE for backward compatibility; rejects anything else. */
+  private String normaliseClassification(String raw) {
+    if (raw == null || raw.isBlank()) return PRIVATE;
+    String upper = raw.trim().toUpperCase();
+    if (!upper.equals(PRIVATE) && !upper.equals(PUBLIC)) {
+      throw new IllegalArgumentException("Classification must be PRIVATE or PUBLIC");
+    }
+    return upper;
   }
 
   public void delete(Long id) {
@@ -104,6 +128,32 @@ public class CustomPrivateRangeService {
       if (inCidrBytes(addrBytes, range.getCidr())) return true;
     }
     return false;
+  }
+
+  /** Verdict for an IP against the classification overrides. */
+  public enum Override {
+    FORCE_PRIVATE,
+    FORCE_PUBLIC,
+    NONE
+  }
+
+  /**
+   * Returns the classification override that applies to an IP, or {@link Override#NONE} if no range
+   * matches. When multiple ranges match, the first in the provided list wins (ranges are ordered
+   * most-recent-first), so a newer override takes precedence.
+   */
+  public Override overrideFor(String ip, List<CustomPrivateRangeEntity> ranges) {
+    if (ip == null || ranges.isEmpty()) return Override.NONE;
+    byte[] addrBytes = resolveAddress(ip);
+    if (addrBytes == null) return Override.NONE;
+    for (CustomPrivateRangeEntity range : ranges) {
+      if (inCidrBytes(addrBytes, range.getCidr())) {
+        return PUBLIC.equals(range.getClassification())
+            ? Override.FORCE_PUBLIC
+            : Override.FORCE_PRIVATE;
+      }
+    }
+    return Override.NONE;
   }
 
   /**

--- a/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
@@ -2,6 +2,7 @@ package com.tracepcap.intelligence.service;
 
 import com.tracepcap.intelligence.dto.CustomPrivateRangeDto;
 import com.tracepcap.intelligence.entity.CustomPrivateRangeEntity;
+import com.tracepcap.intelligence.entity.IpClassification;
 import com.tracepcap.intelligence.repository.CustomPrivateRangeRepository;
 import java.net.InetAddress;
 import java.time.LocalDateTime;
@@ -21,9 +22,6 @@ public class CustomPrivateRangeService {
 
   private final CustomPrivateRangeRepository repository;
 
-  public static final String PRIVATE = "PRIVATE";
-  public static final String PUBLIC = "PUBLIC";
-
   private record ParsedCidr(byte[] networkBytes, int prefixLen) {}
   private final ConcurrentHashMap<String, Optional<ParsedCidr>> cidrCache =
       new ConcurrentHashMap<>();
@@ -42,7 +40,7 @@ public class CustomPrivateRangeService {
     return CustomPrivateRangeDto.builder()
         .id(e.getId())
         .cidr(e.getCidr())
-        .classification(e.getClassification())
+        .classification(e.getClassification().name())
         .build();
   }
 
@@ -79,7 +77,7 @@ public class CustomPrivateRangeService {
     } catch (Exception e) {
       throw new IllegalArgumentException("Invalid IP address in CIDR: " + cidr);
     }
-    String classification = normaliseClassification(dto.getClassification());
+    IpClassification classification = parseClassification(dto.getClassification());
     CustomPrivateRangeEntity entity = CustomPrivateRangeEntity.builder()
         .cidr(cidr)
         .classification(classification)
@@ -91,13 +89,13 @@ public class CustomPrivateRangeService {
   }
 
   /** Defaults to PRIVATE for backward compatibility; rejects anything else. */
-  private String normaliseClassification(String raw) {
-    if (raw == null || raw.isBlank()) return PRIVATE;
-    String upper = raw.trim().toUpperCase();
-    if (!upper.equals(PRIVATE) && !upper.equals(PUBLIC)) {
+  private IpClassification parseClassification(String raw) {
+    if (raw == null || raw.isBlank()) return IpClassification.PRIVATE;
+    try {
+      return IpClassification.valueOf(raw.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException("Classification must be PRIVATE or PUBLIC");
     }
-    return upper;
   }
 
   public void delete(Long id) {
@@ -142,7 +140,7 @@ public class CustomPrivateRangeService {
     if (addrBytes == null) return Override.NONE;
     for (CustomPrivateRangeEntity range : ranges) {
       if (inCidrBytes(addrBytes, range.getCidr())) {
-        return PUBLIC.equals(range.getClassification())
+        return range.getClassification() == IpClassification.PUBLIC
             ? Override.FORCE_PUBLIC
             : Override.FORCE_PRIVATE;
       }

--- a/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/CustomPrivateRangeService.java
@@ -137,7 +137,7 @@ public class CustomPrivateRangeService {
    * most-recent-first), so a newer override takes precedence.
    */
   public Override overrideFor(String ip, List<CustomPrivateRangeEntity> ranges) {
-    if (ip == null || ranges.isEmpty()) return Override.NONE;
+    if (ip == null || ranges == null || ranges.isEmpty()) return Override.NONE;
     byte[] addrBytes = resolveAddress(ip);
     if (addrBytes == null) return Override.NONE;
     for (CustomPrivateRangeEntity range : ranges) {

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -9,6 +9,7 @@ import com.tracepcap.analysis.repository.IpGeoInfoRepository;
 import com.tracepcap.insights.dto.LabelDrift;
 import com.tracepcap.insights.service.LabelStalenessService;
 import com.tracepcap.intelligence.entity.CustomPrivateRangeEntity;
+import com.tracepcap.intelligence.entity.IpClassification;
 import com.tracepcap.intelligence.service.CustomPrivateRangeService;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.ChangeType;
@@ -598,7 +599,7 @@ public class ChangeDetectionService {
     }
     List<String> globalPrivateCidrs =
         global.stream()
-            .filter(e -> CustomPrivateRangeService.PRIVATE.equals(e.getClassification()))
+            .filter(e -> e.getClassification() == IpClassification.PRIVATE)
             .map(CustomPrivateRangeEntity::getCidr)
             .collect(Collectors.toList());
     return new LocalityRules(globalPrivateCidrs, global);

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -8,6 +8,7 @@ import com.tracepcap.analysis.repository.HostClassificationRepository;
 import com.tracepcap.analysis.repository.IpGeoInfoRepository;
 import com.tracepcap.insights.dto.LabelDrift;
 import com.tracepcap.insights.service.LabelStalenessService;
+import com.tracepcap.intelligence.entity.CustomPrivateRangeEntity;
 import com.tracepcap.intelligence.service.CustomPrivateRangeService;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.ChangeType;
@@ -256,8 +257,8 @@ public class ChangeDetectionService {
 
     if (fromFileId == null) return List.of();
 
-    List<String> fromCidrs = effectiveCidrs(fromSnapshot);
-    List<String> toCidrs = effectiveCidrs(toSnapshot);
+    LocalityRules fromCidrs = effectiveCidrs(fromSnapshot);
+    LocalityRules toCidrs = effectiveCidrs(toSnapshot);
     Set<String> fromExternalIps = externalIpsForFile(fromFileId, fromCidrs);
     Set<String> toExternalIps = externalIpsForFile(toFileId, toCidrs);
 
@@ -296,6 +297,7 @@ public class ChangeDetectionService {
     // Gateway heuristic: top-traffic external IP
     String fromGateway = topExternalIp(fromFileId, fromGeo, fromCidrs);
     String toGateway = topExternalIp(toFileId, toGeo, toCidrs);
+    // (rules threaded through so force-public overrides beat RFC1918)
     if (fromGateway != null && toGateway != null && !fromGateway.equals(toGateway)) {
       IpGeoInfoEntity fromGeoEntry = fromGeo.get(fromGateway);
       IpGeoInfoEntity toGeoEntry = toGeo.get(toGateway);
@@ -465,11 +467,11 @@ public class ChangeDetectionService {
     return result;
   }
 
-  private Set<String> externalIpsForFile(UUID fileId, List<String> customCidrs) {
+  private Set<String> externalIpsForFile(UUID fileId, LocalityRules rules) {
     if (fileId == null) return Set.of();
     return conversationRepository.findByFileId(fileId).stream()
         .flatMap(c -> Stream.of(c.getSrcIp(), c.getDstIp()))
-        .filter(ip -> ip != null && !isPrivate(ip, customCidrs))
+        .filter(ip -> ip != null && !isPrivate(ip, rules))
         .collect(Collectors.toSet());
   }
 
@@ -493,15 +495,15 @@ public class ChangeDetectionService {
 
   /** Returns the external IP with the highest total bytes for a file (gateway heuristic). */
   private String topExternalIp(
-      UUID fileId, Map<String, IpGeoInfoEntity> geoMap, List<String> customCidrs) {
+      UUID fileId, Map<String, IpGeoInfoEntity> geoMap, LocalityRules rules) {
     if (fileId == null || geoMap.isEmpty()) return null;
     Map<String, Long> ipBytes = new HashMap<>();
     for (ConversationEntity c : conversationRepository.findByFileId(fileId)) {
       String dst = c.getDstIp();
       String src = c.getSrcIp();
       String external = null;
-      if (dst != null && !isPrivate(dst, customCidrs) && geoMap.containsKey(dst)) external = dst;
-      else if (src != null && !isPrivate(src, customCidrs) && geoMap.containsKey(src))
+      if (dst != null && !isPrivate(dst, rules) && geoMap.containsKey(dst)) external = dst;
+      else if (src != null && !isPrivate(src, rules) && geoMap.containsKey(src))
         external = src;
       if (external != null) {
         ipBytes.merge(external, c.getTotalBytes() != null ? c.getTotalBytes() : 0L, Long::sum);
@@ -537,8 +539,28 @@ public class ChangeDetectionService {
         .collect(Collectors.toSet());
   }
 
-  private boolean isPrivate(String ip, List<String> customCidrs) {
+  /**
+   * Locality inputs for a file's classification: snapshot-scoped private CIDRs plus the global
+   * classification overrides (which can force either PRIVATE or PUBLIC).
+   */
+  private record LocalityRules(
+      List<String> privateCidrs, List<CustomPrivateRangeEntity> globalOverrides) {}
+
+  private boolean isPrivate(String ip, LocalityRules rules) {
     if (ip == null) return true;
+    // A global override wins over the RFC1918 heuristic, in either direction. This is what lets a
+    // private-looking address be forced to PUBLIC (and vice versa for a public address).
+    switch (customPrivateRangeService.overrideFor(ip, rules.globalOverrides())) {
+      case FORCE_PRIVATE -> {
+        return true;
+      }
+      case FORCE_PUBLIC -> {
+        return false;
+      }
+      case NONE -> {
+        // fall through to the range heuristics below
+      }
+    }
     for (String prefix : PRIVATE_PREFIXES) {
       if (ip.startsWith(prefix)) return true;
     }
@@ -553,26 +575,33 @@ public class ChangeDetectionService {
         }
       }
     }
-    return customPrivateRangeService.isInCidrs(ip, customCidrs);
+    return customPrivateRangeService.isInCidrs(ip, rules.privateCidrs());
   }
 
   /**
-   * Returns the effective CIDR list for a snapshot: its own subnet overrides if any are defined,
-   * otherwise falls back to the global custom private ranges.
+   * Returns the locality rules for a snapshot: its own subnet overrides as private CIDRs if any are
+   * defined (otherwise the global private ranges), always paired with the global classification
+   * overrides so force-public rules apply regardless of snapshot scope.
    */
-  private List<String> effectiveCidrs(NetworkSnapshotEntity snapshot) {
+  private LocalityRules effectiveCidrs(NetworkSnapshotEntity snapshot) {
+    List<CustomPrivateRangeEntity> global = customPrivateRangeService.loadRanges();
     if (snapshot != null) {
       List<SnapshotSubnetOverrideEntity> overrides =
           snapshotSubnetOverrideRepository.findBySnapshotId(snapshot.getId());
       if (!overrides.isEmpty()) {
-        return overrides.stream()
-            .map(SnapshotSubnetOverrideEntity::getCidr)
-            .collect(Collectors.toList());
+        List<String> snapshotCidrs =
+            overrides.stream()
+                .map(SnapshotSubnetOverrideEntity::getCidr)
+                .collect(Collectors.toList());
+        return new LocalityRules(snapshotCidrs, global);
       }
     }
-    return customPrivateRangeService.loadRanges().stream()
-        .map(e -> e.getCidr())
-        .collect(Collectors.toList());
+    List<String> globalPrivateCidrs =
+        global.stream()
+            .filter(e -> CustomPrivateRangeService.PRIVATE.equals(e.getClassification()))
+            .map(CustomPrivateRangeEntity::getCidr)
+            .collect(Collectors.toList());
+    return new LocalityRules(globalPrivateCidrs, global);
   }
 
   private static String orEmpty(String s) {

--- a/backend/src/main/resources/db/migration/V29__custom_range_classification.sql
+++ b/backend/src/main/resources/db/migration/V29__custom_range_classification.sql
@@ -1,0 +1,8 @@
+-- Allow custom IP/CIDR overrides to force either classification, not just private.
+-- Existing rows were all "treat as private", so default preserves current behaviour.
+ALTER TABLE custom_private_ranges
+    ADD COLUMN classification VARCHAR(16) NOT NULL DEFAULT 'PRIVATE';
+
+ALTER TABLE custom_private_ranges
+    ADD CONSTRAINT custom_private_ranges_classification_chk
+        CHECK (classification IN ('PRIVATE', 'PUBLIC'));

--- a/backend/src/main/resources/db/migration/V30__drop_custom_range_label.sql
+++ b/backend/src/main/resources/db/migration/V30__drop_custom_range_label.sql
@@ -1,0 +1,3 @@
+-- The per-range label was a free-text memo that nothing consumed; drop it.
+ALTER TABLE custom_private_ranges
+    DROP COLUMN label;

--- a/backend/src/test/java/com/tracepcap/intelligence/service/CustomPrivateRangeServiceTest.java
+++ b/backend/src/test/java/com/tracepcap/intelligence/service/CustomPrivateRangeServiceTest.java
@@ -1,0 +1,63 @@
+package com.tracepcap.intelligence.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tracepcap.intelligence.entity.CustomPrivateRangeEntity;
+import com.tracepcap.intelligence.entity.IpClassification;
+import com.tracepcap.intelligence.service.CustomPrivateRangeService.Override;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CustomPrivateRangeService#overrideFor}. It drives
+ * {@code ChangeDetectionService.isPrivate}, so a bad match flips classification across the pipeline.
+ * The method does not touch the repository, so a null repository is sufficient here.
+ */
+class CustomPrivateRangeServiceTest {
+
+  private final CustomPrivateRangeService service = new CustomPrivateRangeService(null);
+
+  private static CustomPrivateRangeEntity range(String cidr, IpClassification classification) {
+    return CustomPrivateRangeEntity.builder().cidr(cidr).classification(classification).build();
+  }
+
+  @Test
+  void overrideFor_publicRange_forcesPublic() {
+    List<CustomPrivateRangeEntity> ranges = List.of(range("10.0.0.0/8", IpClassification.PUBLIC));
+    assertThat(service.overrideFor("10.1.2.3", ranges)).isEqualTo(Override.FORCE_PUBLIC);
+  }
+
+  @Test
+  void overrideFor_privateRange_forcesPrivate() {
+    List<CustomPrivateRangeEntity> ranges = List.of(range("203.0.113.0/24", IpClassification.PRIVATE));
+    assertThat(service.overrideFor("203.0.113.7", ranges)).isEqualTo(Override.FORCE_PRIVATE);
+  }
+
+  @Test
+  void overrideFor_noMatch_returnsNone() {
+    List<CustomPrivateRangeEntity> ranges = List.of(range("10.0.0.0/8", IpClassification.PUBLIC));
+    assertThat(service.overrideFor("192.168.1.1", ranges)).isEqualTo(Override.NONE);
+  }
+
+  @Test
+  void overrideFor_overlappingRanges_firstMatchWins() {
+    // Ranges arrive most-recent-first; the first matching entry should win regardless of the second.
+    List<CustomPrivateRangeEntity> ranges =
+        List.of(
+            range("10.1.0.0/16", IpClassification.PUBLIC),
+            range("10.0.0.0/8", IpClassification.PRIVATE));
+    assertThat(service.overrideFor("10.1.2.3", ranges)).isEqualTo(Override.FORCE_PUBLIC);
+  }
+
+  @Test
+  void overrideFor_nullIp_returnsNone() {
+    List<CustomPrivateRangeEntity> ranges = List.of(range("10.0.0.0/8", IpClassification.PUBLIC));
+    assertThat(service.overrideFor(null, ranges)).isEqualTo(Override.NONE);
+  }
+
+  @Test
+  void overrideFor_nullOrEmptyRanges_returnsNone() {
+    assertThat(service.overrideFor("10.1.2.3", null)).isEqualTo(Override.NONE);
+    assertThat(service.overrideFor("10.1.2.3", List.of())).isEqualTo(Override.NONE);
+  }
+}

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -5,7 +5,7 @@ import { apiClient } from '@/services/api/client';
 import type { NetworkSnapshot, AbsentEntity } from '@/features/monitor/types/monitor.types';
 import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
 import { customPrivateRangeService } from '@/features/intelligence/services/customPrivateRangeService';
-import type { CustomPrivateRange } from '@/features/intelligence/types/customPrivateRange.types';
+import type { CustomPrivateRange, IpClassification } from '@/features/intelligence/types/customPrivateRange.types';
 import { EntityDetailModal } from '@components/common/EntityDetailModal';
 
 interface IpDriftPanelProps {
@@ -34,8 +34,11 @@ function isRfc1918(ip: string): boolean {
 }
 
 function isPrivateIp(ip: string, customRanges: CustomPrivateRange[]): boolean {
-  if (isRfc1918(ip)) return true;
-  return customRanges.some(r => ipInCidr(ip, r.cidr));
+  // A user override wins over the RFC1918 heuristic, in either direction — the first
+  // matching range takes precedence (ranges arrive most-recent-first).
+  const match = customRanges.find(r => ipInCidr(ip, r.cidr));
+  if (match) return match.classification !== 'PUBLIC';
+  return isRfc1918(ip);
 }
 
 function ipToInt(ip: string): number {
@@ -51,6 +54,21 @@ function ipInCidr(ip: string, cidr: string): boolean {
   } catch {
     return false;
   }
+}
+
+const CLASSIFICATION_HINT =
+  'Addresses are sorted automatically by their range (RFC1918 private vs. public). ' +
+  'To override this — force a public address to be treated as internal, or a private ' +
+  'address as external — add the IP or CIDR under “Classification overrides” below.';
+
+function ClassificationInfo() {
+  return (
+    <i
+      className="bi bi-info-circle ms-1 text-muted"
+      style={{ fontSize: '0.75em', cursor: 'help' }}
+      title={CLASSIFICATION_HINT}
+    ></i>
+  );
 }
 
 function stringHue(s: string): number {
@@ -127,6 +145,7 @@ function PrivateOverridesSection({
   const [open, setOpen] = useState(false);
   const [cidr, setCidr] = useState('');
   const [label, setLabel] = useState('');
+  const [classification, setClassification] = useState<IpClassification>('PRIVATE');
   const [adding, setAdding] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
 
@@ -136,10 +155,11 @@ function PrivateOverridesSection({
     setAdding(true);
     setAddError(null);
     try {
-      const created = await customPrivateRangeService.create(trimmed, label.trim());
+      const created = await customPrivateRangeService.create(trimmed, label.trim(), classification);
       onSaved(created);
       setCidr('');
       setLabel('');
+      setClassification('PRIVATE');
     } catch (e: unknown) {
       const msg = (e as { response?: { data?: unknown } })?.response?.data;
       setAddError(typeof msg === 'string' ? msg : 'Failed to add range');
@@ -167,8 +187,8 @@ function PrivateOverridesSection({
         onClick={() => setOpen(o => !o)}
       >
         <i className={`bi bi-chevron-${open ? 'up' : 'down'}`}></i>
-        <i className="bi bi-lock ms-1"></i>
-        Private IP overrides
+        <i className="bi bi-sliders ms-1"></i>
+        Classification overrides
         {customRanges.length > 0 && (
           <span className="badge bg-secondary ms-1" style={{ fontSize: '0.7rem' }}>
             {customRanges.length}
@@ -179,7 +199,9 @@ function PrivateOverridesSection({
       {open && (
         <div className="mt-2" style={{ fontSize: '0.82rem' }}>
           <p className="text-muted mb-2" style={{ fontSize: '0.78rem' }}>
-            Add a public IP or CIDR that should be treated as internal (e.g. a public address used by a private terminal).
+            Force an IP or CIDR to be treated as internal or external, overriding the automatic
+            RFC1918 sort (e.g. a public address used by a private terminal, or a private range that
+            is actually reached over the internet).
           </p>
           {customRanges.length > 0 && (
             <table className="table table-sm table-borderless mb-2">
@@ -187,6 +209,15 @@ function PrivateOverridesSection({
                 {customRanges.map(r => (
                   <tr key={r.id}>
                     <td className="font-monospace py-1 ps-0">{r.cidr}</td>
+                    <td className="py-1">
+                      <span
+                        className={`badge ${r.classification === 'PUBLIC' ? 'bg-primary' : 'bg-secondary'}`}
+                        style={{ fontSize: '0.68rem' }}
+                      >
+                        <i className={`bi bi-${r.classification === 'PUBLIC' ? 'globe' : 'house'} me-1`}></i>
+                        {r.classification === 'PUBLIC' ? 'Public' : 'Private'}
+                      </span>
+                    </td>
                     <td className="text-muted py-1">{r.label ?? <em>—</em>}</td>
                     <td className="text-end py-1 pe-0">
                       <button
@@ -213,6 +244,16 @@ function PrivateOverridesSection({
               onChange={e => setCidr(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && handleAdd()}
             />
+            <select
+              className="form-select form-select-sm"
+              style={{ maxWidth: 130 }}
+              value={classification}
+              onChange={e => setClassification(e.target.value as IpClassification)}
+              aria-label="Treat as"
+            >
+              <option value="PRIVATE">Private</option>
+              <option value="PUBLIC">Public</option>
+            </select>
             <input
               type="text"
               className="form-control form-control-sm"
@@ -390,7 +431,7 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
           {unmatchedActive.filter(ip => isPrivateIp(ip, customRanges)).length > 0 || unmatchedAbsent.filter(e => isPrivateIp(e.key, customRanges)).length > 0 ? (
             <div className="mb-3">
               <small className="text-muted fw-semibold d-block mb-1">
-                <i className="bi bi-house me-1"></i>Private
+                <i className="bi bi-house me-1"></i>Private<ClassificationInfo />
               </small>
               <IpBadgeGroup
                 items={filterIps(unmatchedActive.filter(ip => isPrivateIp(ip, customRanges)))}
@@ -403,7 +444,7 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
           {unmatchedActive.filter(ip => !isPrivateIp(ip, customRanges)).length > 0 || unmatchedAbsent.filter(e => !isPrivateIp(e.key, customRanges)).length > 0 ? (
             <div className="mb-3">
               <small className="text-muted fw-semibold d-block mb-1">
-                <i className="bi bi-globe me-1"></i>Public
+                <i className="bi bi-globe me-1"></i>Public<ClassificationInfo />
               </small>
               <IpBadgeGroup
                 items={filterIps(unmatchedActive.filter(ip => !isPrivateIp(ip, customRanges)))}
@@ -419,7 +460,7 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
           {(privateIps.active.length > 0 || privateIps.absent.length > 0) && (
             <div className="mb-3">
               <small className="text-muted fw-semibold d-block mb-2">
-                <i className="bi bi-house me-1"></i>Private
+                <i className="bi bi-house me-1"></i>Private<ClassificationInfo />
               </small>
               <IpBadgeGroup
                 items={filterIps(privateIps.active)}
@@ -432,7 +473,7 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
           {(publicIps.active.length > 0 || publicIps.absent.length > 0) && (
             <div className="mb-3">
               <small className="text-muted fw-semibold d-block mb-2">
-                <i className="bi bi-globe me-1"></i>Public
+                <i className="bi bi-globe me-1"></i>Public<ClassificationInfo />
               </small>
               <IpBadgeGroup
                 items={filterIps(publicIps.active)}

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -70,6 +70,9 @@ function ClassificationInfo() {
       className="bi bi-info-circle ms-1 text-muted"
       style={{ fontSize: '0.75em', cursor: 'help' }}
       title={CLASSIFICATION_HINT}
+      tabIndex={0}
+      role="img"
+      aria-label={CLASSIFICATION_HINT}
     ></i>
   );
 }

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -144,7 +144,6 @@ function PrivateOverridesSection({
 }) {
   const [open, setOpen] = useState(false);
   const [cidr, setCidr] = useState('');
-  const [label, setLabel] = useState('');
   const [classification, setClassification] = useState<IpClassification>('PRIVATE');
   const [adding, setAdding] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
@@ -155,10 +154,9 @@ function PrivateOverridesSection({
     setAdding(true);
     setAddError(null);
     try {
-      const created = await customPrivateRangeService.create(trimmed, label.trim(), classification);
+      const created = await customPrivateRangeService.create(trimmed, classification);
       onSaved(created);
       setCidr('');
-      setLabel('');
       setClassification('PRIVATE');
     } catch (e: unknown) {
       const msg = (e as { response?: { data?: unknown } })?.response?.data;
@@ -218,7 +216,6 @@ function PrivateOverridesSection({
                         {r.classification === 'PUBLIC' ? 'Public' : 'Private'}
                       </span>
                     </td>
-                    <td className="text-muted py-1">{r.label ?? <em>—</em>}</td>
                     <td className="text-end py-1 pe-0">
                       <button
                         type="button"
@@ -254,15 +251,6 @@ function PrivateOverridesSection({
               <option value="PRIVATE">Private</option>
               <option value="PUBLIC">Public</option>
             </select>
-            <input
-              type="text"
-              className="form-control form-control-sm"
-              style={{ maxWidth: 160 }}
-              placeholder="Label (optional)"
-              value={label}
-              onChange={e => setLabel(e.target.value)}
-              onKeyDown={e => e.key === 'Enter' && handleAdd()}
-            />
             <Button
               type="button"
               variant="primary"

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -47,6 +47,9 @@ function ipToInt(ip: string): number {
 }
 
 function ipInCidr(ip: string, cidr: string): boolean {
+  // ipToInt is IPv4-only; a colon means IPv6, which would otherwise both parse to 0
+  // and spuriously match. Bail out so IPv6 addresses never match an IPv4 CIDR (or vice versa).
+  if (ip.includes(':') || cidr.includes(':')) return false;
   try {
     const [base, bits] = cidr.split('/');
     const mask = bits ? (0xffffffff << (32 - parseInt(bits))) >>> 0 : 0xffffffff;

--- a/frontend/src/features/intelligence/services/customPrivateRangeService.ts
+++ b/frontend/src/features/intelligence/services/customPrivateRangeService.ts
@@ -9,12 +9,10 @@ export const customPrivateRangeService = {
 
   async create(
     cidr: string,
-    label: string,
     classification: IpClassification = 'PRIVATE',
   ): Promise<CustomPrivateRange> {
     const res = await apiClient.post<CustomPrivateRange>('/custom-private-ranges', {
       cidr,
-      label,
       classification,
     });
     return res.data;

--- a/frontend/src/features/intelligence/services/customPrivateRangeService.ts
+++ b/frontend/src/features/intelligence/services/customPrivateRangeService.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/services/api/client';
-import type { CustomPrivateRange } from '../types/customPrivateRange.types';
+import type { CustomPrivateRange, IpClassification } from '../types/customPrivateRange.types';
 
 export const customPrivateRangeService = {
   async list(): Promise<CustomPrivateRange[]> {
@@ -7,8 +7,16 @@ export const customPrivateRangeService = {
     return res.data;
   },
 
-  async create(cidr: string, label: string): Promise<CustomPrivateRange> {
-    const res = await apiClient.post<CustomPrivateRange>('/custom-private-ranges', { cidr, label });
+  async create(
+    cidr: string,
+    label: string,
+    classification: IpClassification = 'PRIVATE',
+  ): Promise<CustomPrivateRange> {
+    const res = await apiClient.post<CustomPrivateRange>('/custom-private-ranges', {
+      cidr,
+      label,
+      classification,
+    });
     return res.data;
   },
 

--- a/frontend/src/features/intelligence/types/customPrivateRange.types.ts
+++ b/frontend/src/features/intelligence/types/customPrivateRange.types.ts
@@ -1,5 +1,8 @@
+export type IpClassification = 'PRIVATE' | 'PUBLIC';
+
 export interface CustomPrivateRange {
   id: number;
   cidr: string;
   label: string | null;
+  classification: IpClassification;
 }

--- a/frontend/src/features/intelligence/types/customPrivateRange.types.ts
+++ b/frontend/src/features/intelligence/types/customPrivateRange.types.ts
@@ -3,6 +3,5 @@ export type IpClassification = 'PRIVATE' | 'PUBLIC';
 export interface CustomPrivateRange {
   id: number;
   cidr: string;
-  label: string | null;
   classification: IpClassification;
 }

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -993,6 +993,11 @@
             "type": "string"
           },
           "classification": {
+            "default": "PRIVATE",
+            "enum": [
+              "PRIVATE",
+              "PUBLIC"
+            ],
             "type": "string"
           },
           "id": {

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -992,6 +992,9 @@
           "cidr": {
             "type": "string"
           },
+          "classification": {
+            "type": "string"
+          },
           "id": {
             "format": "int64",
             "type": "integer"

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -998,9 +998,6 @@
           "id": {
             "format": "int64",
             "type": "integer"
-          },
-          "label": {
-            "type": "string"
           }
         },
         "type": "object"


### PR DESCRIPTION
## Summary

The Network Monitor sorts IP addresses into **Private** and **Public** groups, but this was computed purely from RFC1918 ranges — the only override available was one-directional (force an address to be treated as *private*). This adds a genuine **two-way** override so a user can also force a private-looking address to be treated as *public*.

Motivated by an end-user question: pcaps where the network admin uses private IPs for the local network — confirming individual IPs are **not** tagged (classification is computed per-address), and giving users a way to correct it in either direction.

## Changes

- **`classification` field** (`PRIVATE` | `PUBLIC`) on custom ranges:
  - `V29` migration adds the column (default `PRIVATE` → existing rows keep current behaviour) + a CHECK constraint.
  - Entity / DTO / service carry & validate it; service exposes `overrideFor(ip, ranges)` → `FORCE_PRIVATE` / `FORCE_PUBLIC` / `NONE`.
  - `ChangeDetectionService.isPrivate` applies the global override **before** the RFC1918 heuristic (via a new `LocalityRules` record), so force-public wins in either direction. Snapshot subnet overrides still contribute private CIDRs.
- **Frontend**: renamed the section to **"Classification overrides"** with a Private/Public dropdown, a per-row classification badge, and an info tooltip on the Private/Public headers explaining that the sort is automatic and how to override it.
- **Dropped the unused `label` field** (2nd commit): it was a free-text memo nothing consumed. `V30` drops the column; form is now just IP/CIDR + Private/Public.
- Regenerated `openapi/baseline.json`.

## Verification

- Migrations V29 + V30 applied cleanly (verified column state in Postgres).
- API exercised live: PUBLIC override, PRIVATE default, invalid classification rejected (400), delete — all correct.
- Frontend `tsc --noEmit` clean.
- Playwright: dropdown (Private/Public), badges, and tooltip render; label input confirmed removed.
- Full `docker compose up -d --build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom IP range overrides now support explicit **Private** or **Public** classification.
  * The monitoring view now shows override status with clearer badges and icons.

* **Bug Fixes**
  * IP classification now respects the first matching custom override before falling back to default rules.
  * Existing private-range behavior is preserved by defaulting new overrides to **Private**.

* **Chores**
  * Updated the API and data storage format to use classification instead of a free-form label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->