### PR TITLE
feat(monitor): surface analysis-mode security signals in monitor mode

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
@@ -42,6 +42,34 @@ public interface ConversationRepository
   List<String> findDistinctFileTypesByFileId(@Param("fileId") UUID fileId);
 
   /**
+   * Batched count of the distinct security-signal values present per file — the union across nDPI
+   * flow risks, custom signatures, Suricata IDS alerts (three array columns on {@code conversations})
+   * and detected file types (from {@code packets}). Mirrors the four signals surfaced in the monitor
+   * Security tab; used to populate the per-snapshot absolute posture count without an N+1 fan-out.
+   *
+   * <p>Returns rows of {@code (file_id, count)}; files with no signals are simply absent.
+   */
+  @Query(
+      value =
+          "SELECT file_id, COUNT(*) AS cnt FROM ("
+              + "  SELECT c.file_id, unnest(c.flow_risks) AS v FROM conversations c"
+              + "    WHERE c.file_id IN (:fileIds) AND c.flow_risks IS NOT NULL"
+              + "  UNION"
+              + "  SELECT c.file_id, unnest(c.custom_signatures) AS v FROM conversations c"
+              + "    WHERE c.file_id IN (:fileIds) AND c.custom_signatures IS NOT NULL"
+              + "  UNION"
+              + "  SELECT c.file_id, unnest(c.suricata_alerts) AS v FROM conversations c"
+              + "    WHERE c.file_id IN (:fileIds) AND c.suricata_alerts IS NOT NULL"
+              + "  UNION"
+              + "  SELECT p.file_id, p.detected_file_type AS v FROM packets p"
+              + "    WHERE p.file_id IN (:fileIds) AND p.detected_file_type IS NOT NULL"
+              + ") sigs"
+              + " WHERE v IS NOT NULL AND btrim(v) <> ''"
+              + " GROUP BY file_id",
+      nativeQuery = true)
+  List<Object[]> countSecuritySignalsByFileIds(@Param("fileIds") List<UUID> fileIds);
+
+  /**
    * Returns only conversations that have at least one nDPI risk flag, custom signature match, or
    * Suricata IDS alert — matching the {@code hasRisks} Specification predicate in {@link #buildSpec}.
    */

--- a/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
@@ -48,20 +48,25 @@ public interface ConversationRepository
    * Security tab; used to populate the per-snapshot absolute posture count without an N+1 fan-out.
    *
    * <p>Returns rows of {@code (file_id, count)}; files with no signals are simply absent.
