### PR TITLE
Paginate the extracted-files table (#478)

### DIFF
--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -295,7 +295,13 @@ export const ExtractedFilesPage = () => {
   const sorted = sortFiles(filtered, sortBy, sortDir);
 
   const totalPages = Math.ceil(sorted.length / pageSize);
-  const paginated = sorted.slice((page - 1) * pageSize, page * pageSize);
+  // Clamp during render so a shrunk list (e.g. after applying a filter) can't leave `page`
+  // out of bounds — and thus the table briefly empty — before the reset effect runs.
+  const currentPage = Math.min(page, Math.max(1, totalPages));
+  const paginated = sorted.slice((currentPage - 1) * pageSize, currentPage * pageSize);
+  // Keep the pager (and its page-size selector) reachable whenever the unpaged list would
+  // exceed the smallest page-size option, so bumping the size to one page can't strand the user.
+  const showPagination = sorted.length > 10;
 
   return (
     <div>
@@ -597,10 +603,10 @@ export const ExtractedFilesPage = () => {
               </table>
             </ScrollableTable>
           )}
-          {totalPages > 1 && (
+          {showPagination && (
             <div className="p-2 border-top">
               <Pagination
-                currentPage={page}
+                currentPage={currentPage}
                 totalPages={totalPages}
                 totalItems={sorted.length}
                 pageSize={pageSize}

--- a/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
+++ b/frontend/src/pages/ExtractedFiles/ExtractedFilesPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '@features/extractedFiles/services/extractedFilesService';
 import { LoadingSpinner } from '@components/common/LoadingSpinner';
 import { ErrorMessage } from '@components/common/ErrorMessage';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import { ScrollableTable } from '@components/common/ScrollableTable';
 import { PillSectionHeader } from '@components/common/PillSectionHeader/PillSectionHeader';
 import { Badge, Button, Card, Modal } from '@govtechsg/sgds-react';
@@ -210,12 +211,20 @@ export const ExtractedFilesPage = () => {
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [mimeTypeFilter, setMimeTypeFilter] = useState<string[]>([]);
   const [filterOpen, setFilterOpen] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
 
   const allMimeTypes = useMemo(
     () =>
       [...new Set(files.map(f => f.mimeType).filter((m): m is string => m !== null))].sort(),
     [files]
   );
+
+  // Reset to the first page whenever the filter/sort changes the result set, so the current
+  // page can't fall out of range when the list shrinks.
+  useEffect(() => {
+    setPage(1);
+  }, [mimeTypeFilter, sortBy, sortDir, pageSize, fileId]);
 
   useEffect(() => {
     setLoading(true);
@@ -284,6 +293,9 @@ export const ExtractedFilesPage = () => {
       ? files.filter(f => f.mimeType !== null && mimeTypeFilter.includes(f.mimeType))
       : files;
   const sorted = sortFiles(filtered, sortBy, sortDir);
+
+  const totalPages = Math.ceil(sorted.length / pageSize);
+  const paginated = sorted.slice((page - 1) * pageSize, page * pageSize);
 
   return (
     <div>
@@ -487,7 +499,7 @@ export const ExtractedFilesPage = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {sorted.map(file => {
+                  {paginated.map(file => {
                     const isSkipped = file.skippedReason != null;
                     return (
                     <tr key={file.id} className={isSkipped ? 'text-muted' : undefined}>
@@ -584,6 +596,18 @@ export const ExtractedFilesPage = () => {
                 </tbody>
               </table>
             </ScrollableTable>
+          )}
+          {totalPages > 1 && (
+            <div className="p-2 border-top">
+              <Pagination
+                currentPage={page}
+                totalPages={totalPages}
+                totalItems={sorted.length}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={ps => { setPageSize(ps); setPage(1); }}
+              />
+            </div>
           )}
         </Card.Body>
       </Card>


### PR DESCRIPTION
Closes #478.

`ExtractedFilesPage` fetched all carved files (`getExtractedFiles(fileId)` → `files`) and rendered every row via `sorted.map(...)` with no pagination. A busy capture can carve thousands of files, all in the DOM at once. Found in a follow-up sweep after #475 — this page wasn't in the original candidate list.

## Change
- Added client-side pagination with the shared `common/Pagination` component (default page size 25, **with** page-size selector — the extracted-files list can be large).
- Pages over the already-sorted/MIME-filtered array, so sort + filter still work.
- Resets to page 1 whenever the sort/filter/page-size changes, so the page can't fall out of range when the list shrinks.

## Not blocked on #476
Unlike `FileList`/drift panels, the extractions fetch has no hard `pageSize` cap — the frontend already has the full list, so this is a pure client-side fix (same shape as #477).

## Verification
- `tsc --noEmit` clean; `docker compose up -d --build` succeeds.
- Playwright on a capture with 29 extractions: page 1 shows **25 rows** ("Showing 1 to 25 of 29 items"), clicking page 2 shows the remaining **4** ("Showing 26 to 29 of 29 items"). Zero console errors; sort headers, MIME filter, and page-size selector all render.

_(Aside: this capture also surfaces an "Extraction may be incomplete" banner — that's a **backend** extraction cap, already surfaced to the user, out of scope for this UI change.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination to the extracted files table.
  * Users can now change pages and adjust how many results are shown per page.

* **Bug Fixes**
  * The current page now resets when filters, sorting, page size, or the selected file changes.
  * Page numbers are kept within valid bounds when the result count changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->