### PR TITLE
Server-side distinct IP/app/protocol endpoints for drift panels (#476)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
@@ -246,6 +246,35 @@ public interface ConversationRepository
   List<String> findDistinctRiskTypesByFileId(@Param("fileId") UUID fileId);
 
   /**
+   * Distinct IP addresses (both source and destination) seen in a file's conversations. Computed
+   * server-side so callers that only need the IP set — e.g. the monitor IP-drift panel — never pull
+   * the full conversation rows (which previously truncated at a fixed pageSize cap).
+   */
+  @Query(
+      value =
+          "SELECT DISTINCT ip FROM ("
+              + "  SELECT src_ip AS ip FROM conversations WHERE file_id = :fileId AND src_ip IS NOT NULL"
+              + "  UNION"
+              + "  SELECT dst_ip AS ip FROM conversations WHERE file_id = :fileId AND dst_ip IS NOT NULL"
+              + ") ips ORDER BY ip",
+      nativeQuery = true)
+  List<String> findDistinctIpsByFileId(@Param("fileId") UUID fileId);
+
+  /** Distinct application names present in a file's conversations. */
+  @Query(
+      "SELECT DISTINCT c.appName FROM ConversationEntity c"
+          + " WHERE c.file.id = :fileId AND c.appName IS NOT NULL AND c.appName <> ''"
+          + " ORDER BY c.appName")
+  List<String> findDistinctAppNamesByFileId(@Param("fileId") UUID fileId);
+
+  /** Distinct L7 (tshark) protocol names present in a file's conversations. */
+  @Query(
+      "SELECT DISTINCT c.tsharkProtocol FROM ConversationEntity c"
+          + " WHERE c.file.id = :fileId AND c.tsharkProtocol IS NOT NULL AND c.tsharkProtocol <> ''"
+          + " ORDER BY c.tsharkProtocol")
+  List<String> findDistinctProtocolsByFileId(@Param("fileId") UUID fileId);
+
+  /**
    * For each distinct risk type in the file, returns aggregate stats: [risk_type,
    * conversation_count, total_bytes, distinct_src_ips, distinct_dst_ips]. Used to build risk-type
    * cluster summaries for the story prompt.

--- a/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/ConversationRepository.java
@@ -254,7 +254,9 @@ public interface ConversationRepository
       value =
           "SELECT DISTINCT ip FROM ("
               + "  SELECT src_ip AS ip FROM conversations WHERE file_id = :fileId AND src_ip IS NOT NULL"
-              + "  UNION"
+              // UNION ALL (not UNION): the outer SELECT DISTINCT already dedups, so the inner
+              // set-union's implicit dedup would be redundant work.
+              + "  UNION ALL"
               + "  SELECT dst_ip AS ip FROM conversations WHERE file_id = :fileId AND dst_ip IS NOT NULL"
               + ") ips ORDER BY ip",
       nativeQuery = true)

--- a/backend/src/main/java/com/tracepcap/conversation/controller/ConversationsController.java
+++ b/backend/src/main/java/com/tracepcap/conversation/controller/ConversationsController.java
@@ -205,6 +205,31 @@ public class ConversationsController {
     return ResponseEntity.ok(conversationQueryService.getDistinctCountries(fileId));
   }
 
+  /**
+   * Returns the distinct IP addresses (src and dst) seen in this file's conversations. Computed
+   * server-side so the monitor IP-drift panel no longer pulls every conversation row (which
+   * truncated at a fixed pageSize cap) just to derive the address set.
+   */
+  @GetMapping("/{fileId}/distinct-ips")
+  @Operation(summary = "List distinct IP addresses (src and dst) for a file")
+  public ResponseEntity<List<String>> getDistinctIps(@PathVariable UUID fileId) {
+    return ResponseEntity.ok(conversationQueryService.getDistinctIps(fileId));
+  }
+
+  /** Returns the distinct application names present in this file's conversations. */
+  @GetMapping("/{fileId}/distinct-apps")
+  @Operation(summary = "List distinct application names for a file")
+  public ResponseEntity<List<String>> getDistinctApps(@PathVariable UUID fileId) {
+    return ResponseEntity.ok(conversationQueryService.getDistinctApps(fileId));
+  }
+
+  /** Returns the distinct L7 (tshark) protocol names present in this file's conversations. */
+  @GetMapping("/{fileId}/distinct-protocols")
+  @Operation(summary = "List distinct L7 protocol names for a file")
+  public ResponseEntity<List<String>> getDistinctProtocols(@PathVariable UUID fileId) {
+    return ResponseEntity.ok(conversationQueryService.getDistinctProtocols(fileId));
+  }
+
   /** Export all matching conversations as CSV (no pagination, same filters as listing) */
   @GetMapping("/{fileId}/export")
   @Operation(summary = "Export filtered conversations as CSV")

--- a/backend/src/main/java/com/tracepcap/conversation/service/ConversationQueryService.java
+++ b/backend/src/main/java/com/tracepcap/conversation/service/ConversationQueryService.java
@@ -157,6 +157,24 @@ public class ConversationQueryService {
     return conversationRepository.findDistinctSuricataAlertsByFileId(fileId);
   }
 
+  /** Returns distinct IP addresses (src and dst) seen in this file's conversations. */
+  @Transactional(readOnly = true)
+  public List<String> getDistinctIps(UUID fileId) {
+    return conversationRepository.findDistinctIpsByFileId(fileId);
+  }
+
+  /** Returns distinct application names present in this file's conversations. */
+  @Transactional(readOnly = true)
+  public List<String> getDistinctApps(UUID fileId) {
+    return conversationRepository.findDistinctAppNamesByFileId(fileId);
+  }
+
+  /** Returns distinct L7 (tshark) protocol names present in this file's conversations. */
+  @Transactional(readOnly = true)
+  public List<String> getDistinctProtocols(UUID fileId) {
+    return conversationRepository.findDistinctProtocolsByFileId(fileId);
+  }
+
   /**
    * Returns distinct country codes seen in this file's conversations, as "CC|Country name" strings
    * (e.g. "US|United States"). Only countries with a non-null country code are returned.

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -2,6 +2,7 @@ import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, type CSSProperties } from 'react';
 import { Button } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
+import { API_ENDPOINTS } from '@/services/api/endpoints';
 import type { NetworkSnapshot, AbsentEntity } from '@/features/monitor/types/monitor.types';
 import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
 import { customPrivateRangeService } from '@/features/intelligence/services/customPrivateRangeService';
@@ -19,15 +20,6 @@ type EntityGroup = {
   active: string[];
   absent: AbsentEntity[];
 };
-
-interface ConversationSummary {
-  srcIp: string;
-  dstIp: string;
-}
-
-interface ConversationsResponse {
-  data: ConversationSummary[];
-}
 
 function isRfc1918(ip: string): boolean {
   return /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|169\.254\.|f[cd][0-9a-f]{2}:|fe80:)/i.test(ip);
@@ -298,15 +290,10 @@ export const IpDriftPanel = ({ snapshots, subnets = [] }: IpDriftPanelProps) => 
     Promise.all(
       sorted.map(snap =>
         apiClient
-          .get<ConversationsResponse>(`/conversations/${snap.fileId}?pageSize=10000`)
-          .then(r => {
-            const ips = new Set<string>();
-            for (const c of r.data.data) {
-              if (c.srcIp) ips.add(c.srcIp);
-              if (c.dstIp) ips.add(c.dstIp);
-            }
-            return { snap, ips };
-          })
+          // Distinct IPs are computed server-side, so we no longer pull every conversation row
+          // (which truncated at the backend's pageSize cap and dropped IPs on busy snapshots).
+          .get<string[]>(API_ENDPOINTS.DISTINCT_IPS(snap.fileId))
+          .then(r => ({ snap, ips: new Set(r.data) }))
           .catch(() => ({ snap, ips: new Set<string>() }))
       )
     ).then(results => {

--- a/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
+++ b/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
@@ -2,6 +2,7 @@ import { Spinner } from '@components/common/Spinner/Spinner';
 import { useState, useEffect, type CSSProperties } from 'react';
 import { Button } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
+import { API_ENDPOINTS } from '@/services/api/endpoints';
 import type {
   NetworkSnapshot,
   AbsentEntity,
@@ -33,15 +34,6 @@ type EntityGroup = {
   active: string[];
   absent: AbsentEntity[];
 };
-
-interface ConversationSummary {
-  appName: string | null;
-  tsharkProtocol: string | null;
-}
-
-interface ConversationsResponse {
-  data: ConversationSummary[];
-}
 
 function BadgeGroup({
   items,
@@ -108,12 +100,16 @@ export const ProtocolDriftPanel = ({ snapshots }: ProtocolDriftPanelProps) => {
     setLoading(true);
     Promise.all(
       sorted.map(snap =>
-        apiClient
-          .get<ConversationsResponse>(`/conversations/${snap.fileId}?pageSize=10000`)
-          .then(r => ({
+        // Distinct apps/protocols are computed server-side, so we no longer pull every conversation
+        // row (which truncated at the backend's pageSize cap on busy snapshots).
+        Promise.all([
+          apiClient.get<string[]>(API_ENDPOINTS.DISTINCT_APPS(snap.fileId)).then(r => r.data),
+          apiClient.get<string[]>(API_ENDPOINTS.DISTINCT_PROTOCOLS(snap.fileId)).then(r => r.data),
+        ])
+          .then(([apps, protos]) => ({
             snap,
-            apps: new Set(r.data.data.map(c => c.appName).filter(Boolean) as string[]),
-            protos: new Set(r.data.data.map(c => c.tsharkProtocol).filter(Boolean) as string[]),
+            apps: new Set(apps),
+            protos: new Set(protos),
           }))
           .catch(() => ({ snap, apps: new Set<string>(), protos: new Set<string>() }))
       )

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -22,6 +22,9 @@ export const API_ENDPOINTS = {
   CONVERSATION_DETAIL: (conversationId: string) => `/conversations/detail/${conversationId}`,
   SECURITY_ALERTS: (fileId: string) => `/files/${fileId}/security-alerts`,
   RISK_TYPES: (fileId: string) => `/conversations/${fileId}/risk-types`,
+  DISTINCT_IPS: (fileId: string) => `/conversations/${fileId}/distinct-ips`,
+  DISTINCT_APPS: (fileId: string) => `/conversations/${fileId}/distinct-apps`,
+  DISTINCT_PROTOCOLS: (fileId: string) => `/conversations/${fileId}/distinct-protocols`,
 
   // Timeline (Not yet implemented in backend)
   TIMELINE_DATA: (fileId: string) => `/timeline/${fileId}`,

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -3689,6 +3689,111 @@
         ]
       }
     },
+    "/api/v1/conversations/{fileId}/distinct-apps": {
+      "get": {
+        "operationId": "getDistinctApps",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List distinct application names for a file",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/api/v1/conversations/{fileId}/distinct-ips": {
+      "get": {
+        "operationId": "getDistinctIps",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List distinct IP addresses (src and dst) for a file",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
+    "/api/v1/conversations/{fileId}/distinct-protocols": {
+      "get": {
+        "operationId": "getDistinctProtocols",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List distinct L7 protocol names for a file",
+        "tags": [
+          "Conversations"
+        ]
+      }
+    },
     "/api/v1/conversations/{fileId}/entity-stats": {
       "get": {
         "operationId": "getEntityStats",


### PR DESCRIPTION
Part of #476 — the **drift-panel** half (the `FileList` server-side paging piece is a separate follow-up per the issue's two-part split).

## Problem
`IpDriftPanel` and `ProtocolDriftPanel` derived their distinct entity sets by fetching **every conversation row per snapshot** at `?pageSize=10000` and deduping client-side. The backend caps `pageSize` at 10000 (`ConversationsController`), so on a busy snapshot this silently dropped IPs/apps/protocols beyond the cap — truncation, not pagination. Paging a truncated array (the #475 approach) couldn't fix this; the data has to come complete from the backend.

## Change
Three server-side distinct-facet endpoints, mirroring the existing `/risk-types`, `/countries`, etc. pattern (repo `@Query` → service `getDistinct*` → controller `List<String>`):
- `GET /conversations/{fileId}/distinct-ips` — `src ∪ dst`, sorted
- `GET /conversations/{fileId}/distinct-apps`
- `GET /conversations/{fileId}/distinct-protocols`

Each is a `DISTINCT` query — **correct** (no cap) and far cheaper than transferring up to 10k conversation rows to extract a small set. Rewired both panels to call them and dropped the now-unused `ConversationSummary`/`ConversationsResponse` types.

`DeviceDriftPanel` is unaffected — it reads the uncapped `host-classifications` endpoint, not the conversation fetch.

## Verification
- `docker compose build backend` + full `up -d --build` succeed; `tsc --noEmit` clean.
- New endpoints smoke-tested: return sorted distinct sets (e.g. `distinct-apps` → `["Apple","Protobuf","Roughtime"]`).
- Playwright on the monitor network: all drift panels render the same IP/app/protocol badges as before, now sourced from the new endpoints. Confirmed the `pageSize=10000` fetch is **gone** (network trace shows only `distinct-*` calls), zero console errors.
- Regenerated `openapi/baseline.json` — diff is exactly the three new paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)