+   *
+   * <p>Uses {@code UNION ALL} with per-category {@code DISTINCT} (rather than a global {@code UNION})
+   * so each of the four categories is counted independently. This matches the frontend badge, which
+   * sums the four category set sizes — a value shared across two categories (e.g. a file type equal
+   * to a risk name) must count once per category, not be globally de-duplicated.
    */
   @Query(
       value =
           "SELECT file_id, COUNT(*) AS cnt FROM ("
-              + "  SELECT c.file_id, unnest(c.flow_risks) AS v FROM conversations c"
+              + "  SELECT DISTINCT c.file_id, unnest(c.flow_risks) AS v FROM conversations c"
               + "    WHERE c.file_id IN (:fileIds) AND c.flow_risks IS NOT NULL"
-              + "  UNION"
-              + "  SELECT c.file_id, unnest(c.custom_signatures) AS v FROM conversations c"
+              + "  UNION ALL"
+              + "  SELECT DISTINCT c.file_id, unnest(c.custom_signatures) AS v FROM conversations c"
               + "    WHERE c.file_id IN (:fileIds) AND c.custom_signatures IS NOT NULL"
-              + "  UNION"
-              + "  SELECT c.file_id, unnest(c.suricata_alerts) AS v FROM conversations c"
+              + "  UNION ALL"
+              + "  SELECT DISTINCT c.file_id, unnest(c.suricata_alerts) AS v FROM conversations c"
               + "    WHERE c.file_id IN (:fileIds) AND c.suricata_alerts IS NOT NULL"
-              + "  UNION"
-              + "  SELECT p.file_id, p.detected_file_type AS v FROM packets p"
+              + "  UNION ALL"
+              + "  SELECT DISTINCT p.file_id, p.detected_file_type AS v FROM packets p"
               + "    WHERE p.file_id IN (:fileIds) AND p.detected_file_type IS NOT NULL"
               + ") sigs"
               + " WHERE v IS NOT NULL AND btrim(v) <> ''"

--- a/backend/src/main/java/com/tracepcap/monitor/dto/NetworkSnapshotDto.java
+++ b/backend/src/main/java/com/tracepcap/monitor/dto/NetworkSnapshotDto.java
@@ -20,6 +20,8 @@ public class NetworkSnapshotDto {
   private Long totalBytes;
   private long changeCount;
   private long criticalCount;
+  /** Distinct absolute security signals present in this snapshot's capture (IDS/risks/sigs/file types). */
+  private long securitySignalCount;
   private String context;
   private String notes;
   private boolean hasInsights;

--- a/backend/src/main/java/com/tracepcap/monitor/entity/NetworkChangeEventEntity.java
+++ b/backend/src/main/java/com/tracepcap/monitor/entity/NetworkChangeEventEntity.java
@@ -90,6 +90,8 @@ public class NetworkChangeEventEntity {
     APP_ADDED,
     APP_REMOVED,
     VPN_DRIFT,
+    SECURITY_ALERT_ADDED,
+    SECURITY_ALERT_REMOVED,
     LABEL_STALE
   }
 
@@ -99,6 +101,7 @@ public class NetworkChangeEventEntity {
     ISP,
     PROTOCOL,
     APP,
+    SECURITY,
     NODE_ROLE
   }
 

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -447,34 +447,34 @@ public class ChangeDetectionService {
 
     if (fromFileId == null) return List.of();
 
-    List<ConversationEntity> fromConvs = conversationRepository.findByFileId(fromFileId);
-    List<ConversationEntity> toConvs = conversationRepository.findByFileId(toFileId);
-
     List<NetworkChangeEventEntity> events = new ArrayList<>();
+
+    // Fetch distinct signal values directly from the DB rather than loading full conversation
+    // entities into memory — the repository already provides purpose-built distinct queries, which
+    // scale to large captures. All sets are null/blank-cleaned before reaching diffSecurity's Map.of.
 
     // IDS alerts (Suricata) — added CRITICAL, removed INFO
     diffSecurity(
         events, fromSnapshot, toSnapshot,
-        arraySet(fromConvs, ConversationEntity::getSuricataAlerts),
-        arraySet(toConvs, ConversationEntity::getSuricataAlerts),
+        cleanSet(conversationRepository.findDistinctSuricataAlertsByFileId(fromFileId)),
+        cleanSet(conversationRepository.findDistinctSuricataAlertsByFileId(toFileId)),
         "ids", Severity.CRITICAL, true);
 
     // Custom signatures — added CRITICAL, removed INFO
     diffSecurity(
         events, fromSnapshot, toSnapshot,
-        arraySet(fromConvs, ConversationEntity::getCustomSignatures),
-        arraySet(toConvs, ConversationEntity::getCustomSignatures),
+        cleanSet(conversationRepository.findDistinctCustomSignaturesByFileId(fromFileId)),
+        cleanSet(conversationRepository.findDistinctCustomSignaturesByFileId(toFileId)),
         "signature", Severity.CRITICAL, true);
 
     // nDPI flow risks (excluding VPN, handled by VPN_DRIFT) — added WARNING, removed INFO
     diffSecurity(
         events, fromSnapshot, toSnapshot,
-        nonVpnRiskSet(fromConvs), nonVpnRiskSet(toConvs),
+        nonVpnRiskSet(conversationRepository.findDistinctRiskTypesByFileId(fromFileId)),
+        nonVpnRiskSet(conversationRepository.findDistinctRiskTypesByFileId(toFileId)),
         "risk", Severity.WARNING, true);
 
-    // Detected file types — added INFO only (removals not actionable). Unlike the other three
-    // signals (cleaned by arraySet/nonVpnRiskSet), this query returns a raw list that may be null
-    // or contain null/blank entries, so clean it before it reaches diffSecurity's Map.of.
+    // Detected file types — added INFO only (removals not actionable)
     diffSecurity(
         events, fromSnapshot, toSnapshot,
         cleanSet(conversationRepository.findDistinctFileTypesByFileId(fromFileId)),
@@ -522,22 +522,10 @@ public class ChangeDetectionService {
     }
   }
 
-  /** Flatten a String[] conversation field across conversations into a distinct non-blank set. */
-  private Set<String> arraySet(
-      List<ConversationEntity> convs, java.util.function.Function<ConversationEntity, String[]> field) {
-    return convs.stream()
-        .map(field)
-        .filter(a -> a != null)
-        .flatMap(Arrays::stream)
-        .filter(s -> s != null && !s.isBlank())
-        .collect(Collectors.toSet());
-  }
-
   /** nDPI flow risks excluding VPN-related ones (those are reported as VPN_DRIFT). */
-  private Set<String> nonVpnRiskSet(List<ConversationEntity> convs) {
-    return convs.stream()
-        .filter(c -> c.getFlowRisks() != null)
-        .flatMap(c -> Arrays.stream(c.getFlowRisks()))
+  private Set<String> nonVpnRiskSet(List<String> risks) {
+    if (risks == null) return Set.of();
+    return risks.stream()
         .filter(r -> r != null && !r.isBlank() && !r.toUpperCase().contains("VPN"))
         .collect(Collectors.toSet());
   }

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -472,11 +472,13 @@ public class ChangeDetectionService {
         nonVpnRiskSet(fromConvs), nonVpnRiskSet(toConvs),
         "risk", Severity.WARNING, true);
 
-    // Detected file types — added INFO only (removals not actionable)
+    // Detected file types — added INFO only (removals not actionable). Unlike the other three
+    // signals (cleaned by arraySet/nonVpnRiskSet), this query returns a raw list that may be null
+    // or contain null/blank entries, so clean it before it reaches diffSecurity's Map.of.
     diffSecurity(
         events, fromSnapshot, toSnapshot,
-        new java.util.HashSet<>(conversationRepository.findDistinctFileTypesByFileId(fromFileId)),
-        new java.util.HashSet<>(conversationRepository.findDistinctFileTypesByFileId(toFileId)),
+        cleanSet(conversationRepository.findDistinctFileTypesByFileId(fromFileId)),
+        cleanSet(conversationRepository.findDistinctFileTypesByFileId(toFileId)),
         "fileType", Severity.INFO, false);
 
     return events;
@@ -538,6 +540,12 @@ public class ChangeDetectionService {
         .flatMap(c -> Arrays.stream(c.getFlowRisks()))
         .filter(r -> r != null && !r.isBlank() && !r.toUpperCase().contains("VPN"))
         .collect(Collectors.toSet());
+  }
+
+  /** Null-safe distinct non-blank set from a (possibly null) list of strings. */
+  private Set<String> cleanSet(List<String> values) {
+    if (values == null) return Set.of();
+    return values.stream().filter(s -> s != null && !s.isBlank()).collect(Collectors.toSet());
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -79,6 +79,7 @@ public class ChangeDetectionService {
     events.addAll(detectIpMacDrift(fromFileId, toFileId, fromSnapshot, toSnapshot));
     events.addAll(detectIspAsnChanges(fromFileId, toFileId, fromSnapshot, toSnapshot));
     events.addAll(detectProtocolAppDrift(fromFileId, toFileId, fromSnapshot, toSnapshot));
+    events.addAll(detectSecurityDrift(fromFileId, toFileId, fromSnapshot, toSnapshot));
     events.addAll(detectStaleLabels(toFileId, fromSnapshot, toSnapshot));
 
     // Carry subnet labels forward onto this snapshot (inherited overrides), mirroring node roles.
@@ -417,6 +418,126 @@ public class ChangeDetectionService {
     }
 
     return events;
+  }
+
+  // ── Signal 6: Security posture drift (IDS / risks / signatures / file types) ──
+
+  /**
+   * Emit change events when the security-relevant signals analysis mode computes per capture appear
+   * or disappear between two snapshots. This is the differential complement to the snapshot Security
+   * tab: the tab shows the absolute posture, this flags what newly appeared (or cleared).
+   *
+   * <p>Signals and severities:
+   *
+   * <ul>
+   *   <li><b>Suricata IDS alerts</b> — added: CRITICAL (a fresh IDS hit is high-signal), removed: INFO.
+   *   <li><b>Custom signatures</b> — added: CRITICAL, removed: INFO.
+   *   <li><b>nDPI flow risks</b> — added: WARNING, removed: INFO. VPN risks are intentionally
+   *       excluded here because {@code detectProtocolAppDrift} already reports them as VPN_DRIFT;
+   *       double-reporting would clutter the feed.
+   *   <li><b>Detected file types</b> — added: INFO only. Removals are noisy (content simply not
+   *       re-transferred) and not actionable, so they are not reported.
+   * </ul>
+   */
+  private List<NetworkChangeEventEntity> detectSecurityDrift(
+      UUID fromFileId,
+      UUID toFileId,
+      NetworkSnapshotEntity fromSnapshot,
+      NetworkSnapshotEntity toSnapshot) {
+
+    if (fromFileId == null) return List.of();
+
+    List<ConversationEntity> fromConvs = conversationRepository.findByFileId(fromFileId);
+    List<ConversationEntity> toConvs = conversationRepository.findByFileId(toFileId);
+
+    List<NetworkChangeEventEntity> events = new ArrayList<>();
+
+    // IDS alerts (Suricata) — added CRITICAL, removed INFO
+    diffSecurity(
+        events, fromSnapshot, toSnapshot,
+        arraySet(fromConvs, ConversationEntity::getSuricataAlerts),
+        arraySet(toConvs, ConversationEntity::getSuricataAlerts),
+        "ids", Severity.CRITICAL, true);
+
+    // Custom signatures — added CRITICAL, removed INFO
+    diffSecurity(
+        events, fromSnapshot, toSnapshot,
+        arraySet(fromConvs, ConversationEntity::getCustomSignatures),
+        arraySet(toConvs, ConversationEntity::getCustomSignatures),
+        "signature", Severity.CRITICAL, true);
+
+    // nDPI flow risks (excluding VPN, handled by VPN_DRIFT) — added WARNING, removed INFO
+    diffSecurity(
+        events, fromSnapshot, toSnapshot,
+        nonVpnRiskSet(fromConvs), nonVpnRiskSet(toConvs),
+        "risk", Severity.WARNING, true);
+
+    // Detected file types — added INFO only (removals not actionable)
+    diffSecurity(
+        events, fromSnapshot, toSnapshot,
+        new java.util.HashSet<>(conversationRepository.findDistinctFileTypesByFileId(fromFileId)),
+        new java.util.HashSet<>(conversationRepository.findDistinctFileTypesByFileId(toFileId)),
+        "fileType", Severity.INFO, false);
+
+    return events;
+  }
+
+  /**
+   * Set-diff two security-signal sets and append ADDED (and, when {@code reportRemoved}, REMOVED)
+   * events. {@code signalKind} tags the {@code newValue}/{@code oldValue} payload so the UI can
+   * label it (e.g. "ids", "risk"). Added events carry {@code addedSeverity}; removed events are
+   * always INFO (a cleared signal is informational, not alarming).
+   */
+  private void diffSecurity(
+      List<NetworkChangeEventEntity> events,
+      NetworkSnapshotEntity fromSnapshot,
+      NetworkSnapshotEntity toSnapshot,
+      Set<String> from,
+      Set<String> to,
+      String signalKind,
+      Severity addedSeverity,
+      boolean reportRemoved) {
+
+    for (String v : to) {
+      if (!from.contains(v)) {
+        events.add(
+            buildEvent(
+                toSnapshot.getNetwork().getId(), fromSnapshot, toSnapshot,
+                ChangeType.SECURITY_ALERT_ADDED, EntityType.SECURITY, v,
+                null, Map.of("signalKind", signalKind, "value", v), addedSeverity));
+      }
+    }
+    if (reportRemoved) {
+      for (String v : from) {
+        if (!to.contains(v)) {
+          events.add(
+              buildEvent(
+                  toSnapshot.getNetwork().getId(), fromSnapshot, toSnapshot,
+                  ChangeType.SECURITY_ALERT_REMOVED, EntityType.SECURITY, v,
+                  Map.of("signalKind", signalKind, "value", v), null, Severity.INFO));
+        }
+      }
+    }
+  }
+
+  /** Flatten a String[] conversation field across conversations into a distinct non-blank set. */
+  private Set<String> arraySet(
+      List<ConversationEntity> convs, java.util.function.Function<ConversationEntity, String[]> field) {
+    return convs.stream()
+        .map(field)
+        .filter(a -> a != null)
+        .flatMap(Arrays::stream)
+        .filter(s -> s != null && !s.isBlank())
+        .collect(Collectors.toSet());
+  }
+
+  /** nDPI flow risks excluding VPN-related ones (those are reported as VPN_DRIFT). */
+  private Set<String> nonVpnRiskSet(List<ConversationEntity> convs) {
+    return convs.stream()
+        .filter(c -> c.getFlowRisks() != null)
+        .flatMap(c -> Arrays.stream(c.getFlowRisks()))
+        .filter(r -> r != null && !r.isBlank() && !r.toUpperCase().contains("VPN"))
+        .collect(Collectors.toSet());
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/SnapshotService.java
@@ -1,5 +1,6 @@
 package com.tracepcap.monitor.service;
 
+import com.tracepcap.analysis.repository.ConversationRepository;
 import com.tracepcap.common.exception.InvalidFileException;
 import com.tracepcap.common.exception.ResourceNotFoundException;
 import com.tracepcap.file.entity.FileEntity;
@@ -40,6 +41,7 @@ public class SnapshotService {
   private final SnapshotInsightRepository snapshotInsightRepository;
   private final SnapshotSubnetOverrideRepository subnetOverrideRepository;
   private final SubnetOverrideCarryForwardService subnetOverrideCarryForwardService;
+  private final ConversationRepository conversationRepository;
 
   @Transactional(readOnly = true)
   public List<NetworkSnapshotDto> listSnapshots(UUID networkId) {
@@ -59,11 +61,17 @@ public class SnapshotService {
                 o -> o.getSnapshot().getId(),
                 Collectors.mapping(this::toOverrideDto, Collectors.toList())));
 
+    // Batch absolute security-signal counts, keyed by fileId (one query for all snapshots)
+    Map<UUID, Long> securityCounts =
+        securitySignalCounts(
+            snapshots.stream().map(s -> s.getFile().getId()).distinct().collect(Collectors.toList()));
+
     return snapshots.stream()
         .map(s -> toDto(
             s,
             changeCounts.getOrDefault(s.getId(), 0L),
             criticalCounts.getOrDefault(s.getId(), 0L),
+            securityCounts.getOrDefault(s.getFile().getId(), 0L),
             overridesMap.getOrDefault(s.getId(), Collections.emptyList())))
         .collect(Collectors.toList());
   }
@@ -149,7 +157,8 @@ public class SnapshotService {
     long changeCount = changeEventRepository.countByToSnapshotId(snapshot.getId());
     long criticalCount = changeEventRepository.countCriticalByToSnapshotId(snapshot.getId());
     List<SnapshotSubnetOverrideDto> overrides = fetchOverrideDtos(snapshot.getId());
-    return toDto(snapshot, changeCount, criticalCount, overrides);
+    return toDto(snapshot, changeCount, criticalCount,
+        securitySignalCount(snapshot.getFile().getId()), overrides);
   }
 
   public NetworkSnapshotDto patchSnapshot(UUID networkId, UUID snapshotId, PatchSnapshotRequest req) {
@@ -217,7 +226,8 @@ public class SnapshotService {
     long changeCount = changeEventRepository.countByToSnapshotId(snapshotId);
     long criticalCount = changeEventRepository.countCriticalByToSnapshotId(snapshotId);
     List<SnapshotSubnetOverrideDto> overrides = fetchOverrideDtos(snapshotId);
-    return toDto(snapshot, changeCount, criticalCount, overrides);
+    return toDto(snapshot, changeCount, criticalCount,
+        securitySignalCount(snapshot.getFile().getId()), overrides);
   }
 
   public void removeSnapshot(UUID networkId, UUID snapshotId) {
@@ -281,7 +291,7 @@ public class SnapshotService {
   }
 
   NetworkSnapshotDto toDto(NetworkSnapshotEntity s, long changeCount, long criticalCount,
-      List<SnapshotSubnetOverrideDto> overrides) {
+      long securitySignalCount, List<SnapshotSubnetOverrideDto> overrides) {
     return NetworkSnapshotDto.builder()
         .id(s.getId())
         .networkId(s.getNetwork().getId())
@@ -294,11 +304,27 @@ public class SnapshotService {
         .totalBytes(s.getFile().getTotalBytes())
         .changeCount(changeCount)
         .criticalCount(criticalCount)
+        .securitySignalCount(securitySignalCount)
         .context(s.getContext())
         .notes(s.getNotes())
         .hasInsights(snapshotInsightRepository.existsBySnapshotId(s.getId()))
         .addedAt(s.getAddedAt())
         .subnetOverrides(overrides)
         .build();
+  }
+
+  /** Absolute distinct security-signal count for a single file (0 if none). */
+  private long securitySignalCount(UUID fileId) {
+    return securitySignalCounts(List.of(fileId)).getOrDefault(fileId, 0L);
+  }
+
+  /** Batched fileId → distinct security-signal count. Files with no signals are absent from the map. */
+  private Map<UUID, Long> securitySignalCounts(List<UUID> fileIds) {
+    if (fileIds.isEmpty()) return Map.of();
+    Map<UUID, Long> result = new java.util.HashMap<>();
+    for (Object[] row : conversationRepository.countSecuritySignalsByFileIds(fileIds)) {
+      result.put((UUID) row[0], ((Number) row[1]).longValue());
+    }
+    return result;
   }
 }

--- a/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
+++ b/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
@@ -22,6 +22,17 @@ const SEVERITY_ICONS: Record<string, string> = {
   INFO:     'bi-info-circle-fill',
 };
 
+/** Human label for a security-drift signalKind payload value. */
+function securityKindLabel(kind: unknown): string {
+  switch (kind) {
+    case 'ids':       return 'IDS alert';
+    case 'signature': return 'Custom signature';
+    case 'risk':      return 'Flow risk';
+    case 'fileType':  return 'File type';
+    default:          return 'Security signal';
+  }
+}
+
 function describeEvent(event: ChangeEvent): string {
   const nv = event.newValue ?? {};
   const ov = event.oldValue ?? {};
@@ -52,6 +63,10 @@ function describeEvent(event: ChangeEvent): string {
     case 'VPN_DRIFT':
       if (nv['riskType']) return `VPN detected: ${nv['riskType']}`;
       return `VPN signal gone: ${ov['riskType'] ?? event.entityKey}`;
+    case 'SECURITY_ALERT_ADDED':
+      return `${securityKindLabel(nv['signalKind'])} appeared: ${event.entityKey}`;
+    case 'SECURITY_ALERT_REMOVED':
+      return `${securityKindLabel(ov['signalKind'])} cleared: ${event.entityKey}`;
     case 'LABEL_STALE': {
       const changes = Array.isArray(nv['changes']) ? (nv['changes'] as string[]).join(', ') : '';
       const label = nv['roleLabel'] ? ` (${nv['roleLabel']})` : '';

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -38,6 +38,8 @@ function labelForChange(changeType: string, oldValue: Record<string, unknown> | 
     case 'PROTOCOL_ADDED': return 'New protocol';
     case 'APP_ADDED':      return 'New app';
     case 'VPN_DRIFT':      return newValue?.['riskType'] ? 'VPN detected' : 'VPN stopped';
+    case 'SECURITY_ALERT_ADDED':   return 'Security alert';
+    case 'SECURITY_ALERT_REMOVED': return 'Security alert cleared';
     default:               return changeType;
   }
 }

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -590,7 +590,7 @@ export const SnapshotDetailModal = ({
 
         {/* ── Security tab ── */}
         {activeTab === 'security' && (
-          <SnapshotSecurityTab edges={edges} loading={graphLoading} />
+          <SnapshotSecurityTab edges={edges} loading={graphLoading} fileId={diagramSnap.fileId} />
         )}
 
         {/* ── Context & Notes tab ── */}

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -5,6 +5,7 @@ import { subnetService } from '@/features/subnets/services/subnetService';
 import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
 import type { SubnetOverrideInput } from '@/features/monitor/types/monitor.types';
 import { ChangeEventBadge } from '@/components/monitor/ChangeEventBadge/ChangeEventBadge';
+import { SnapshotSecurityTab } from '@/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab';
 import { NetworkInsightsPanel } from '@/components/monitor/NetworkInsightsPanel/NetworkInsightsPanel';
 import { NetworkGraph } from '@/components/network/NetworkGraph';
 import { NetworkControls } from '@/components/network/NetworkControls';
@@ -20,7 +21,7 @@ import type { GraphNode } from '@/features/network/types';
 import type { NodeHighlight } from '@/components/network/NetworkGraph/NetworkGraph';
 import { parseDateTime } from '@/utils/dateUtils';
 
-type Tab = 'diagram' | 'changes' | 'context' | 'subnets' | 'insights';
+type Tab = 'diagram' | 'changes' | 'security' | 'context' | 'subnets' | 'insights';
 
 const HIGHLIGHT_COLORS: Record<string, string> = {
   CRITICAL: '#e74c3c',
@@ -207,6 +208,19 @@ export const SnapshotDetailModal = ({
   const presentCustomSigs  = useMemo(() => { const s = new Set<string>(); edges.forEach(e => e.data.customSignatures?.forEach(sig => s.add(sig))); return [...s].sort(); }, [edges]);
   const presentFileTypes   = useMemo(() => { const s = new Set<string>(); edges.forEach(e => e.data.detectedFileTypes?.forEach(f => s.add(f))); return [...s].sort(); }, [edges]);
   const presentCountries   = useMemo(() => { const s = new Set<string>(); edges.forEach(e => { if (e.data.srcCountry) s.add(e.data.srcCountry); if (e.data.dstCountry) s.add(e.data.dstCountry); }); return [...s].sort(); }, [edges]);
+
+  // Distinct security signals across all four analysis-mode signal types (for the Security tab badge).
+  // Any Suricata IDS alert or custom signature is treated as high-severity for badge coloring.
+  const securitySignals = useMemo(() => {
+    const ids = new Set<string>(), risks = new Set<string>(), sigs = new Set<string>(), files = new Set<string>();
+    edges.forEach(e => {
+      e.data.suricataAlerts?.forEach(a => ids.add(a));
+      e.data.flowRisks?.forEach(r => risks.add(r));
+      e.data.customSignatures?.forEach(sig => sigs.add(sig));
+      e.data.detectedFileTypes?.forEach(f => files.add(f));
+    });
+    return { count: ids.size + risks.size + sigs.size + files.size, critical: ids.size + sigs.size > 0 };
+  }, [edges]);
 
   // Filter logic
   const { filteredNodes, filteredEdges } = useMemo(() =>
@@ -400,7 +414,7 @@ export const SnapshotDetailModal = ({
       {/* Tabs */}
       <div className="modal-header py-2 border-bottom">
         <ul className="nav nav-pills gap-1">
-          {(['diagram', 'changes', 'context', 'subnets', 'insights'] as Tab[]).map(tab => (
+          {(['diagram', 'changes', 'security', 'context', 'subnets', 'insights'] as Tab[]).map(tab => (
             <li key={tab} className="nav-item">
               <button
                 className={`nav-link py-1 px-3${activeTab === tab ? ' active' : ''}`}
@@ -409,6 +423,7 @@ export const SnapshotDetailModal = ({
               >
                 {tab === 'diagram'  && <i className="bi bi-diagram-3 me-1" />}
                 {tab === 'changes'  && <i className="bi bi-activity me-1" />}
+                {tab === 'security' && <i className="bi bi-shield-lock me-1" />}
                 {tab === 'context'  && <i className="bi bi-pencil-square me-1" />}
                 {tab === 'subnets'  && <i className="bi bi-diagram-2 me-1" />}
                 {tab === 'insights' && <i className="bi bi-stars me-1" />}
@@ -423,6 +438,20 @@ export const SnapshotDetailModal = ({
                         color: '#fff',
                       }}>
                         {snapshotEvents.length}
+                      </span>
+                    )}
+                  </>
+                )}
+                {tab === 'security' && (
+                  <>
+                    Security
+                    {securitySignals.count > 0 && (
+                      <span className="badge rounded-pill ms-1" style={{
+                        fontSize: '0.6rem',
+                        background: securitySignals.critical ? '#dc3545' : '#fd7e14',
+                        color: '#fff',
+                      }}>
+                        {securitySignals.count}
                       </span>
                     )}
                   </>
@@ -555,6 +584,11 @@ export const SnapshotDetailModal = ({
               ))
             )}
           </div>
+        )}
+
+        {/* ── Security tab ── */}
+        {activeTab === 'security' && (
+          <SnapshotSecurityTab edges={edges} loading={graphLoading} />
         )}
 
         {/* ── Context & Notes tab ── */}

--- a/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
+++ b/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
@@ -109,7 +109,9 @@ export const SnapshotSecurityTab = ({ edges, loading, fileId }: SnapshotSecurity
         key: 'sigs',
         title: 'Custom Signatures',
         icon: 'bi-fingerprint',
-        severity: 'WARNING',
+        // CRITICAL to stay consistent with the tab-header badge (SnapshotDetailModal treats
+        // signatures as critical) and the backend detectSecurityDrift severity.
+        severity: 'CRITICAL',
         filterParam: 'customSignatures',
         blurb: 'Matches against your user-defined signatures.',
       },

--- a/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
+++ b/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
@@ -1,0 +1,165 @@
+import { useMemo } from 'react';
+import type { GraphEdge } from '@/features/network/types';
+
+/**
+ * Absolute security posture of a single snapshot's capture. Aggregates the four analysis-mode
+ * security signals already carried on the network edges (Suricata IDS alerts, nDPI flow risks,
+ * user custom signatures, detected file types) into grouped rows, each listing the src→dst pairs
+ * that exhibited it. This is the "what security-relevant things are in this capture" view, as a
+ * complement to the differential Changes tab.
+ */
+
+type Severity = 'CRITICAL' | 'WARNING' | 'INFO';
+
+interface SignalRow {
+  /** The signal value, e.g. an IDS signature string or an nDPI risk name. */
+  value: string;
+  /** Distinct "src → dst" flow labels that exhibited this signal. */
+  flows: string[];
+}
+
+interface SignalSection {
+  key: string;
+  title: string;
+  icon: string;
+  severity: Severity;
+  /** Explains what this signal means, shown under the section title. */
+  blurb: string;
+  rows: SignalRow[];
+}
+
+const SEVERITY_COLOR: Record<Severity, string> = {
+  CRITICAL: '#dc3545',
+  WARNING: '#fd7e14',
+  INFO: '#6c757d',
+};
+
+/** Group one signal across all edges: value → sorted distinct flow labels. */
+function aggregate(edges: GraphEdge[], pick: (e: GraphEdge) => string[] | undefined): SignalRow[] {
+  const byValue = new Map<string, Set<string>>();
+  for (const e of edges) {
+    const values = pick(e);
+    if (!values || values.length === 0) continue;
+    const flow = `${e.source} → ${e.target}`;
+    for (const v of values) {
+      if (!v) continue;
+      if (!byValue.has(v)) byValue.set(v, new Set());
+      byValue.get(v)!.add(flow);
+    }
+  }
+  return [...byValue.entries()]
+    .map(([value, flows]) => ({ value, flows: [...flows].sort() }))
+    .sort((a, b) => b.flows.length - a.flows.length || a.value.localeCompare(b.value));
+}
+
+interface SnapshotSecurityTabProps {
+  edges: GraphEdge[];
+  loading: boolean;
+}
+
+export const SnapshotSecurityTab = ({ edges, loading }: SnapshotSecurityTabProps) => {
+  const sections = useMemo<SignalSection[]>(() => {
+    const defs: Omit<SignalSection, 'rows'>[] = [
+      {
+        key: 'ids',
+        title: 'IDS Alerts',
+        icon: 'bi-shield-exclamation',
+        severity: 'CRITICAL',
+        blurb: 'Suricata signature matches against the Emerging Threats ruleset.',
+      },
+      {
+        key: 'risks',
+        title: 'Flow Risks',
+        icon: 'bi-exclamation-triangle',
+        severity: 'WARNING',
+        blurb: 'nDPI-detected anomalies — VPNs, self-signed certs, malformed traffic, and more.',
+      },
+      {
+        key: 'sigs',
+        title: 'Custom Signatures',
+        icon: 'bi-fingerprint',
+        severity: 'WARNING',
+        blurb: 'Matches against your user-defined signatures.',
+      },
+      {
+        key: 'files',
+        title: 'Detected File Types',
+        icon: 'bi-file-earmark-binary',
+        severity: 'INFO',
+        blurb: 'File types carved from transferred content.',
+      },
+    ];
+    const pickers: Record<string, (e: GraphEdge) => string[] | undefined> = {
+      ids: e => e.data.suricataAlerts,
+      risks: e => e.data.flowRisks,
+      sigs: e => e.data.customSignatures,
+      files: e => e.data.detectedFileTypes,
+    };
+    return defs.map(d => ({ ...d, rows: aggregate(edges, pickers[d.key]) }));
+  }, [edges]);
+
+  if (loading) {
+    return <p className="text-muted small mb-0">Loading capture data…</p>;
+  }
+
+  const totalSignals = sections.reduce((n, s) => n + s.rows.length, 0);
+
+  if (totalSignals === 0) {
+    return (
+      <div className="text-center text-muted py-5">
+        <i className="bi bi-shield-check text-success d-block mb-2" style={{ fontSize: '2rem' }} />
+        No security signals detected in this capture.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="text-muted small mb-3">
+        Security-relevant signals detected in this capture. This is the absolute posture of the
+        snapshot; the <strong>Changes</strong> tab shows what is new versus the previous snapshot.
+      </p>
+      {sections.map(section => (
+        <div key={section.key} className="mb-4">
+          <div className="d-flex align-items-center gap-2 mb-1">
+            <i className={`bi ${section.icon}`} style={{ color: SEVERITY_COLOR[section.severity] }} />
+            <span className="fw-semibold">{section.title}</span>
+            <span
+              className="badge rounded-pill"
+              style={{ fontSize: '0.7rem', background: SEVERITY_COLOR[section.severity], color: '#fff' }}
+            >
+              {section.rows.length}
+            </span>
+          </div>
+          <p className="text-muted mb-2" style={{ fontSize: '0.78rem' }}>{section.blurb}</p>
+          {section.rows.length === 0 ? (
+            <p className="text-muted small mb-0 ps-1">None detected.</p>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-sm table-bordered mb-0" style={{ fontSize: '0.82rem' }}>
+                <thead className="table-light">
+                  <tr>
+                    <th style={{ width: '55%' }}>{section.title === 'Detected File Types' ? 'File type' : 'Signal'}</th>
+                    <th>Flows</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {section.rows.map(row => (
+                    <tr key={row.value}>
+                      <td className="font-monospace" style={{ wordBreak: 'break-word' }}>{row.value}</td>
+                      <td>
+                        {row.flows.map(f => (
+                          <div key={f} className="font-monospace text-muted" style={{ fontSize: '0.76rem' }}>{f}</div>
+                        ))}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
+++ b/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
@@ -11,11 +11,21 @@ import type { GraphEdge } from '@/features/network/types';
 
 type Severity = 'CRITICAL' | 'WARNING' | 'INFO';
 
+/** The conversation-filter query param each signal maps to (see useConversationFilters). */
+type FilterParam = 'suricataAlerts' | 'riskTypes' | 'customSignatures' | 'fileTypes';
+
+interface Flow {
+  /** Display label "src → dst". */
+  label: string;
+  /** Source IP — used as the `ip` filter when deep-linking a single flow. */
+  src: string;
+}
+
 interface SignalRow {
   /** The signal value, e.g. an IDS signature string or an nDPI risk name. */
   value: string;
-  /** Distinct "src → dst" flow labels that exhibited this signal. */
-  flows: string[];
+  /** Distinct flows that exhibited this signal. */
+  flows: Flow[];
 }
 
 interface SignalSection {
@@ -23,6 +33,8 @@ interface SignalSection {
   title: string;
   icon: string;
   severity: Severity;
+  /** Which conversation-filter param this signal deep-links through. */
+  filterParam: FilterParam;
   /** Explains what this signal means, shown under the section title. */
   blurb: string;
   rows: SignalRow[];
@@ -34,30 +46,47 @@ const SEVERITY_COLOR: Record<Severity, string> = {
   INFO: '#6c757d',
 };
 
-/** Group one signal across all edges: value → sorted distinct flow labels. */
+/** Group one signal across all edges: value → distinct flows (deduped by label). */
 function aggregate(edges: GraphEdge[], pick: (e: GraphEdge) => string[] | undefined): SignalRow[] {
-  const byValue = new Map<string, Set<string>>();
+  const byValue = new Map<string, Map<string, Flow>>();
   for (const e of edges) {
     const values = pick(e);
     if (!values || values.length === 0) continue;
-    const flow = `${e.source} → ${e.target}`;
+    const label = `${e.source} → ${e.target}`;
     for (const v of values) {
       if (!v) continue;
-      if (!byValue.has(v)) byValue.set(v, new Set());
-      byValue.get(v)!.add(flow);
+      if (!byValue.has(v)) byValue.set(v, new Map());
+      byValue.get(v)!.set(label, { label, src: e.source });
     }
   }
   return [...byValue.entries()]
-    .map(([value, flows]) => ({ value, flows: [...flows].sort() }))
+    .map(([value, flows]) => ({
+      value,
+      flows: [...flows.values()].sort((a, b) => a.label.localeCompare(b.label)),
+    }))
     .sort((a, b) => b.flows.length - a.flows.length || a.value.localeCompare(b.value));
 }
 
 interface SnapshotSecurityTabProps {
   edges: GraphEdge[];
   loading: boolean;
+  /** File backing this snapshot; deep-links jump to its analysis-mode conversation view. */
+  fileId: string;
 }
 
-export const SnapshotSecurityTab = ({ edges, loading }: SnapshotSecurityTabProps) => {
+export const SnapshotSecurityTab = ({ edges, loading, fileId }: SnapshotSecurityTabProps) => {
+  /**
+   * Build a deep-link into analysis mode's conversation table, pre-filtered to this signal
+   * (and optionally a single source host). The conversation page reads every filter from URL
+   * query params, so this lands the analyst on exactly the offending flows.
+   */
+  const buildUrl = (param: FilterParam, value: string, ip?: string): string => {
+    const qs = new URLSearchParams();
+    qs.set(param, value);
+    if (ip) qs.set('ip', ip);
+    return `/analysis/${fileId}/conversations?${qs.toString()}`;
+  };
+
   const sections = useMemo<SignalSection[]>(() => {
     const defs: Omit<SignalSection, 'rows'>[] = [
       {
@@ -65,6 +94,7 @@ export const SnapshotSecurityTab = ({ edges, loading }: SnapshotSecurityTabProps
         title: 'IDS Alerts',
         icon: 'bi-shield-exclamation',
         severity: 'CRITICAL',
+        filterParam: 'suricataAlerts',
         blurb: 'Suricata signature matches against the Emerging Threats ruleset.',
       },
       {
@@ -72,6 +102,7 @@ export const SnapshotSecurityTab = ({ edges, loading }: SnapshotSecurityTabProps
         title: 'Flow Risks',
         icon: 'bi-exclamation-triangle',
         severity: 'WARNING',
+        filterParam: 'riskTypes',
         blurb: 'nDPI-detected anomalies — VPNs, self-signed certs, malformed traffic, and more.',
       },
       {
@@ -79,6 +110,7 @@ export const SnapshotSecurityTab = ({ edges, loading }: SnapshotSecurityTabProps
         title: 'Custom Signatures',
         icon: 'bi-fingerprint',
         severity: 'WARNING',
+        filterParam: 'customSignatures',
         blurb: 'Matches against your user-defined signatures.',
       },
       {
@@ -86,6 +118,7 @@ export const SnapshotSecurityTab = ({ edges, loading }: SnapshotSecurityTabProps
         title: 'Detected File Types',
         icon: 'bi-file-earmark-binary',
         severity: 'INFO',
+        filterParam: 'fileTypes',
         blurb: 'File types carved from transferred content.',
       },
     ];
@@ -118,6 +151,8 @@ export const SnapshotSecurityTab = ({ edges, loading }: SnapshotSecurityTabProps
       <p className="text-muted small mb-3">
         Security-relevant signals detected in this capture. This is the absolute posture of the
         snapshot; the <strong>Changes</strong> tab shows what is new versus the previous snapshot.
+        Click a signal to open the matching conversations in analysis mode, or a flow to also
+        filter by that host.
       </p>
       {sections.map(section => (
         <div key={section.key} className="mb-4">
@@ -146,10 +181,29 @@ export const SnapshotSecurityTab = ({ edges, loading }: SnapshotSecurityTabProps
                 <tbody>
                   {section.rows.map(row => (
                     <tr key={row.value}>
-                      <td className="font-monospace" style={{ wordBreak: 'break-word' }}>{row.value}</td>
+                      <td className="font-monospace" style={{ wordBreak: 'break-word' }}>
+                        <a
+                          href={buildUrl(section.filterParam, row.value)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title="Open matching conversations in analysis mode"
+                        >
+                          {row.value}
+                        </a>
+                      </td>
                       <td>
                         {row.flows.map(f => (
-                          <div key={f} className="font-monospace text-muted" style={{ fontSize: '0.76rem' }}>{f}</div>
+                          <div key={f.label} className="font-monospace" style={{ fontSize: '0.76rem' }}>
+                            <a
+                              href={buildUrl(section.filterParam, row.value, f.src)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-muted"
+                              title={`Open conversations for this signal involving ${f.src}`}
+                            >
+                              {f.label}
+                            </a>
+                          </div>
                         ))}
                       </td>
                     </tr>

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -262,8 +262,12 @@ export const SnapshotTimeline = ({
       ? <Badge bg="light" text="dark" className="border fw-normal">{count}</Badge>
       : <span className="text-muted small">—</span>;
 
+  // In the bucketed "By Time" view, per-snapshot drift doesn't aggregate meaningfully, so the
+  // Security column there always shows the absolute (total) count — surfaced whenever *either*
+  // security toggle is on, so enabling the default "Security (new)" still yields a Security column.
+  const showBucketSecurity = showCol('securityAbsolute') || showCol('securityDrift');
   // Column count of a "By Time" bucket header row (Period + Captures + Changes always shown).
-  const bucketColSpan = 3 + (showCol('packets') ? 1 : 0) + (showCol('securityAbsolute') ? 1 : 0);
+  const bucketColSpan = 3 + (showCol('packets') ? 1 : 0) + (showBucketSecurity ? 1 : 0);
 
   const renderSnapshotRow = (snap: NetworkSnapshot) => {
     const drift = securityDriftBySnapshot.get(snap.id) ?? 0;
@@ -353,8 +357,9 @@ export const SnapshotTimeline = ({
               <i className="bi bi-layout-three-columns me-1"></i>Columns
             </Dropdown.Toggle>
             <Dropdown.Menu>
+              <div className="dropdown-header small text-muted py-1">Show columns</div>
               {TOGGLEABLE_COLUMNS.map(col => (
-                <div key={col.key} className="dropdown-item-text py-1">
+                <div key={col.key} className="dropdown-item-text py-1 small">
                   <Form.Check
                     type="checkbox"
                     id={`col-${col.key}`}
@@ -411,7 +416,7 @@ export const SnapshotTimeline = ({
                     <th className="text-muted fw-normal">Captures</th>
                     {showCol('packets') && <th className="text-muted fw-normal">Packets</th>}
                     <th className="text-muted fw-normal">Changes</th>
-                    {showCol('securityAbsolute') && <th className="text-muted fw-normal">Security (total)</th>}
+                    {showBucketSecurity && <th className="text-muted fw-normal">Security (total)</th>}
                   </tr>
                 </thead>
                 <tbody>
@@ -433,7 +438,7 @@ export const SnapshotTimeline = ({
                             </td>
                           )}
                           <td>{renderChangesPill(b.changes, b.critical)}</td>
-                          {showCol('securityAbsolute') && <td>{renderSecurityAbsolute(b.security)}</td>}
+                          {showBucketSecurity && <td>{renderSecurityAbsolute(b.security)}</td>}
                         </tr>
                         {isOpen && (
                           <tr>

--- a/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
+++ b/frontend/src/components/monitor/SnapshotTimeline/SnapshotTimeline.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useEffect, useMemo, useState, type MouseEvent } from 'react';
-import { Badge, Button, ButtonGroup, Form } from '@govtechsg/sgds-react';
+import { Badge, Button, ButtonGroup, Dropdown, Form } from '@govtechsg/sgds-react';
 import type { NetworkSnapshot, ChangeEvent } from '@/features/monitor/types/monitor.types';
 import { Pagination } from '@/components/common/Pagination';
 import { ScrollableTable } from '@/components/common/ScrollableTable';
@@ -37,7 +37,22 @@ interface TimeBucket {
   packets: number;
   changes: number;
   critical: number;
+  security: number; // summed absolute security-signal count across the bucket's snapshots
 }
+
+// Toggleable table columns. "Captured/Period", "File/Captures", and "Changes" are always shown.
+type ColumnKey = 'duration' | 'packets' | 'securityDrift' | 'securityAbsolute';
+
+const TOGGLEABLE_COLUMNS: { key: ColumnKey; label: string }[] = [
+  { key: 'duration',         label: 'Duration' },
+  { key: 'packets',          label: 'Packets' },
+  { key: 'securityDrift',    label: 'Security (new)' },
+  { key: 'securityAbsolute', label: 'Security (total)' },
+];
+
+// Duration, Packets, and absolute Security are off by default to keep the default view focused;
+// Security (new) — the drift count — is on, matching the timeline's differential theme.
+const DEFAULT_VISIBLE_COLUMNS: ColumnKey[] = ['securityDrift'];
 
 // Start (ms) of the bucket a given timestamp falls into for the active granularity.
 function bucketStartFor(ms: number, granularity: Granularity): number {
@@ -97,13 +112,33 @@ export const SnapshotTimeline = ({
   onSnapshotUpdated,
 }: SnapshotTimelineProps) => {
   const [detailSnap, setDetailSnap] = useState<NetworkSnapshot | null>(null);
-  const [detailInitialTab, setDetailInitialTab] = useState<'diagram' | 'changes' | 'context' | 'insights'>('diagram');
+  const [detailInitialTab, setDetailInitialTab] = useState<'diagram' | 'changes' | 'security' | 'context' | 'insights'>('diagram');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [viewMode, setViewMode] = useState<ViewMode>('file');
   const [granularity, setGranularity] = useState<Granularity>(3600);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [visibleCols, setVisibleCols] = useState<Set<ColumnKey>>(new Set(DEFAULT_VISIBLE_COLUMNS));
+
+  const showCol = (key: ColumnKey) => visibleCols.has(key);
+  const toggleCol = (key: ColumnKey) =>
+    setVisibleCols(prev => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+
+  // Security-drift (new) count per snapshot: SECURITY_ALERT_* change events landing on it.
+  const securityDriftBySnapshot = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const e of changeEvents) {
+      if (e.changeType === 'SECURITY_ALERT_ADDED' || e.changeType === 'SECURITY_ALERT_REMOVED') {
+        m.set(e.toSnapshotId, (m.get(e.toSnapshotId) ?? 0) + 1);
+      }
+    }
+    return m;
+  }, [changeEvents]);
 
   const toggleSort = () => {
     setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
@@ -159,6 +194,7 @@ export const SnapshotTimeline = ({
       packets: snaps.reduce((s, x) => s + (x.packetCount ?? 0), 0),
       changes: snaps.reduce((s, x) => s + x.changeCount, 0),
       critical: snaps.reduce((s, x) => s + x.criticalCount, 0),
+      security: snaps.reduce((s, x) => s + (x.securitySignalCount ?? 0), 0),
     });
     const list = [...map.entries()]
       .map(([start, snaps]) => toBucket(start, snaps))
@@ -205,33 +241,71 @@ export const SnapshotTimeline = ({
     );
   };
 
-  const renderSnapshotRow = (snap: NetworkSnapshot) => (
-    <tr
-      key={snap.id}
-      style={{ cursor: 'pointer' }}
-      onClick={() => { setDetailInitialTab('diagram'); setDetailSnap(snap); }}
-    >
-      <td>
-        <small className="text-muted">{formatCaptureDate(snap.startTime)}</small>
-      </td>
-      <td>
-        <span className="fw-medium text-break">{snap.fileName}</span>
-      </td>
-      <td>
-        <small className="text-muted">{formatDuration(snap.startTime, snap.endTime)}</small>
-      </td>
-      <td>
-        <small className="text-muted">{snap.packetCount != null ? snap.packetCount.toLocaleString() : '—'}</small>
-      </td>
-      <td>
-        {renderChangesPill(snap.changeCount, snap.criticalCount, e => {
-          e.stopPropagation();
-          setDetailInitialTab('changes');
-          setDetailSnap(snap);
-        })}
-      </td>
-    </tr>
-  );
+  // "Security (new)" drift pill — count of SECURITY_ALERT_* change events on this snapshot.
+  const renderSecurityDriftPill = (count: number, onClick?: (e: MouseEvent<HTMLElement>) => void) => {
+    if (count === 0) return <span className="text-muted small">—</span>;
+    return (
+      <Badge
+        bg="danger"
+        className="fw-normal"
+        style={onClick ? { cursor: 'pointer' } : undefined}
+        onClick={onClick}
+      >
+        {count} new
+      </Badge>
+    );
+  };
+
+  // "Security (total)" absolute posture — distinct signals present in the capture.
+  const renderSecurityAbsolute = (count: number) =>
+    count > 0
+      ? <Badge bg="light" text="dark" className="border fw-normal">{count}</Badge>
+      : <span className="text-muted small">—</span>;
+
+  // Column count of a "By Time" bucket header row (Period + Captures + Changes always shown).
+  const bucketColSpan = 3 + (showCol('packets') ? 1 : 0) + (showCol('securityAbsolute') ? 1 : 0);
+
+  const renderSnapshotRow = (snap: NetworkSnapshot) => {
+    const drift = securityDriftBySnapshot.get(snap.id) ?? 0;
+    const openSecurity = (e: MouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      setDetailInitialTab('security');
+      setDetailSnap(snap);
+    };
+    return (
+      <tr
+        key={snap.id}
+        style={{ cursor: 'pointer' }}
+        onClick={() => { setDetailInitialTab('diagram'); setDetailSnap(snap); }}
+      >
+        <td>
+          <small className="text-muted">{formatCaptureDate(snap.startTime)}</small>
+        </td>
+        <td>
+          <span className="fw-medium text-break">{snap.fileName}</span>
+        </td>
+        {showCol('duration') && (
+          <td>
+            <small className="text-muted">{formatDuration(snap.startTime, snap.endTime)}</small>
+          </td>
+        )}
+        {showCol('packets') && (
+          <td>
+            <small className="text-muted">{snap.packetCount != null ? snap.packetCount.toLocaleString() : '—'}</small>
+          </td>
+        )}
+        <td>
+          {renderChangesPill(snap.changeCount, snap.criticalCount, e => {
+            e.stopPropagation();
+            setDetailInitialTab('changes');
+            setDetailSnap(snap);
+          })}
+        </td>
+        {showCol('securityDrift') && <td>{renderSecurityDriftPill(drift, openSecurity)}</td>}
+        {showCol('securityAbsolute') && <td onClick={openSecurity}>{renderSecurityAbsolute(snap.securitySignalCount ?? 0)}</td>}
+      </tr>
+    );
+  };
 
   return (
     <div>
@@ -274,6 +348,24 @@ export const SnapshotTimeline = ({
               By Time
             </Button>
           </ButtonGroup>
+          <Dropdown autoClose="outside">
+            <Dropdown.Toggle size="sm" variant="outline-secondary">
+              <i className="bi bi-layout-three-columns me-1"></i>Columns
+            </Dropdown.Toggle>
+            <Dropdown.Menu>
+              {TOGGLEABLE_COLUMNS.map(col => (
+                <div key={col.key} className="dropdown-item-text py-1">
+                  <Form.Check
+                    type="checkbox"
+                    id={`col-${col.key}`}
+                    label={col.label}
+                    checked={showCol(col.key)}
+                    onChange={() => toggleCol(col.key)}
+                  />
+                </div>
+              ))}
+            </Dropdown.Menu>
+          </Dropdown>
           <Button size="sm" variant="outline-secondary" onClick={onManage}>
             <i className="bi bi-collection me-1"></i>Manage PCAPs
           </Button>
@@ -297,9 +389,11 @@ export const SnapshotTimeline = ({
                       <i className={`bi bi-arrow-${sortDir === 'asc' ? 'up' : 'down'} ms-1`}></i>
                     </th>
                     <th className="text-muted fw-normal">File</th>
-                    <th className="text-muted fw-normal">Duration</th>
-                    <th className="text-muted fw-normal">Packets</th>
+                    {showCol('duration') && <th className="text-muted fw-normal">Duration</th>}
+                    {showCol('packets') && <th className="text-muted fw-normal">Packets</th>}
                     <th className="text-muted fw-normal">Changes</th>
+                    {showCol('securityDrift') && <th className="text-muted fw-normal">Security (new)</th>}
+                    {showCol('securityAbsolute') && <th className="text-muted fw-normal">Security (total)</th>}
                   </tr>
                 </thead>
                 <tbody>
@@ -315,8 +409,9 @@ export const SnapshotTimeline = ({
                       <i className={`bi bi-arrow-${sortDir === 'asc' ? 'up' : 'down'} ms-1`}></i>
                     </th>
                     <th className="text-muted fw-normal">Captures</th>
-                    <th className="text-muted fw-normal">Packets</th>
+                    {showCol('packets') && <th className="text-muted fw-normal">Packets</th>}
                     <th className="text-muted fw-normal">Changes</th>
+                    {showCol('securityAbsolute') && <th className="text-muted fw-normal">Security (total)</th>}
                   </tr>
                 </thead>
                 <tbody>
@@ -332,22 +427,27 @@ export const SnapshotTimeline = ({
                           <td>
                             <small className="text-muted">{b.snaps.length}</small>
                           </td>
-                          <td>
-                            <small className="text-muted">{b.packets.toLocaleString()}</small>
-                          </td>
+                          {showCol('packets') && (
+                            <td>
+                              <small className="text-muted">{b.packets.toLocaleString()}</small>
+                            </td>
+                          )}
                           <td>{renderChangesPill(b.changes, b.critical)}</td>
+                          {showCol('securityAbsolute') && <td>{renderSecurityAbsolute(b.security)}</td>}
                         </tr>
                         {isOpen && (
                           <tr>
-                            <td colSpan={4} className="p-0 bg-light">
+                            <td colSpan={bucketColSpan} className="p-0 bg-light">
                               <table className="table table-sm table-hover align-middle mb-0">
                                 <thead>
                                   <tr>
                                     <th className="text-muted fw-normal small border-0">Captured</th>
                                     <th className="text-muted fw-normal small border-0">File</th>
-                                    <th className="text-muted fw-normal small border-0">Duration</th>
-                                    <th className="text-muted fw-normal small border-0">Packets</th>
+                                    {showCol('duration') && <th className="text-muted fw-normal small border-0">Duration</th>}
+                                    {showCol('packets') && <th className="text-muted fw-normal small border-0">Packets</th>}
                                     <th className="text-muted fw-normal small border-0">Changes</th>
+                                    {showCol('securityDrift') && <th className="text-muted fw-normal small border-0">Security (new)</th>}
+                                    {showCol('securityAbsolute') && <th className="text-muted fw-normal small border-0">Security (total)</th>}
                                   </tr>
                                 </thead>
                                 <tbody>

--- a/frontend/src/features/monitor/types/monitor.types.ts
+++ b/frontend/src/features/monitor/types/monitor.types.ts
@@ -52,9 +52,12 @@ export type ChangeType =
   | 'PROTOCOL_ADDED'
   | 'APP_ADDED'
   | 'VPN_DRIFT'
+  | 'SECURITY_ALERT_ADDED'
+  | 'SECURITY_ALERT_REMOVED'
   | 'LABEL_STALE';
 
-export type EntityType = 'DEVICE' | 'IP_MAC_BINDING' | 'ISP' | 'PROTOCOL' | 'APP' | 'NODE_ROLE';
+export type EntityType =
+  | 'DEVICE' | 'IP_MAC_BINDING' | 'ISP' | 'PROTOCOL' | 'APP' | 'SECURITY' | 'NODE_ROLE';
 
 export type Severity = 'INFO' | 'WARNING' | 'CRITICAL';
 

--- a/frontend/src/features/monitor/types/monitor.types.ts
+++ b/frontend/src/features/monitor/types/monitor.types.ts
@@ -37,6 +37,8 @@ export interface NetworkSnapshot {
   totalBytes: number | null;
   changeCount: number;
   criticalCount: number;
+  /** Distinct absolute security signals in this capture (IDS/risks/sigs/file types). */
+  securitySignalCount: number;
   context: string | null;
   notes: string | null;
   hasInsights: boolean;

--- a/frontend/src/features/network/services/networkService.ts
+++ b/frontend/src/features/network/services/networkService.ts
@@ -240,6 +240,7 @@ function createEdge(conversation: Conversation, srcIp: string, dstIp: string): G
       category: conversation.category,
       flowRisks,
       customSignatures: conversation.customSignatures ?? [],
+      suricataAlerts: conversation.suricataAlerts ?? [],
       detectedFileTypes: conversation.detectedFileTypes ?? [],
       srcCountry: conversation.srcGeo?.countryCode,
       dstCountry: conversation.dstGeo?.countryCode,

--- a/frontend/src/features/network/types/index.ts
+++ b/frontend/src/features/network/types/index.ts
@@ -105,6 +105,7 @@ export interface EdgeData {
   category?: string;
   flowRisks?: string[];
   customSignatures?: string[];
+  suricataAlerts?: string[];
   detectedFileTypes?: string[];
   srcCountry?: string;
   dstCountry?: string;

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -2094,6 +2094,10 @@
             "format": "int32",
             "type": "integer"
           },
+          "securitySignalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
           "snapshotOrder": {
             "format": "int32",
             "type": "integer"


### PR DESCRIPTION
## Why

Monitor mode was purely **differential** (what changed between snapshots) and never surfaced the security intelligence **analysis mode already computes per capture** — Suricata IDS alerts, nDPI flow risks, custom signatures, and detected file types. This PR closes that gap in two layers: an absolute per-snapshot view and a differential drift signal.

## Layer 1 — Per-snapshot Security tab

A new **Security** tab in `SnapshotDetailModal` showing the absolute security posture of a capture, aggregating all four signals from the network edges already loaded for the diagram, grouped by signal value with the flows that exhibited each. Count badge coloured by worst severity (IDS/custom-sig = critical), mirroring the existing Changes badge.

- The one real gap: `suricataAlerts` was dropped in `networkService.buildNetworkGraph` even though the conversation DTO already carried it — one-line map onto `EdgeData`. **No backend change.**

## Layer 2 — Security drift as change events

A sixth change-detection signal (`ChangeDetectionService.detectSecurityDrift`) emitting `SECURITY_ALERT_ADDED`/`REMOVED` events when signals appear/disappear between snapshots — the differential complement to Layer 1.

| Signal | Added | Removed |
|---|---|---|
| Suricata IDS alerts | CRITICAL | INFO |
| Custom signatures | CRITICAL | INFO |
| nDPI flow risks (VPN excluded — already `VPN_DRIFT`) | WARNING | INFO |
| Detected file types | INFO | — (not reported) |

- Reuses the conversation lists and `findDistinctFileTypesByFileId` — no new persistence.
- New `SECURITY_ALERT_ADDED/REMOVED` change types + `SECURITY` entity type. **No Flyway migration** (enum stored as `varchar` via `EnumType.STRING`) and **no OpenAPI baseline change** (`changeType`/`entityType` serialise as plain strings). Frontend renders via the existing change-event feed and dynamic change-type filter.

## Verification (real demo data, Playwright)

- **Layer 1**: `week5_shadow_device_arp_spoof` Security tab renders the `ET P2P BitTorrent DHT ping request` IDS alert and `malicious_fingerprint` flow risk with their flows; badge shows the count. Zero console errors.
- **Layer 2**: re-detection produced **8 ADDED / 6 REMOVED** security events with correct severities and `signalKind` payloads. On `week3_telnet_bittorrent`'s Changes tab: "IDS alert appeared: …" (critical), "Flow risk appeared: unsafe_protocol" (warning), interleaved with existing events.

## Deferred

**Layer 3 (network-wide Security Overview) intentionally not built** — the change-event feed likely already covers cross-snapshot collation. Revisit only if a trend / standing-posture view proves missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Security view in snapshot details to review alerts, risks, signatures, and detected file types.
  * Security-related change events are now shown with clearer labels, including alert added/cleared states.

* **Bug Fixes**
  * Security posture changes are now detected and displayed more consistently between snapshots.
  * Network graphs now carry alert information needed for security-related views and badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->