### PR TITLE
feat(monitor): Change Events header compression, last-seen pcap, sortable+paginated snapshot history

### DIFF
--- a/frontend/src/assets/styles/index.css
+++ b/frontend/src/assets/styles/index.css
@@ -259,3 +259,37 @@ body {
   display: inline-block;
   animation: spin 1s linear infinite;
 }
+
+/* Compact, refined search/filter inputs — single source of truth shared by the
+   conversation filter panel, the network-diagram filter modal (NetworkControls),
+   and the IP classification-override row. Add `tp-compact-search` to an
+   `.input-group` (icon + field + clear button) or directly to a standalone
+   `.form-control` / `.form-select`. Keeps these fields from towering over the
+   compact pill rows around them. */
+.tp-compact-search.input-group > .form-control,
+.tp-compact-search.input-group > .input-group-text,
+.tp-compact-search.input-group > .btn,
+.form-control.tp-compact-search,
+.form-select.tp-compact-search {
+  height: 1.9rem;
+  font-size: 0.8rem;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.tp-compact-search.input-group > .input-group-text {
+  background-color: var(--tp-bg-subtle, #f0f2f5);
+  border-color: var(--tp-border, #dee2e6);
+  color: var(--tp-text-muted, #6c757d);
+}
+
+.tp-compact-search.input-group > .input-group-text .bi {
+  font-size: 0.8rem;
+}
+
+.tp-compact-search.input-group > .btn {
+  display: inline-flex;
+  align-items: center;
+  padding-inline: 0.55rem;
+  line-height: 1;
+}

--- a/frontend/src/components/common/EntityDetailModal/EntityDetailModal.tsx
+++ b/frontend/src/components/common/EntityDetailModal/EntityDetailModal.tsx
@@ -65,8 +65,9 @@ export function EntityDetailModal({
     if (isActive) {
       return <span className="badge bg-success ms-2" style={{ fontSize: '0.7rem' }}>Active</span>;
     }
-    const days = lastSeenTime
-      ? Math.floor((Date.now() - new Date(lastSeenTime).getTime()) / 86400000)
+    const parsedTime = lastSeenTime ? new Date(lastSeenTime).getTime() : null;
+    const days = parsedTime !== null && !Number.isNaN(parsedTime)
+      ? Math.floor((Date.now() - parsedTime) / 86400000)
       : null;
     const agoText = days != null && days > 0 ? ` · ${days}d ago` : '';
     const tooltip = lastSeenFileName ? `Last seen in ${lastSeenFileName}` : undefined;

--- a/frontend/src/components/common/EntityDetailModal/EntityDetailModal.tsx
+++ b/frontend/src/components/common/EntityDetailModal/EntityDetailModal.tsx
@@ -21,6 +21,7 @@ export function EntityDetailModal({
   badge,
   isActive,
   lastSeenTime,
+  lastSeenFileName,
   onViewConversations,
   snapshots,
   onClose,
@@ -64,11 +65,21 @@ export function EntityDetailModal({
     if (isActive) {
       return <span className="badge bg-success ms-2" style={{ fontSize: '0.7rem' }}>Active</span>;
     }
-    if (lastSeenTime) {
-      const days = Math.floor((Date.now() - new Date(lastSeenTime).getTime()) / 86400000);
-      return <span className="badge bg-secondary ms-2" style={{ fontSize: '0.7rem' }}>Inactive{days > 0 ? ` · ${days}d ago` : ''}</span>;
-    }
-    return <span className="badge bg-secondary ms-2" style={{ fontSize: '0.7rem' }}>Inactive</span>;
+    const days = lastSeenTime
+      ? Math.floor((Date.now() - new Date(lastSeenTime).getTime()) / 86400000)
+      : null;
+    const agoText = days != null && days > 0 ? ` · ${days}d ago` : '';
+    const tooltip = lastSeenFileName ? `Last seen in ${lastSeenFileName}` : undefined;
+    return (
+      <span className="badge bg-secondary ms-2 d-inline-flex align-items-center" style={{ fontSize: '0.7rem', gap: '0.5rem' }} title={tooltip}>
+        <span>Inactive{agoText}</span>
+        {lastSeenFileName && (
+          <span className="fw-normal opacity-75 ps-2 border-start border-light border-opacity-50">
+            <i className="bi bi-camera-reels me-1"></i>{lastSeenFileName}
+          </span>
+        )}
+      </span>
+    );
   })() : null;
 
   const hasFileStats = !!fileId && (entityType === 'APPLICATION' || entityType === 'PROTOCOL');

--- a/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
@@ -47,6 +47,10 @@ export function SnapshotHistoryTable({
   const activePage = Math.min(page, totalPages);
   const pagedHistory = sortedHistory.slice((activePage - 1) * HISTORY_PAGE_SIZE, activePage * HISTORY_PAGE_SIZE);
 
+  // Reset to page 1 when the modal is reused for a different entity, so the next
+  // entity doesn't open on a stale page inherited from the previous one.
+  useEffect(() => { setPage(1); }, [entityKey]);
+
   // Clamp back into range if the data shrinks (e.g. the modal is reused for another entity).
   useEffect(() => {
     if (page > totalPages) setPage(totalPages);

--- a/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
@@ -1,10 +1,13 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Badge, Button, Table } from '@govtechsg/sgds-react';
 import { Spinner } from '@components/common/Spinner/Spinner';
+import { Pagination } from '@components/common/Pagination';
 import { RoleEditModal } from '@components/common/RoleEditModal';
 import type { EntityType } from '@/features/notes/services/entityNotesService';
 import { formatSnapTime, hashBadgeStyle } from '../format';
 import type { IpSnapshotEntry } from '../types';
+
+const HISTORY_PAGE_SIZE = 10;
 
 interface SnapshotHistoryTableProps {
   entityType: EntityType;
@@ -24,6 +27,32 @@ export function SnapshotHistoryTable({
   onRoleChanged,
 }: SnapshotHistoryTableProps) {
   const [editing, setEditing] = useState<{ fileId: string; name: string } | null>(null);
+  // Sort by snapshot capture order (monotonic with date). Latest-first by default.
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+  const [page, setPage] = useState(1);
+
+  const sortedHistory = [...ipSnapHistory].sort((a, b) =>
+    sortDir === 'desc'
+      ? b.snap.snapshotOrder - a.snap.snapshotOrder
+      : a.snap.snapshotOrder - b.snap.snapshotOrder
+  );
+  const toggleSort = () => { setSortDir(d => (d === 'desc' ? 'asc' : 'desc')); setPage(1); };
+
+  const totalPages = Math.max(1, Math.ceil(sortedHistory.length / HISTORY_PAGE_SIZE));
+  const pagedHistory = sortedHistory.slice((page - 1) * HISTORY_PAGE_SIZE, page * HISTORY_PAGE_SIZE);
+
+  // Clamp back into range if the data shrinks (e.g. the modal is reused for another entity).
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages);
+  }, [page, totalPages]);
+
+  // Chronological order (oldest→newest) for the "MAC changed vs previous snapshot" comparison,
+  // which must stay correct regardless of the display sort direction.
+  const chronological = [...ipSnapHistory].sort((a, b) => a.snap.snapshotOrder - b.snap.snapshotOrder);
+  const prevMacBySnapId = new Map<string, string | null | undefined>();
+  chronological.forEach((entry, i) => {
+    prevMacBySnapId.set(entry.snap.id, i > 0 ? chronological[i - 1].host?.mac : undefined);
+  });
 
   return (
     <div className="mt-4">
@@ -44,7 +73,16 @@ export function SnapshotHistoryTable({
             <Table.Header className="table-light" style={{ fontSize: '0.8rem' }}>
               <Table.Row>
                 <Table.HeaderCell className="text-muted fw-normal">#</Table.HeaderCell>
-                <Table.HeaderCell className="text-muted fw-normal">Snapshot</Table.HeaderCell>
+                <Table.HeaderCell
+                  className="text-muted fw-normal user-select-none"
+                  style={{ cursor: 'pointer' }}
+                  onClick={toggleSort}
+                  title="Sort by capture date"
+                  aria-sort={sortDir === 'desc' ? 'descending' : 'ascending'}
+                >
+                  Snapshot
+                  <i className={`bi ms-1 ${sortDir === 'desc' ? 'bi-sort-down' : 'bi-sort-up'}`} />
+                </Table.HeaderCell>
                 <Table.HeaderCell className="text-muted fw-normal">{entityType === 'DEVICE' ? 'IP(s)' : 'MAC Address'}</Table.HeaderCell>
                 <Table.HeaderCell className="text-muted fw-normal">Device Type</Table.HeaderCell>
                 <Table.HeaderCell className="text-muted fw-normal">Role</Table.HeaderCell>
@@ -52,7 +90,7 @@ export function SnapshotHistoryTable({
               </Table.Row>
             </Table.Header>
             <Table.Body>
-              {ipSnapHistory.map(({ snap, host, protocols, apps, roleLabel, roleOrigin, roleStale, macs, ips }, idx) => (
+              {pagedHistory.map(({ snap, host, protocols, apps, roleLabel, roleOrigin, roleStale, macs, ips }) => (
                 <Table.Row key={snap.id}>
                   <Table.DataCell><small className="text-muted">{snap.snapshotOrder + 1}</small></Table.DataCell>
                   <Table.DataCell>
@@ -88,10 +126,12 @@ export function SnapshotHistoryTable({
                           <i className="bi bi-diagram-3 me-1" />conflict — {macs.length} MACs
                         </Badge>
                       )}
-                      {idx > 0 && host?.mac && ipSnapHistory[idx - 1].host?.mac &&
-                        host.mac !== ipSnapHistory[idx - 1].host!.mac && (
+                      {(() => {
+                        const prevMac = prevMacBySnapId.get(snap.id);
+                        return host?.mac && prevMac && host.mac !== prevMac ? (
                           <Badge bg="warning" text="dark" className="ms-1" style={{ fontSize: '0.65rem' }}>changed</Badge>
-                        )}
+                        ) : null;
+                      })()}
                     </Table.DataCell>
                   )}
                   <Table.DataCell><small className="text-muted">{host?.deviceType ?? '—'}</small></Table.DataCell>
@@ -127,6 +167,17 @@ export function SnapshotHistoryTable({
               ))}
             </Table.Body>
           </Table>
+        </div>
+      )}
+      {!ipHistoryLoading && sortedHistory.length > HISTORY_PAGE_SIZE && (
+        <div className="mt-2">
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            totalItems={sortedHistory.length}
+            pageSize={HISTORY_PAGE_SIZE}
+            onPageChange={setPage}
+          />
         </div>
       )}
 

--- a/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/SnapshotHistoryTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Badge, Button, Table } from '@govtechsg/sgds-react';
 import { Spinner } from '@components/common/Spinner/Spinner';
 import { Pagination } from '@components/common/Pagination';
@@ -31,15 +31,21 @@ export function SnapshotHistoryTable({
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
   const [page, setPage] = useState(1);
 
-  const sortedHistory = [...ipSnapHistory].sort((a, b) =>
-    sortDir === 'desc'
-      ? b.snap.snapshotOrder - a.snap.snapshotOrder
-      : a.snap.snapshotOrder - b.snap.snapshotOrder
+  const sortedHistory = useMemo(() =>
+    [...ipSnapHistory].sort((a, b) =>
+      sortDir === 'desc'
+        ? b.snap.snapshotOrder - a.snap.snapshotOrder
+        : a.snap.snapshotOrder - b.snap.snapshotOrder
+    ),
+    [ipSnapHistory, sortDir]
   );
   const toggleSort = () => { setSortDir(d => (d === 'desc' ? 'asc' : 'desc')); setPage(1); };
 
   const totalPages = Math.max(1, Math.ceil(sortedHistory.length / HISTORY_PAGE_SIZE));
-  const pagedHistory = sortedHistory.slice((page - 1) * HISTORY_PAGE_SIZE, page * HISTORY_PAGE_SIZE);
+  // Derive the active page during render so a shrunken dataset can't slice out of
+  // range for the one frame before the useEffect below clamps `page`.
+  const activePage = Math.min(page, totalPages);
+  const pagedHistory = sortedHistory.slice((activePage - 1) * HISTORY_PAGE_SIZE, activePage * HISTORY_PAGE_SIZE);
 
   // Clamp back into range if the data shrinks (e.g. the modal is reused for another entity).
   useEffect(() => {
@@ -48,11 +54,14 @@ export function SnapshotHistoryTable({
 
   // Chronological order (oldest→newest) for the "MAC changed vs previous snapshot" comparison,
   // which must stay correct regardless of the display sort direction.
-  const chronological = [...ipSnapHistory].sort((a, b) => a.snap.snapshotOrder - b.snap.snapshotOrder);
-  const prevMacBySnapId = new Map<string, string | null | undefined>();
-  chronological.forEach((entry, i) => {
-    prevMacBySnapId.set(entry.snap.id, i > 0 ? chronological[i - 1].host?.mac : undefined);
-  });
+  const prevMacBySnapId = useMemo(() => {
+    const chronological = [...ipSnapHistory].sort((a, b) => a.snap.snapshotOrder - b.snap.snapshotOrder);
+    const map = new Map<string, string | null | undefined>();
+    chronological.forEach((entry, i) => {
+      map.set(entry.snap.id, i > 0 ? chronological[i - 1].host?.mac : undefined);
+    });
+    return map;
+  }, [ipSnapHistory]);
 
   return (
     <div className="mt-4">
@@ -126,12 +135,9 @@ export function SnapshotHistoryTable({
                           <i className="bi bi-diagram-3 me-1" />conflict — {macs.length} MACs
                         </Badge>
                       )}
-                      {(() => {
-                        const prevMac = prevMacBySnapId.get(snap.id);
-                        return host?.mac && prevMac && host.mac !== prevMac ? (
-                          <Badge bg="warning" text="dark" className="ms-1" style={{ fontSize: '0.65rem' }}>changed</Badge>
-                        ) : null;
-                      })()}
+                      {host?.mac && prevMacBySnapId.get(snap.id) && host.mac !== prevMacBySnapId.get(snap.id) && (
+                        <Badge bg="warning" text="dark" className="ms-1" style={{ fontSize: '0.65rem' }}>changed</Badge>
+                      )}
                     </Table.DataCell>
                   )}
                   <Table.DataCell><small className="text-muted">{host?.deviceType ?? '—'}</small></Table.DataCell>
@@ -172,7 +178,7 @@ export function SnapshotHistoryTable({
       {!ipHistoryLoading && sortedHistory.length > HISTORY_PAGE_SIZE && (
         <div className="mt-2">
           <Pagination
-            currentPage={page}
+            currentPage={activePage}
             totalPages={totalPages}
             totalItems={sortedHistory.length}
             pageSize={HISTORY_PAGE_SIZE}

--- a/frontend/src/components/common/EntityDetailModal/types.ts
+++ b/frontend/src/components/common/EntityDetailModal/types.ts
@@ -48,6 +48,8 @@ export interface EntityDetailModalProps {
   isActive?: boolean;
   /** ISO timestamp of last seen time — used to compute "inactive X days ago" */
   lastSeenTime?: string | null;
+  /** File name of the snapshot the entity was last seen in (Monitor context) */
+  lastSeenFileName?: string | null;
   /** Called when "View conversations" is clicked */
   onViewConversations?: () => void;
   /** Monitor snapshots — when provided for IP type, shows per-snapshot MAC/device history */

--- a/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.css
+++ b/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.css
@@ -75,3 +75,32 @@
   align-items: center;
   margin-bottom: 0.4rem;
 }
+
+/* Compact, refined text search inputs (IP / Port / Payload) so they don't
+   tower over the tight pill rows below them. */
+.filter-panel-body .input-group-sm > .form-control,
+.filter-panel-body .input-group-sm > .input-group-text,
+.filter-panel-body .input-group-sm > .btn {
+  height: 1.9rem;
+  font-size: 0.8rem;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.filter-panel-body .input-group-sm > .input-group-text {
+  background-color: var(--tp-bg-subtle, #f0f2f5);
+  border-color: var(--tp-border, #dee2e6);
+  color: var(--tp-text-muted, #6c757d);
+}
+
+.filter-panel-body .input-group-sm > .input-group-text .bi {
+  font-size: 0.8rem;
+}
+
+/* Clear (×) button: mute it so it reads as a control, not a primary action. */
+.filter-panel-body .input-group-sm > .btn {
+  display: inline-flex;
+  align-items: center;
+  padding-inline: 0.55rem;
+  line-height: 1;
+}

--- a/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.css
+++ b/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.css
@@ -76,31 +76,5 @@
   margin-bottom: 0.4rem;
 }
 
-/* Compact, refined text search inputs (IP / Port / Payload) so they don't
-   tower over the tight pill rows below them. */
-.filter-panel-body .input-group-sm > .form-control,
-.filter-panel-body .input-group-sm > .input-group-text,
-.filter-panel-body .input-group-sm > .btn {
-  height: 1.9rem;
-  font-size: 0.8rem;
-  padding-top: 0;
-  padding-bottom: 0;
-}
-
-.filter-panel-body .input-group-sm > .input-group-text {
-  background-color: var(--tp-bg-subtle, #f0f2f5);
-  border-color: var(--tp-border, #dee2e6);
-  color: var(--tp-text-muted, #6c757d);
-}
-
-.filter-panel-body .input-group-sm > .input-group-text .bi {
-  font-size: 0.8rem;
-}
-
-/* Clear (×) button: mute it so it reads as a control, not a primary action. */
-.filter-panel-body .input-group-sm > .btn {
-  display: inline-flex;
-  align-items: center;
-  padding-inline: 0.55rem;
-  line-height: 1;
-}
+/* Compact search inputs (IP / Port / Payload) use the shared `.tp-compact-search`
+   class — see assets/styles/index.css. */

--- a/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
+++ b/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
@@ -287,7 +287,8 @@ export function ConversationFilterPanel({
                     onChange={e => onFiltersChange({ hasRisks: e.target.checked })}
                   />
                   <label
-                    className="form-check-label small d-inline-flex align-items-center"
+                    className="form-check-label d-inline-flex align-items-center text-nowrap"
+                    style={{ fontSize: '0.8rem' }}
                     htmlFor="hasRisksCheck"
                   >
                     Security risks only

--- a/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
+++ b/frontend/src/components/conversation/ConversationFilterPanel/ConversationFilterPanel.tsx
@@ -188,7 +188,7 @@ export function ConversationFilterPanel({
                     body="Matches conversations where the source IP, destination IP, or hostname contains this text (case-insensitive)."
                   />
                 </label>
-                <div className="input-group input-group-sm">
+                <div className="input-group input-group-sm tp-compact-search">
                   <span className="input-group-text">
                     <i className="bi bi-search"></i>
                   </span>
@@ -219,7 +219,7 @@ export function ConversationFilterPanel({
                     body="Filters to conversations where either the source or destination port exactly matches the entered number."
                   />
                 </label>
-                <div className="input-group input-group-sm">
+                <div className="input-group input-group-sm tp-compact-search">
                   <Form.Control
                     type="text"
                     inputMode="numeric"
@@ -255,7 +255,7 @@ export function ConversationFilterPanel({
                     }
                   />
                 </label>
-                <div className="input-group input-group-sm">
+                <div className="input-group input-group-sm tp-compact-search">
                   <span className="input-group-text">
                     <i className="bi bi-search"></i>
                   </span>

--- a/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
+++ b/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
@@ -159,6 +159,7 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
           fileId={selectedAbsent.lastSeenFileId ?? ''}
           isActive={false}
           lastSeenTime={selectedAbsent.lastSeenStartTime}
+          lastSeenFileName={selectedAbsent.lastSeenFileName}
           snapshots={snapshots}
           onClose={() => setSelectedAbsent(null)}
         />

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -498,6 +498,7 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
           fileId={selectedAbsent.lastSeenFileId ?? ''}
           isActive={false}
           lastSeenTime={selectedAbsent.lastSeenStartTime}
+          lastSeenFileName={selectedAbsent.lastSeenFileName}
           snapshots={snapshots}
           onClose={() => setSelectedAbsent(null)}
         />

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -240,16 +240,16 @@ function PrivateOverridesSection({
           <div className="d-flex gap-2 flex-wrap align-items-center">
             <input
               type="text"
-              className="form-control form-control-sm font-monospace"
-              style={{ maxWidth: 180 }}
+              className="form-control form-control-sm font-monospace tp-compact-search"
+              style={{ maxWidth: 160 }}
               placeholder="IP or CIDR"
               value={cidr}
               onChange={e => setCidr(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && handleAdd()}
             />
             <select
-              className="form-select form-select-sm"
-              style={{ maxWidth: 130 }}
+              className="form-select form-select-sm tp-compact-search"
+              style={{ maxWidth: 120 }}
               value={classification}
               onChange={e => setClassification(e.target.value as IpClassification)}
               aria-label="Treat as"

--- a/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
+++ b/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
@@ -89,7 +89,7 @@ function BadgeGroup({
   );
 }
 
-type SelectedEntity = { key: string; entityType: EntityType; fileId: string; isActive: boolean; lastSeenTime?: string | null } | null;
+type SelectedEntity = { key: string; entityType: EntityType; fileId: string; isActive: boolean; lastSeenTime?: string | null; lastSeenFileName?: string | null } | null;
 
 export const ProtocolDriftPanel = ({ snapshots }: ProtocolDriftPanelProps) => {
   const [selectedEntity, setSelectedEntity] = useState<SelectedEntity>(null);
@@ -198,7 +198,7 @@ export const ProtocolDriftPanel = ({ snapshots }: ProtocolDriftPanelProps) => {
           <BadgeGroup
             items={filterItems(apps.active)}
             absentItems={filterAbsent(apps.absent)}
-            onAbsentClick={e => setSelectedEntity({ key: e.key, entityType: 'APPLICATION', fileId: e.lastSeenFileId ?? latestFileId, isActive: false, lastSeenTime: e.lastSeenStartTime })}
+            onAbsentClick={e => setSelectedEntity({ key: e.key, entityType: 'APPLICATION', fileId: e.lastSeenFileId ?? latestFileId, isActive: false, lastSeenTime: e.lastSeenStartTime, lastSeenFileName: e.lastSeenFileName })}
             onActiveClick={name => setSelectedEntity({ key: name, entityType: 'APPLICATION', fileId: latestFileId, isActive: true, lastSeenTime: latestStartTime })}
           />
         </div>
@@ -209,7 +209,7 @@ export const ProtocolDriftPanel = ({ snapshots }: ProtocolDriftPanelProps) => {
           <BadgeGroup
             items={filterItems(protocols.active)}
             absentItems={filterAbsent(protocols.absent)}
-            onAbsentClick={e => setSelectedEntity({ key: e.key, entityType: 'PROTOCOL', fileId: e.lastSeenFileId ?? latestFileId, isActive: false, lastSeenTime: e.lastSeenStartTime })}
+            onAbsentClick={e => setSelectedEntity({ key: e.key, entityType: 'PROTOCOL', fileId: e.lastSeenFileId ?? latestFileId, isActive: false, lastSeenTime: e.lastSeenStartTime, lastSeenFileName: e.lastSeenFileName })}
             onActiveClick={name => setSelectedEntity({ key: name, entityType: 'PROTOCOL', fileId: latestFileId, isActive: true, lastSeenTime: latestStartTime })}
           />
         </div>
@@ -228,6 +228,7 @@ export const ProtocolDriftPanel = ({ snapshots }: ProtocolDriftPanelProps) => {
           fileId={selectedEntity.fileId}
           isActive={selectedEntity.isActive}
           lastSeenTime={selectedEntity.lastSeenTime}
+          lastSeenFileName={selectedEntity.lastSeenFileName}
           onClose={() => setSelectedEntity(null)}
         />
       )}

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -255,7 +255,7 @@ export function NetworkControls({
                 {/* IP / Hostname */}
                 <div className="col-md-3">
                   <label className="filter-section-label d-block mb-2">IP / Hostname</label>
-                  <div className="input-group input-group-sm">
+                  <div className="input-group input-group-sm tp-compact-search">
                     <span className="input-group-text">
                       <i className="bi bi-search" />
                     </span>
@@ -279,7 +279,7 @@ export function NetworkControls({
                 {/* Port */}
                 <div className="col-md-2">
                   <label className="filter-section-label d-block mb-2">Port</label>
-                  <div className="input-group input-group-sm">
+                  <div className="input-group input-group-sm tp-compact-search">
                     <Form.Control
                       type="text"
                       inputMode="numeric"

--- a/frontend/src/components/network/NetworkControls/NetworkControls.tsx
+++ b/frontend/src/components/network/NetworkControls/NetworkControls.tsx
@@ -299,7 +299,7 @@ export function NetworkControls({
                 </div>
 
                 {/* Has risks */}
-                <div className="col-md-2 d-flex align-items-end">
+                <div className="col-md-3 d-flex align-items-end">
                   <div className="form-check mb-0">
                     <input
                       type="checkbox"
@@ -308,7 +308,11 @@ export function NetworkControls({
                       checked={hasRisksOnly}
                       onChange={e => onHasRisksOnlyChange(e.target.checked)}
                     />
-                    <label className="form-check-label" htmlFor="ncHasRisks">
+                    <label
+                      className="form-check-label text-nowrap"
+                      style={{ fontSize: '0.8rem' }}
+                      htmlFor="ncHasRisks"
+                    >
                       Security risks only
                     </label>
                   </div>

--- a/frontend/src/pages/Monitor/components/ChangeEventsSection.tsx
+++ b/frontend/src/pages/Monitor/components/ChangeEventsSection.tsx
@@ -12,8 +12,9 @@ interface ChangeEventsSectionProps {
   onPatchChange: (eventId: string, patch: { reviewed?: boolean; notes?: string | null }) => Promise<void>;
 }
 
-/** Dropdown labels for non-ALL severities. */
-const SEVERITY_LABELS: Record<Exclude<SeverityFilter, 'ALL'>, string> = {
+/** Dropdown labels for severities. */
+const SEVERITY_LABELS: Record<SeverityFilter, string> = {
+  ALL: 'All severities',
   CRITICAL: 'Critical',
   WARNING: 'Warning',
   INFO: 'Info',
@@ -95,7 +96,7 @@ export const ChangeEventsSection = ({ changeEvents, snapshots, onPatchChange }: 
             title="Filter by severity"
           >
             {SEVERITY_FILTERS.map(f => (
-              <option key={f} value={f}>{f === 'ALL' ? 'All severities' : SEVERITY_LABELS[f]}</option>
+              <option key={f} value={f}>{SEVERITY_LABELS[f]}</option>
             ))}
           </Form.Select>
           {/* Change type select */}

--- a/frontend/src/pages/Monitor/components/ChangeEventsSection.tsx
+++ b/frontend/src/pages/Monitor/components/ChangeEventsSection.tsx
@@ -4,12 +4,32 @@ import { ChangeEventBadge } from '@/components/monitor/ChangeEventBadge/ChangeEv
 import { Pagination } from '@/components/common/Pagination';
 import { HelpPopover } from './HelpPopover';
 import { SEVERITY_FILTERS, useChangeEventFilters } from '../hooks/useChangeEventFilters';
+import type { ReviewedFilter, SeverityFilter } from '../hooks/useChangeEventFilters';
 
 interface ChangeEventsSectionProps {
   changeEvents: ChangeEvent[];
   snapshots: NetworkSnapshot[];
   onPatchChange: (eventId: string, patch: { reviewed?: boolean; notes?: string | null }) => Promise<void>;
 }
+
+/** Dropdown labels for non-ALL severities. */
+const SEVERITY_LABELS: Record<Exclude<SeverityFilter, 'ALL'>, string> = {
+  CRITICAL: 'Critical',
+  WARNING: 'Warning',
+  INFO: 'Info',
+};
+
+/** Cycle order + display for the single reviewed toggle button. */
+const NEXT_REVIEWED: Record<ReviewedFilter, ReviewedFilter> = {
+  ALL: 'UNREVIEWED',
+  UNREVIEWED: 'REVIEWED',
+  REVIEWED: 'ALL',
+};
+const REVIEWED_META: Record<ReviewedFilter, { label: string; icon: string }> = {
+  ALL: { label: 'All', icon: 'bi-list-ul' },
+  UNREVIEWED: { label: 'Unreviewed', icon: 'bi-circle' },
+  REVIEWED: { label: 'Reviewed', icon: 'bi-check-circle-fill' },
+};
 
 /** The "Change Events" card: severity/type/reviewed filters, paged event list. */
 export const ChangeEventsSection = ({ changeEvents, snapshots, onPatchChange }: ChangeEventsSectionProps) => {
@@ -31,8 +51,8 @@ export const ChangeEventsSection = ({ changeEvents, snapshots, onPatchChange }: 
 
   return (
     <Card id="sec-changes" className="mb-4 tp-anchor" style={{ overflow: 'hidden' }}>
-      <Card.Header className="d-flex justify-content-between align-items-center">
-        <h6 className="mb-0">
+      <Card.Header className="d-flex flex-wrap justify-content-between align-items-center gap-2">
+        <h6 className="mb-0 d-flex align-items-center flex-shrink-0">
           <i className="bi bi-activity me-2"></i>Change Events
           {filteredEvents.length > 0 && (
             <Badge bg="secondary" className="ms-2">{filteredEvents.length}</Badge>
@@ -65,28 +85,19 @@ export const ChangeEventsSection = ({ changeEvents, snapshots, onPatchChange }: 
             </ul>
           </HelpPopover>
         </h6>
-        <div className="d-flex align-items-center gap-2 flex-wrap">
-          {/* Severity pills */}
-          <div className="d-flex gap-1">
+        <div className="d-flex align-items-center gap-2 flex-wrap justify-content-end">
+          {/* Severity select */}
+          <Form.Select
+            size="sm"
+            style={{ width: 'auto' }}
+            value={severityFilter}
+            onChange={e => selectSeverity(e.target.value as SeverityFilter)}
+            title="Filter by severity"
+          >
             {SEVERITY_FILTERS.map(f => (
-              <Button
-                key={f}
-                type="button"
-                size="sm"
-                variant={
-                  severityFilter === f
-                    ? f === 'CRITICAL' ? 'danger'
-                      : f === 'WARNING' ? 'warning'
-                      : f === 'INFO' ? 'info'
-                      : 'primary'
-                    : 'outline-secondary'
-                }
-                onClick={() => selectSeverity(f)}
-              >
-                {f}
-              </Button>
+              <option key={f} value={f}>{f === 'ALL' ? 'All severities' : SEVERITY_LABELS[f]}</option>
             ))}
-          </div>
+          </Form.Select>
           {/* Change type select */}
           {changeTypes.length > 2 && (
             <Form.Select
@@ -94,26 +105,24 @@ export const ChangeEventsSection = ({ changeEvents, snapshots, onPatchChange }: 
               style={{ width: 'auto' }}
               value={changeTypeFilter}
               onChange={e => selectChangeType(e.target.value)}
+              title="Filter by change type"
             >
               {changeTypes.map(t => (
                 <option key={t} value={t}>{t === 'ALL' ? 'All types' : t}</option>
               ))}
             </Form.Select>
           )}
-          {/* Reviewed filter */}
-          <div className="d-flex gap-1">
-            {(['ALL', 'UNREVIEWED', 'REVIEWED'] as const).map(r => (
-              <Button
-                key={r}
-                type="button"
-                size="sm"
-                variant={reviewedFilter === r ? 'secondary' : 'outline-secondary'}
-                onClick={() => selectReviewed(r)}
-              >
-                {r === 'ALL' ? 'All' : r === 'UNREVIEWED' ? 'Unreviewed' : 'Reviewed'}
-              </Button>
-            ))}
-          </div>
+          {/* Reviewed filter — single button cycling All → Unreviewed → Reviewed */}
+          <Button
+            type="button"
+            size="sm"
+            variant={reviewedFilter === 'ALL' ? 'outline-secondary' : 'secondary'}
+            onClick={() => selectReviewed(NEXT_REVIEWED[reviewedFilter])}
+            title="Click to cycle: All → Unreviewed → Reviewed"
+          >
+            <i className={`bi ${REVIEWED_META[reviewedFilter].icon} me-1`}></i>
+            {REVIEWED_META[reviewedFilter].label}
+          </Button>
         </div>
       </Card.Header>
 


### PR DESCRIPTION
## Summary

Monitor-mode UI polish, all frontend-only (no backend/API/DTO changes).

### Change Events header (monitor)
Collapsed the crowded two-row toolbar into a single row beside the title:
- **Severity**: 4 buttons → one `All severities ▾` select
- **Reviewed**: 3 buttons → one button that cycles `All → Unreviewed → Reviewed`
- Change-type dropdown unchanged
- Header now wraps cleanly at narrow widths instead of orphaning the count badge

### Last-seen pcap on the Inactive badge
The entity detail modal's **Inactive** badge now names the pcap snapshot the entity was last seen in — for **Devices, Protocols/Applications, and IP Addresses** — with a camera icon, a divider from the "Xd ago" text, and a `Last seen in …` tooltip. New `lastSeenFileName` prop threaded through `EntityDetailModal` and all three drift panels.

`Inactive · 867d ago │ 🎬 week7_violations_drop_gateway_back.pcap`

### Snapshot History table
- **Sortable by date**: the Snapshot column header is a click toggle (latest-first by default, caret indicator). The "MAC changed vs previous snapshot" badge stays chronologically correct regardless of display sort direction.
- **Pagination** (10/page) added for larger histories.

### Conversation filter panel
Slimmed the IP / Port / Payload search inputs (38px → 30px, subtler search-icon prepend) so they no longer tower over the compact pill rows below.

## Testing
- `npx tsc --noEmit` clean
- Rebuilt via `docker compose up -d --build` and verified each change visually with Playwright: single-row Change Events header (wide + narrow), reviewed toggle cycling through all three states with filtering, Inactive badge with divider + pcap name, snapshot-history sort toggling asc/desc, and the pagination control (verified at a reduced page size, then restored to 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for showing the last-seen snapshot file name in entity details, with a helpful tooltip and icon when available.
  * Snapshot history can now be sorted and paged directly in the table.

* **Bug Fixes**
  * Improved snapshot change detection so MAC address changes are highlighted correctly even after sorting.

* **Style**
  * Updated filter and modal layouts for a cleaner, more compact interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->