### PR TITLE
Paginate client-side list/table components (#475)

### DIFF
--- a/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Table } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
 import { Spinner } from '@components/common/Spinner/Spinner';
@@ -22,6 +22,12 @@ export function CaptureHistoryTable({ history, historyLoading, historyError, onC
   const [page, setPage] = useState(1);
   const totalPages = Math.ceil(history.length / PAGE_SIZE);
   const visible = history.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  // Keep the current page in range as the history data changes (e.g. entity switch/refetch).
+  useEffect(() => {
+    if (page > totalPages && totalPages > 0) setPage(totalPages);
+  }, [page, totalPages]);
+
   return (
     <div className="mt-4">
       <h6 className="text-muted fw-semibold mb-2">

--- a/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/CaptureHistoryTable.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { Table } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
 import { Spinner } from '@components/common/Spinner/Spinner';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import { useNavigate } from 'react-router-dom';
 import type { EntityHistoryEntry } from '@/features/notes/services/entityNotesService';
 import { formatBytes, formatNumber } from '../format';
@@ -12,9 +14,14 @@ interface CaptureHistoryTableProps {
   onClose: () => void;
 }
 
+const PAGE_SIZE = 10;
+
 /** Generic capture history: which uploaded files this entity appeared in. */
 export function CaptureHistoryTable({ history, historyLoading, historyError, onClose }: CaptureHistoryTableProps) {
   const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const totalPages = Math.ceil(history.length / PAGE_SIZE);
+  const visible = history.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
   return (
     <div className="mt-4">
       <h6 className="text-muted fw-semibold mb-2">
@@ -32,6 +39,7 @@ export function CaptureHistoryTable({ history, historyLoading, historyError, onC
         <p className="text-muted small fst-italic">Not seen in any uploaded files.</p>
       )}
       {!historyLoading && !historyError && history.length > 0 && (
+        <>
         <div className="rounded border overflow-hidden">
           <Table size="sm" hover responsive className="mb-0">
             <Table.Header className="table-light" style={{ fontSize: '0.8rem' }}>
@@ -43,7 +51,7 @@ export function CaptureHistoryTable({ history, historyLoading, historyError, onC
               </Table.Row>
             </Table.Header>
             <Table.Body>
-              {history.map(entry => (
+              {visible.map(entry => (
                 <Table.Row
                   key={entry.fileId}
                   style={{ cursor: 'pointer' }}
@@ -74,6 +82,17 @@ export function CaptureHistoryTable({ history, historyLoading, historyError, onC
             </Table.Body>
           </Table>
         </div>
+        {totalPages > 1 && (
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            totalItems={history.length}
+            pageSize={PAGE_SIZE}
+            onPageChange={setPage}
+            showPageSizeSelector={false}
+          />
+        )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/intelligence/TopHostsTable/TopHostsTable.tsx
+++ b/frontend/src/components/intelligence/TopHostsTable/TopHostsTable.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Badge, Button } from '@govtechsg/sgds-react';
 import { Pagination } from '@components/common/Pagination/Pagination';
 import { formatBytes } from '@/utils/formatters';
@@ -62,6 +62,11 @@ export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHos
   const pageSize = 20;
   const totalPages = Math.ceil(hosts.length / pageSize);
   const visible = hosts.slice((page - 1) * pageSize, page * pageSize);
+
+  // Keep the current page in range as the hosts list changes (e.g. re-sort/refetch).
+  useEffect(() => {
+    if (page > totalPages && totalPages > 0) setPage(totalPages);
+  }, [page, totalPages]);
 
   return (
     <div>

--- a/frontend/src/components/intelligence/TopHostsTable/TopHostsTable.tsx
+++ b/frontend/src/components/intelligence/TopHostsTable/TopHostsTable.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState } from 'react';
 import { Badge, Button } from '@govtechsg/sgds-react';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import { formatBytes } from '@/utils/formatters';
 import { HostnameSourceBadge } from '@components/common/HostnameSourceBadge/HostnameSourceBadge';
 import type { HostSummary, SortBy } from '@/features/intelligence/services/intelligenceService';
@@ -56,10 +57,11 @@ const SORT_OPTIONS: { value: SortBy; label: string }[] = [
 ];
 
 export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHostsTableProps) => {
-  const [page, setPage] = useState(0);
+  // 1-indexed to match the shared Pagination component.
+  const [page, setPage] = useState(1);
   const pageSize = 20;
   const totalPages = Math.ceil(hosts.length / pageSize);
-  const visible = hosts.slice(page * pageSize, (page + 1) * pageSize);
+  const visible = hosts.slice((page - 1) * pageSize, page * pageSize);
 
   return (
     <div>
@@ -71,7 +73,7 @@ export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHos
               key={o.value}
               size="sm"
               variant={sortBy === o.value ? 'primary' : 'outline-secondary'}
-              onClick={() => { onSortByChange(o.value); setPage(0); }}
+              onClick={() => { onSortByChange(o.value); setPage(1); }}
               disabled={loading}
             >
               {o.label}
@@ -99,7 +101,7 @@ export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHos
           <tbody>
             {visible.map((host, i) => (
               <tr key={host.ip}>
-                <td className="text-muted">{page * pageSize + i + 1}</td>
+                <td className="text-muted">{(page - 1) * pageSize + i + 1}</td>
                 <td>
                   {host.hostname ? (
                     <>
@@ -171,25 +173,14 @@ export const TopHostsTable = ({ hosts, loading, sortBy, onSortByChange }: TopHos
       </div>
 
       {totalPages > 1 && (
-        <div className="d-flex align-items-center gap-2 mt-2">
-          <Button
-            size="sm"
-            variant="outline-secondary"
-            onClick={() => setPage(p => p - 1)}
-            disabled={page === 0}
-          >
-            ‹ Prev
-          </Button>
-          <small className="text-muted">Page {page + 1} / {totalPages}</small>
-          <Button
-            size="sm"
-            variant="outline-secondary"
-            onClick={() => setPage(p => p + 1)}
-            disabled={page >= totalPages - 1}
-          >
-            Next ›
-          </Button>
-        </div>
+        <Pagination
+          currentPage={page}
+          totalPages={totalPages}
+          totalItems={hosts.length}
+          pageSize={pageSize}
+          onPageChange={setPage}
+          showPageSizeSelector={false}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/monitor/BaselineDefinitionPanel/BaselineDefinitionPanel.tsx
+++ b/frontend/src/components/monitor/BaselineDefinitionPanel/BaselineDefinitionPanel.tsx
@@ -1,7 +1,8 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Badge, Button, Form } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import type {
   BaselineDefinition,
   BaselineEntryType,
@@ -88,6 +89,16 @@ export const BaselineDefinitionPanel = ({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  const PAGE_SIZE = 10;
+  const totalPages = Math.ceil(definitions.length / PAGE_SIZE);
+  const visibleDefinitions = definitions.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  // Keep the current page in range as entries are added/removed.
+  useEffect(() => {
+    if (page > totalPages && totalPages > 0) setPage(totalPages);
+  }, [page, totalPages]);
 
   const handleAdd = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -137,7 +148,7 @@ export const BaselineDefinitionPanel = ({
               </tr>
             </thead>
             <tbody>
-              {definitions.map(def => (
+              {visibleDefinitions.map(def => (
                 <tr key={def.id}>
                   <td>
                     <Badge bg="light" text="dark" className="border">
@@ -173,6 +184,16 @@ export const BaselineDefinitionPanel = ({
               ))}
             </tbody>
           </table>
+          {totalPages > 1 && (
+            <Pagination
+              currentPage={page}
+              totalPages={totalPages}
+              totalItems={definitions.length}
+              pageSize={PAGE_SIZE}
+              onPageChange={setPage}
+              showPageSizeSelector={false}
+            />
+          )}
         </div>
       )}
 

--- a/frontend/src/components/monitor/ExternalEventsPanel/ExternalEventsPanel.tsx
+++ b/frontend/src/components/monitor/ExternalEventsPanel/ExternalEventsPanel.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Form } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
 import { Spinner } from '@components/common/Spinner/Spinner';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import { apiClient } from '@/services/api/client';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
 import type { NetworkExternalEvent } from '@/features/insights/types/insights.types';
@@ -30,6 +31,16 @@ export const ExternalEventsPanel = ({ events, onAdd, onUpdate, onDelete }: Exter
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  const PAGE_SIZE = 10;
+  const totalPages = Math.ceil(events.length / PAGE_SIZE);
+  const visibleEvents = events.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  // Keep the current page in range as events are added/removed.
+  useEffect(() => {
+    if (page > totalPages && totalPages > 0) setPage(totalPages);
+  }, [page, totalPages]);
 
   const resetForm = () => {
     setEditingId(null);
@@ -112,7 +123,7 @@ export const ExternalEventsPanel = ({ events, onAdd, onUpdate, onDelete }: Exter
               </tr>
             </thead>
             <tbody>
-              {events.map(ev => (
+              {visibleEvents.map(ev => (
                 <tr key={ev.id}>
                   <td className="text-nowrap small text-muted">
                     {new Date(ev.eventTime).toLocaleString('en-GB')}
@@ -152,6 +163,16 @@ export const ExternalEventsPanel = ({ events, onAdd, onUpdate, onDelete }: Exter
               ))}
             </tbody>
           </table>
+          {totalPages > 1 && (
+            <Pagination
+              currentPage={page}
+              totalPages={totalPages}
+              totalItems={events.length}
+              pageSize={PAGE_SIZE}
+              onPageChange={setPage}
+              showPageSizeSelector={false}
+            />
+          )}
         </div>
       )}
 

--- a/frontend/src/components/monitor/NetworkAnnotationsPanel/NetworkAnnotationsPanel.tsx
+++ b/frontend/src/components/monitor/NetworkAnnotationsPanel/NetworkAnnotationsPanel.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
 import { Spinner } from '@components/common/Spinner/Spinner';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import type { NetworkAnnotation } from '@/features/insights/types/insights.types';
 
 interface NetworkAnnotationsPanelProps {
@@ -98,6 +99,16 @@ export const NetworkAnnotationsPanel = ({
   const [body, setBody] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  const PAGE_SIZE = 10;
+  const totalPages = Math.ceil(annotations.length / PAGE_SIZE);
+  const visibleAnnotations = annotations.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  // Keep the current page in range as annotations are added/removed.
+  useEffect(() => {
+    if (page > totalPages && totalPages > 0) setPage(totalPages);
+  }, [page, totalPages]);
 
   const handleAdd = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -125,7 +136,7 @@ export const NetworkAnnotationsPanel = ({
 
       {annotations.length > 0 && (
         <div className="mb-3">
-          {annotations.map(a => (
+          {visibleAnnotations.map(a => (
             <AnnotationRow
               key={a.id}
               annotation={a}
@@ -133,6 +144,16 @@ export const NetworkAnnotationsPanel = ({
               onDelete={onDelete}
             />
           ))}
+          {totalPages > 1 && (
+            <Pagination
+              currentPage={page}
+              totalPages={totalPages}
+              totalItems={annotations.length}
+              pageSize={PAGE_SIZE}
+              onPageChange={setPage}
+              showPageSizeSelector={false}
+            />
+          )}
         </div>
       )}
 

--- a/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
+++ b/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import type { GraphEdge } from '@/features/network/types';
 
 /**
@@ -65,6 +66,97 @@ function aggregate(edges: GraphEdge[], pick: (e: GraphEdge) => string[] | undefi
       flows: [...flows.values()].sort((a, b) => a.label.localeCompare(b.label)),
     }))
     .sort((a, b) => b.flows.length - a.flows.length || a.value.localeCompare(b.value));
+}
+
+const SECTION_PAGE_SIZE = 10;
+
+/**
+ * One signal section (IDS / risks / signatures / files) with its own pagination — each has an
+ * independent row count, so they page separately.
+ */
+function SignalSectionView({
+  section,
+  buildUrl,
+}: {
+  section: SignalSection;
+  buildUrl: (param: FilterParam, value: string, ip?: string) => string;
+}) {
+  const [page, setPage] = useState(1);
+  const totalPages = Math.ceil(section.rows.length / SECTION_PAGE_SIZE);
+  const visibleRows = section.rows.slice((page - 1) * SECTION_PAGE_SIZE, page * SECTION_PAGE_SIZE);
+
+  return (
+    <div className="mb-4">
+      <div className="d-flex align-items-center gap-2 mb-1">
+        <i className={`bi ${section.icon}`} style={{ color: SEVERITY_COLOR[section.severity] }} />
+        <span className="fw-semibold">{section.title}</span>
+        <span
+          className="badge rounded-pill"
+          style={{ fontSize: '0.7rem', background: SEVERITY_COLOR[section.severity], color: '#fff' }}
+        >
+          {section.rows.length}
+        </span>
+      </div>
+      <p className="text-muted mb-2" style={{ fontSize: '0.78rem' }}>{section.blurb}</p>
+      {section.rows.length === 0 ? (
+        <p className="text-muted small mb-0 ps-1">None detected.</p>
+      ) : (
+        <>
+          <div className="table-responsive">
+            <table className="table table-sm table-bordered mb-0" style={{ fontSize: '0.82rem' }}>
+              <thead className="table-light">
+                <tr>
+                  <th style={{ width: '55%' }}>{section.title === 'Detected File Types' ? 'File type' : 'Signal'}</th>
+                  <th>Flows</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleRows.map(row => (
+                  <tr key={row.value}>
+                    <td className="font-monospace" style={{ wordBreak: 'break-word' }}>
+                      <a
+                        href={buildUrl(section.filterParam, row.value)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="Open matching conversations in analysis mode"
+                      >
+                        {row.value}
+                      </a>
+                    </td>
+                    <td>
+                      {row.flows.map(f => (
+                        <div key={f.label} className="font-monospace" style={{ fontSize: '0.76rem' }}>
+                          <a
+                            href={buildUrl(section.filterParam, row.value, f.src)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-muted"
+                            title={`Open conversations for this signal involving ${f.src}`}
+                          >
+                            {f.label}
+                          </a>
+                        </div>
+                      ))}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {totalPages > 1 && (
+            <Pagination
+              currentPage={page}
+              totalPages={totalPages}
+              totalItems={section.rows.length}
+              pageSize={SECTION_PAGE_SIZE}
+              onPageChange={setPage}
+              showPageSizeSelector={false}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
 }
 
 interface SnapshotSecurityTabProps {
@@ -157,64 +249,7 @@ export const SnapshotSecurityTab = ({ edges, loading, fileId }: SnapshotSecurity
         filter by that host.
       </p>
       {sections.map(section => (
-        <div key={section.key} className="mb-4">
-          <div className="d-flex align-items-center gap-2 mb-1">
-            <i className={`bi ${section.icon}`} style={{ color: SEVERITY_COLOR[section.severity] }} />
-            <span className="fw-semibold">{section.title}</span>
-            <span
-              className="badge rounded-pill"
-              style={{ fontSize: '0.7rem', background: SEVERITY_COLOR[section.severity], color: '#fff' }}
-            >
-              {section.rows.length}
-            </span>
-          </div>
-          <p className="text-muted mb-2" style={{ fontSize: '0.78rem' }}>{section.blurb}</p>
-          {section.rows.length === 0 ? (
-            <p className="text-muted small mb-0 ps-1">None detected.</p>
-          ) : (
-            <div className="table-responsive">
-              <table className="table table-sm table-bordered mb-0" style={{ fontSize: '0.82rem' }}>
-                <thead className="table-light">
-                  <tr>
-                    <th style={{ width: '55%' }}>{section.title === 'Detected File Types' ? 'File type' : 'Signal'}</th>
-                    <th>Flows</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {section.rows.map(row => (
-                    <tr key={row.value}>
-                      <td className="font-monospace" style={{ wordBreak: 'break-word' }}>
-                        <a
-                          href={buildUrl(section.filterParam, row.value)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          title="Open matching conversations in analysis mode"
-                        >
-                          {row.value}
-                        </a>
-                      </td>
-                      <td>
-                        {row.flows.map(f => (
-                          <div key={f.label} className="font-monospace" style={{ fontSize: '0.76rem' }}>
-                            <a
-                              href={buildUrl(section.filterParam, row.value, f.src)}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-muted"
-                              title={`Open conversations for this signal involving ${f.src}`}
-                            >
-                              {f.label}
-                            </a>
-                          </div>
-                        ))}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
+        <SignalSectionView key={section.key} section={section} buildUrl={buildUrl} />
       ))}
     </div>
   );

--- a/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
+++ b/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Pagination } from '@components/common/Pagination/Pagination';
 import type { GraphEdge } from '@/features/network/types';
 
@@ -84,6 +84,11 @@ function SignalSectionView({
   const [page, setPage] = useState(1);
   const totalPages = Math.ceil(section.rows.length / SECTION_PAGE_SIZE);
   const visibleRows = section.rows.slice((page - 1) * SECTION_PAGE_SIZE, page * SECTION_PAGE_SIZE);
+
+  // Keep the current page in range as the section rows change (e.g. edges refetch).
+  useEffect(() => {
+    if (page > totalPages && totalPages > 0) setPage(totalPages);
+  }, [page, totalPages]);
 
   return (
     <div className="mb-4">

--- a/frontend/src/components/monitor/SubnetsPanel/SubnetsPanel.tsx
+++ b/frontend/src/components/monitor/SubnetsPanel/SubnetsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Badge, Button, Form } from '@govtechsg/sgds-react';
 import { Spinner } from '@components/common/Spinner/Spinner';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import { SubnetDiagramModal } from '@components/monitor/SubnetDiagramModal/SubnetDiagramModal';
 import { SubnetDetailModal } from '@components/monitor/SubnetsPanel/SubnetDetailModal';
 import { subnetService } from '@/features/subnets/services/subnetService';
@@ -33,6 +34,10 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
   const [candidates, setCandidates] = useState<SubnetDefinition[]>([]);
   const [savingCidr, setSavingCidr] = useState<string | null>(null);
 
+  const [subnetsPage, setSubnetsPage] = useState(1);
+  const [candidatesPage, setCandidatesPage] = useState(1);
+  const PAGE_SIZE = 10;
+
   // Overlap warnings keyed by subnet id (gateway IP answered by >1 MAC → possible overlapping nets).
   const [overlaps, setOverlaps] = useState<Record<number, SubnetOverlapWarning>>({});
   // Stable signature of the subnet definitions so overlap badges refetch on any add/delete/CIDR
@@ -50,6 +55,19 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
   }, [networkId, snapshots.length, subnetsKey]);
 
   const sortedSnapshots = [...snapshots].sort((a, b) => a.snapshotOrder - b.snapshotOrder);
+
+  const subnetsTotalPages = Math.ceil(subnets.length / PAGE_SIZE);
+  const visibleSubnets = subnets.slice((subnetsPage - 1) * PAGE_SIZE, subnetsPage * PAGE_SIZE);
+  const candidatesTotalPages = Math.ceil(candidates.length / PAGE_SIZE);
+  const visibleCandidates = candidates.slice((candidatesPage - 1) * PAGE_SIZE, candidatesPage * PAGE_SIZE);
+
+  // Keep pages in range as subnets/candidates are added or removed.
+  useEffect(() => {
+    if (subnetsPage > subnetsTotalPages && subnetsTotalPages > 0) setSubnetsPage(subnetsTotalPages);
+  }, [subnetsPage, subnetsTotalPages]);
+  useEffect(() => {
+    if (candidatesPage > candidatesTotalPages && candidatesTotalPages > 0) setCandidatesPage(candidatesTotalPages);
+  }, [candidatesPage, candidatesTotalPages]);
 
   const handleAdd = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -130,7 +148,7 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
               </tr>
             </thead>
             <tbody>
-              {subnets.map(subnet => {
+              {visibleSubnets.map(subnet => {
                 const warning = subnet.id !== null ? overlaps[subnet.id] : undefined;
                 return (
                 <tr
@@ -199,6 +217,16 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
               })}
             </tbody>
           </table>
+          {subnetsTotalPages > 1 && (
+            <Pagination
+              currentPage={subnetsPage}
+              totalPages={subnetsTotalPages}
+              totalItems={subnets.length}
+              pageSize={PAGE_SIZE}
+              onPageChange={setSubnetsPage}
+              showPageSizeSelector={false}
+            />
+          )}
         </div>
       )}
 
@@ -227,7 +255,7 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
                 </tr>
               </thead>
               <tbody>
-                {candidates.map(c => (
+                {visibleCandidates.map(c => (
                   <tr key={c.cidr}>
                     <td className="font-monospace small">{c.cidr}</td>
                     <td className="small text-muted">{c.hostCount ?? '—'}</td>
@@ -270,6 +298,16 @@ export const SubnetsPanel = ({ networkId, subnets, snapshots, onSaved, onDeleted
               </tbody>
             </table>
           </div>
+          {candidatesTotalPages > 1 && (
+            <Pagination
+              currentPage={candidatesPage}
+              totalPages={candidatesTotalPages}
+              totalItems={candidates.length}
+              pageSize={PAGE_SIZE}
+              onPageChange={setCandidatesPage}
+              showPageSizeSelector={false}
+            />
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Part of #475 — the **client-side batch** (fix-shape 1). Adds the shared `common/Pagination` component to list/table components that rendered unbounded, data-driven collections all at once, and migrates the one component with a hand-rolled pager to the shared control.

## Changes

**Paginated (client-side, `PAGE_SIZE` 10, no page-size selector):**
- `CaptureHistoryTable`
- `ExternalEventsPanel`
- `NetworkAnnotationsPanel`
- `BaselineDefinitionPanel`
- `SubnetsPanel` — saved-subnets and detection-candidates tables get independent pagers
- `SnapshotSecurityTab` — each signal section (IDS / risks / signatures / files) paginates independently (extracted a `SignalSectionView` sub-component)

**Migrated hand-rolled pager → shared component:**
- `TopHostsTable` — replaced the custom Prev/Next + "Page X / Y" with `common/Pagination`; switched internal paging from 0-indexed to 1-indexed to match the shared API.

## Out of scope (tracked in #475 / #476)
- `ConversationList` — needs server-side paging (touches the parent page's fetch/state); separate PR.
- Drift panels (`IpDriftPanel`/`ProtocolDriftPanel`/`DeviceDriftPanel`) and `FileList` — blocked on #476 (they fetch with hard `pageSize` caps that *truncate*; client-side paging over a truncated array would be wrong).

## Verification
- `npx tsc --noEmit` clean (run from `frontend/`).
- `docker compose up -d --build` succeeds; all services healthy.
- Playwright against the live app (monitor network with 7 snapshots + a 174-item list): all six changed panels render with **zero console errors**; the shared pager pages interactively (verified "Showing 1 to 10 of 174" → "Showing 11 to 20 of 174" on click). Under-threshold panels (e.g. Subnet Definitions with 4 rows) correctly render no pager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)