### PR TITLE
feat(geo): GEO_FORCE_OFFLINE flag to suppress runtime ipinfo.io egress (#382)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,14 @@ FILE_RETENTION_HOURS=12
 DB_POOL_MAX_SIZE=20
 DB_POOL_MIN_IDLE=5
 
+# Geolocation Egress
+# TracePcap enriches external IPs via ipinfo.io when the internet is reachable, and automatically
+# falls back to the bundled DB-IP Lite MMDB when offline. This is the ONE intentional runtime egress.
+# Set to true for strict air-gapped / egress-monitored deployments: it skips the ipinfo.io
+# connectivity probe and lookups entirely and resolves geo exclusively from the bundled MMDB
+# (geo_source = mmdb). Default false (probe + ipinfo.io when reachable).
+GEO_FORCE_OFFLINE=false
+
 # Suricata IDS
 # Global kill-switch for Suricata signature-based threat detection. Suricata is ~94% of per-file
 # analysis cost (~50s/file), so setting this to false is the single biggest throughput lever.

--- a/.env.example
+++ b/.env.example
@@ -47,8 +47,11 @@ DB_POOL_MIN_IDLE=5
 # falls back to the bundled DB-IP Lite MMDB when offline. This is the ONE intentional runtime egress.
 # Set to true for strict air-gapped / egress-monitored deployments: it skips the ipinfo.io
 # connectivity probe and lookups entirely and resolves geo exclusively from the bundled MMDB
-# (geo_source = mmdb). Default false (probe + ipinfo.io when reachable).
-GEO_FORCE_OFFLINE=false
+# (geo_source = mmdb).
+# Leave this COMMENTED OUT to inherit each compose file's default: the base stack
+# (docker-compose.yml) defaults to false (probe + ipinfo.io when reachable), while the air-gapped
+# stack (docker-compose.offline.yml) defaults to true. Uncomment to force a specific value in both.
+# GEO_FORCE_OFFLINE=false
 
 # Suricata IDS
 # Global kill-switch for Suricata signature-based threat detection. Suricata is ~94% of per-file

--- a/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
@@ -51,6 +51,14 @@ public class GeoIpService {
   @Value("${tracepcap.geo.mmdb-path:}")
   private String mmdbPathOverride;
 
+  /**
+   * When true, all outbound egress (the connectivity probe and ipinfo.io lookups) is suppressed
+   * and geo is resolved exclusively from the bundled MMDB. For strict air-gapped or
+   * egress-monitored deployments. Default false.
+   */
+  @Value("${tracepcap.geo.force-offline:false}")
+  private boolean forceOffline;
+
   private final IpGeoInfoRepository geoInfoRepository;
   private final ObjectMapper objectMapper;
 
@@ -85,6 +93,10 @@ public class GeoIpService {
     if (!geoEnabled) {
       log.info("GeoIP enrichment disabled via tracepcap.geo.enabled=false");
       return;
+    }
+    if (forceOffline) {
+      log.info("GeoIP force-offline mode enabled (tracepcap.geo.force-offline=true) — "
+          + "no ipinfo.io egress will be attempted; resolving from bundled MMDB only");
     }
     this.dbReader = tryOpenMmdb();
     if (dbReader == null) {
@@ -260,6 +272,8 @@ public class GeoIpService {
   // ── Connectivity check ─────────────────────────────────────────────────────
 
   private boolean isOnline() {
+    // Force-offline suppresses the connectivity probe entirely — no egress ever attempted.
+    if (forceOffline) return false;
     long now = System.currentTimeMillis();
     if (onlineCache != null && (now - onlineCheckedAt) < ONLINE_CHECK_TTL_MS) {
       return onlineCache;

--- a/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
@@ -272,8 +272,9 @@ public class GeoIpService {
   // ── Connectivity check ─────────────────────────────────────────────────────
 
   private boolean isOnline() {
-    // Force-offline suppresses the connectivity probe entirely — no egress ever attempted.
-    if (forceOffline) return false;
+    // Suppress the connectivity probe entirely — no egress ever attempted — when GeoIP is
+    // disabled or force-offline is set.
+    if (!geoEnabled || forceOffline) return false;
     long now = System.currentTimeMillis();
     if (onlineCache != null && (now - onlineCheckedAt) < ONLINE_CHECK_TTL_MS) {
       return onlineCache;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -206,6 +206,9 @@ tracepcap:
     enabled: ${GEO_ENRICHMENT_ENABLED:true}
     timeout-seconds: ${GEO_TIMEOUT_SECONDS:10}
     mmdb-path: ${GEO_MMDB_PATH:}
+    # When true, suppresses all ipinfo.io egress (connectivity probe + lookups) and resolves
+    # geo exclusively from the bundled MMDB. For air-gapped / egress-monitored deployments.
+    force-offline: ${GEO_FORCE_OFFLINE:false}
   intelligence:
     max-clusters: ${INTELLIGENCE_MAX_CLUSTERS:60}   # Max cluster nodes returned per groupBy request
     max-edges: ${INTELLIGENCE_MAX_EDGES:200}         # Max edges returned per groupBy request

--- a/docker-compose.offline.yml
+++ b/docker-compose.offline.yml
@@ -89,6 +89,10 @@ services:
       MINIO_SECRET_KEY: minioadmin
       MINIO_BUCKET: tracepcap-files
       APP_MEMORY_MB: ${APP_MEMORY_MB:-2048}
+      # Air-gapped by default: suppress the one intentional runtime egress (ipinfo.io) and
+      # resolve geo from the bundled MMDB only. Override with GEO_FORCE_OFFLINE=false if this
+      # offline stack does have outbound access and you want live ipinfo.io enrichment.
+      GEO_FORCE_OFFLINE: ${GEO_FORCE_OFFLINE:-true}
       LLM_API_BASE_URL: ${LLM_API_BASE_URL:-http://localhost:1234/v1}
       LLM_API_KEY: ${LLM_API_KEY:-your-api-key-here}
       LLM_MODEL: ${LLM_MODEL:-gpt-4}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,9 @@ services:
       EXTRACTION_MAX_MATCHES_PER_STREAM: ${EXTRACTION_MAX_MATCHES_PER_STREAM:-20}
       EXTRACTION_MAX_STREAM_CONVERSATIONS: ${EXTRACTION_MAX_STREAM_CONVERSATIONS:-50}
       EXTRACTION_MAX_FILE_SIZE_MB: ${EXTRACTION_MAX_FILE_SIZE_MB:-50}
+      # Suppress ipinfo.io runtime egress (the one intentional external call). true = MMDB-only
+      # geo, no probe/lookups — for air-gapped deployments. See .env.example.
+      GEO_FORCE_OFFLINE: ${GEO_FORCE_OFFLINE:-false}
       # Global Suricata IDS kill-switch. false = skip Suricata for every file (biggest throughput
       # lever, ~94% of per-file analysis cost). See .env.example.
       SURICATA_ENABLED: ${SURICATA_ENABLED:-true}

--- a/docs/getting-started/offline-deployment.rst
+++ b/docs/getting-started/offline-deployment.rst
@@ -14,9 +14,36 @@ the workflow for deploying to a machine that has no internet access.
    custom signatures) are fully offline at all times.
 
    If you want to force MMDB-only lookups even on an internet-connected
-   machine, remove internet access from the container. If the MMDB file is
+   machine, set ``GEO_FORCE_OFFLINE=true`` (see below). If the MMDB file is
    not at the default location, also set the ``GEO_MMDB_PATH`` environment
    variable (or ``tracepcap.geo.mmdb-path`` in ``application.yml``).
+
+Suppressing Runtime Egress (``GEO_FORCE_OFFLINE``)
+--------------------------------------------------
+
+The ipinfo.io geolocation enrichment is the **one intentional runtime
+egress** in TracePcap. By default the backend probes ``ipinfo.io`` (~every
+60s while resolving new external IPs) and uses it when reachable, falling
+back to the bundled MMDB otherwise. The fallback is graceful, but the
+outbound *attempt* still occurs.
+
+For strict air-gapped or egress-monitored deployments, set:
+
+.. code-block:: ini
+
+   GEO_FORCE_OFFLINE=true
+
+When enabled, TracePcap:
+
+- **never** performs the connectivity probe or any ipinfo.io lookup — no
+  outbound ``ipinfo.io`` connection is attempted (verifiable via egress
+  logs / a firewall deny rule), and
+- resolves geo **exclusively** from the bundled DB-IP Lite MMDB
+  (``geo_source = mmdb`` on every result).
+
+This is the recommended setting for the offline compose stack. With it set,
+TracePcap makes **no external network calls at runtime** (aside from a
+locally-hosted LLM server, if configured — see below).
 
 Overview
 --------


### PR DESCRIPTION
Closes #382.

## What

Adds a `GEO_FORCE_OFFLINE` global kill-switch (default **off**) that suppresses the one intentional runtime egress — `ipinfo.io` geolocation enrichment — for strict air-gapped / egress-monitored deployments.

When `tracepcap.geo.force-offline=true`, `GeoIpService.isOnline()` short-circuits to `false` before any network call, so **both** the connectivity probe and every `ipinfo.io` lookup are skipped. Geo resolves exclusively from the bundled DB-IP Lite MMDB (`geo_source = mmdb`). `currentSource()` reports `mmdb` too, since it routes through `isOnline()`. Default behaviour (online probe + graceful MMDB fallback) is unchanged.

## Changes

- **`GeoIpService.java`** — `tracepcap.geo.force-offline` `@Value` + force-offline gate in `isOnline()` + a startup log line.
- **`application.yml`** — `geo.force-offline: ${GEO_FORCE_OFFLINE:false}`.
- **`docker-compose.yml`** — passthrough, default `false`.
- **`docker-compose.offline.yml`** — defaults to `true` for the air-gapped stack (overridable).
- **`.env.example`** — new "Geolocation Egress" block documenting the flag and the one intentional egress.
- **`docs/getting-started/offline-deployment.rst`** — "Suppressing Runtime Egress" section.

## Acceptance criteria

- [x] `GEO_FORCE_OFFLINE` flag, default off, that skips the probe + ipinfo.io lookups and resolves from the MMDB only (`geo_source = mmdb`).
- [x] When set, no outbound `ipinfo.io` connections attempted.
- [x] Documented the flag + the one intentional runtime egress in the offline checklist.

## Verification

Backend built cleanly. With `GEO_FORCE_OFFLINE=true`, startup logs:

> `GeoIP force-offline mode enabled (tracepcap.geo.force-offline=true) — no ipinfo.io egress will be attempted; resolving from bundled MMDB only`

With the flag off (default), no force-offline line and MMDB loads as fallback — both paths confirmed at runtime.

> Note: the issue referenced `docs/production-readiness.md` (finding P2-4), but that file isn't committed to the repo, so there was nothing to mark resolved there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline geolocation mode that uses the bundled database only and avoids external lookup attempts.
  * Added configuration options and deployment defaults for air-gapped environments.

* **Documentation**
  * Expanded offline deployment guidance with setup steps for forcing offline geolocation and setting the database path when needed.

* **Bug Fixes**
  * Improved geolocation behavior in restricted networks by preventing failed external connectivity checks and lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->