### PR TITLE
Server-side pagination for the file list (#476)

### DIFF
--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -1,12 +1,13 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
 import { useNavigate } from 'react-router-dom';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { isAxiosError } from 'axios';
 import { Badge, Button, Card, Form, Modal, Tooltip } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
 import { AlertCircle } from 'lucide-react';
 import { apiClient } from '@/services/api/client';
 import { API_ENDPOINTS } from '@/services/api/endpoints';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import { parseDateTime } from '@/utils/dateUtils';
 import './FileList.css';
 
@@ -45,6 +46,10 @@ export const FileList = () => {
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
   const [selectedForCompare, setSelectedForCompare] = useState<Set<string>>(new Set());
   const [hideMonitor, setHideMonitor] = useState(true);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  const [totalItems, setTotalItems] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
   const [showInfo, setShowInfo] = useState(false);
   const [showMultiSelectModal, setShowMultiSelectModal] = useState(false);
   const [merging, setMerging] = useState(false);
@@ -118,22 +123,37 @@ export const FileList = () => {
     }
   };
 
-  const fetchFiles = async () => {
+  const fetchFiles = useCallback(async () => {
     try {
       const res = await apiClient.get(API_ENDPOINTS.FILES_LIST, {
-        params: { sort: 'uploadedAt,desc', pageSize: 100 },
+        params: {
+          sort: 'uploadedAt,desc',
+          page,
+          pageSize,
+          // ANALYSIS is the only non-monitor source, so "hide monitor" == list ANALYSIS only.
+          // Omitting `source` lists everything (monitor files included).
+          ...(hideMonitor ? { source: 'ANALYSIS' } : {}),
+        },
       });
       setFiles(res.data.data ?? []);
+      setTotalItems(res.data.total ?? 0);
+      setTotalPages(res.data.totalPages ?? 0);
     } catch (err) {
       console.error('Failed to fetch files:', err);
     } finally {
       setLoading(false);
     }
-  };
+  }, [page, pageSize, hideMonitor]);
 
   useEffect(() => {
     fetchFiles();
-  }, []);
+  }, [fetchFiles]);
+
+  // Toggling the monitor filter or changing page size resets to the first page so the
+  // current page can't fall out of range against the new (filtered) result set.
+  useEffect(() => {
+    setPage(1);
+  }, [hideMonitor, pageSize]);
 
   const formatFileSize = (bytes: number): string => {
     if (bytes === 0) return '0 Bytes';
@@ -160,15 +180,16 @@ export const FileList = () => {
     if (!pendingDeleteFile) return;
     try {
       await apiClient.delete(API_ENDPOINTS.FILE_DELETE(pendingDeleteFile.fileId));
-      setFiles(prev => prev.filter(f => f.fileId !== pendingDeleteFile.fileId));
     } catch (err) {
-      if (isAxiosError(err) && err.response?.status === 404) {
-        setFiles(prev => prev.filter(f => f.fileId !== pendingDeleteFile.fileId));
-      } else {
+      // A 404 means it's already gone — treat as success and refresh either way.
+      if (!(isAxiosError(err) && err.response?.status === 404)) {
         console.error('Failed to delete file:', err);
       }
     }
     setPendingDeleteFile(null);
+    // If this was the last row on the last page, step back a page; otherwise refetch in place.
+    if (files.length === 1 && page > 1) setPage(p => p - 1);
+    else fetchFiles();
   };
 
   return (
@@ -263,7 +284,7 @@ export const FileList = () => {
                 onClick={() => setConfirmDeleteAll(true)}
               >
                 <i className="bi bi-trash me-1"></i>
-                Delete all
+                Delete page
               </Button>
             </div>
           )}
@@ -275,34 +296,29 @@ export const FileList = () => {
               Loading files…
             </div>
           ) : files.length === 0 ? (
-            <div className="text-center text-muted py-4">
-              <p className="mb-0">No uploads yet. Upload a PCAP file to get started!</p>
-            </div>
-          ) : (() => {
-            const displayedFiles = files.filter(f => !hideMonitor || f.source !== 'MONITOR');
-            if (displayedFiles.length === 0) {
-              return (
-                <div className="text-center text-muted py-4">
-                  <p className="mb-0">
-                    No uploads here. All PCAP files are monitor-sourced and hidden.{' '}
-                    <button
-                      type="button"
-                      className="btn btn-link p-0 align-baseline text-muted"
-                      style={{ fontSize: 'inherit' }}
-                      onClick={() => setHideMonitor(false)}
-                    >
-                      Show monitor files
-                    </button>
-                  </p>
-                </div>
-              );
-            }
-            return (
-              <div
-                className="list-group list-group-flush"
-                style={{ maxHeight: '13.5rem', overflowY: 'auto' }}
-              >
-                {displayedFiles.map(file => {
+            hideMonitor ? (
+              <div className="text-center text-muted py-4">
+                <p className="mb-0">
+                  No uploads here.{' '}
+                  <button
+                    type="button"
+                    className="btn btn-link p-0 align-baseline text-muted"
+                    style={{ fontSize: 'inherit' }}
+                    onClick={() => setHideMonitor(false)}
+                  >
+                    Show monitor files
+                  </button>
+                  {' '}or upload a PCAP file to get started!
+                </p>
+              </div>
+            ) : (
+              <div className="text-center text-muted py-4">
+                <p className="mb-0">No uploads yet. Upload a PCAP file to get started!</p>
+              </div>
+            )
+          ) : (
+              <div className="list-group list-group-flush">
+                {files.map(file => {
                   const isSelected = selectedForCompare.has(file.fileId);
                   const isCompleted = file.status.toLowerCase() === 'completed';
                   return (
@@ -401,8 +417,21 @@ export const FileList = () => {
                   );
                 })}
               </div>
-            );
-          })()}
+          )}
+          {/* Show whenever the total exceeds the smallest page-size option, so the page-size
+              selector stays reachable even when the current size collapses to a single page. */}
+          {totalItems > 10 && (
+            <div className="p-2 border-top">
+              <Pagination
+                currentPage={page}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={setPageSize}
+              />
+            </div>
+          )}
         </Card.Body>
         <Card.Footer className="text-muted small">
           <AlertCircle size={14} className="me-1" />
@@ -529,11 +558,17 @@ export const FileList = () => {
       {/* Delete all confirmation modal */}
       <Modal show={confirmDeleteAll} onHide={() => setConfirmDeleteAll(false)} centered>
         <Modal.Header closeButton>
-          <Modal.Title>Delete All</Modal.Title>
+          <Modal.Title>Delete Page</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <p className="mb-0">
-            Are you sure you want to delete all <strong>{files.length}</strong> uploaded files?
+            Are you sure you want to delete the <strong>{files.length}</strong> file
+            {files.length !== 1 ? 's' : ''} on this page?
+            {totalItems > files.length && (
+              <span className="d-block text-muted small mt-1">
+                Only this page is affected — {totalItems - files.length} more remain on other pages.
+              </span>
+            )}
           </p>
         </Modal.Body>
         <Modal.Footer>
@@ -548,19 +583,16 @@ export const FileList = () => {
             type="button"
             variant="danger"
             onClick={async () => {
-              const results = await Promise.allSettled(
+              await Promise.allSettled(
                 files.map(f => apiClient.delete(API_ENDPOINTS.FILE_DELETE(f.fileId)))
               );
-              const deletedIds = new Set(
-                results
-                  .map((r, i) => (r.status === 'fulfilled' ? files[i].fileId : null))
-                  .filter(Boolean)
-              );
-              setFiles(prev => prev.filter(f => !deletedIds.has(f.fileId)));
               setConfirmDeleteAll(false);
+              // Refetch: step back a page if we just emptied a non-first page.
+              if (page > 1) setPage(p => p - 1);
+              else fetchFiles();
             }}
           >
-            Delete all
+            Delete page
           </Button>
         </Modal.Footer>
       </Modal>

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -45,6 +45,7 @@ export const FileList = () => {
   const [pendingDeleteFile, setPendingDeleteFile] = useState<FileMetadata | null>(null);
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
   const [selectedForCompare, setSelectedForCompare] = useState<Set<string>>(new Set());
+  const [selectedFileNames, setSelectedFileNames] = useState<Map<string, string>>(new Map());
   const [hideMonitor, setHideMonitor] = useState(true);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(25);
@@ -69,28 +70,40 @@ export const FileList = () => {
     return () => document.removeEventListener('mousedown', handler);
   }, [showInfo]);
 
-  const toggleCompareSelect = (fileId: string) =>
+  // Remember the filename of every file the user has selected, so cross-page selections survive
+  // even though `files` only holds the current page (server-side pagination).
+  const toggleCompareSelect = (fileId: string, fileName?: string) => {
     setSelectedForCompare(prev => {
       const next = new Set(prev);
       next.has(fileId) ? next.delete(fileId) : next.add(fileId);
       return next;
     });
+    if (fileName) {
+      setSelectedFileNames(prev => {
+        const next = new Map(prev);
+        if (!next.has(fileId)) next.set(fileId, fileName);
+        return next;
+      });
+    }
+  };
 
   const buildAutoMergeName = (selectedIds: Set<string>): string => {
     const MAX_PART = 20;
     const MAX_SHOWN = 3;
-    const selected = files.filter(f => selectedIds.has(f.fileId));
-    const parts = selected.slice(0, MAX_SHOWN).map(f => {
-      const base = f.fileName.replace(/\.[^.]+$/, '');
+    // Use the accumulated name map (not `files`, which is only the current page) so off-page
+    // selections still contribute to the generated name.
+    const names = [...selectedIds].map(id => selectedFileNames.get(id)).filter((n): n is string => !!n);
+    const parts = names.slice(0, MAX_SHOWN).map(fileName => {
+      const base = fileName.replace(/\.[^.]+$/, '');
       return base.length > MAX_PART ? base.slice(0, MAX_PART) : base;
     });
-    const suffix = selected.length > MAX_SHOWN ? `+${selected.length - MAX_SHOWN}_more` : '';
+    const suffix = names.length > MAX_SHOWN ? `+${names.length - MAX_SHOWN}_more` : '';
     return `merged_${parts.join('+')}${suffix}`;
   };
 
-  const handleRowClick = (fileId: string, status: string) => {
+  const handleRowClick = (fileId: string, status: string, fileName: string) => {
     if (status.toLowerCase() !== 'completed') return;
-    toggleCompareSelect(fileId);
+    toggleCompareSelect(fileId, fileName);
   };
 
   const handleMultiSelectAction = async (action: MultiSelectAction) => {
@@ -111,6 +124,7 @@ export const FileList = () => {
       });
       const newFileId: string = res.data.fileId;
       setSelectedForCompare(new Set());
+      setSelectedFileNames(new Map());
       navigate(`/analysis/${newFileId}`);
     } catch (err) {
       const message =
@@ -149,12 +163,6 @@ export const FileList = () => {
     fetchFiles();
   }, [fetchFiles]);
 
-  // Toggling the monitor filter or changing page size resets to the first page so the
-  // current page can't fall out of range against the new (filtered) result set.
-  useEffect(() => {
-    setPage(1);
-  }, [hideMonitor, pageSize]);
-
   const formatFileSize = (bytes: number): string => {
     if (bytes === 0) return '0 Bytes';
     const k = 1024;
@@ -187,8 +195,9 @@ export const FileList = () => {
       }
     }
     setPendingDeleteFile(null);
-    // If this was the last row on the last page, step back a page; otherwise refetch in place.
-    if (files.length === 1 && page > 1) setPage(p => p - 1);
+    // If we just emptied the last page, step back; on earlier pages the rows below shift up to
+    // fill the gap, so refetch in place instead of kicking the user backwards.
+    if (files.length === 1 && page === totalPages && page > 1) setPage(p => p - 1);
     else fetchFiles();
   };
 
@@ -247,6 +256,8 @@ export const FileList = () => {
                 size="sm"
                 onClick={() => setHideMonitor(v => {
                   const next = !v;
+                  // New filter → back to page 1 so the current page can't fall out of range.
+                  setPage(1);
                   if (next) {
                     setSelectedForCompare(prev => {
                       const monitorIds = new Set(files.filter(f => f.source === 'MONITOR').map(f => f.fileId));
@@ -333,12 +344,12 @@ export const FileList = () => {
                       role={isCompleted ? 'checkbox' : undefined}
                       aria-checked={isCompleted ? isSelected : undefined}
                       tabIndex={isCompleted ? 0 : -1}
-                      onClick={() => handleRowClick(file.fileId, file.status)}
+                      onClick={() => handleRowClick(file.fileId, file.status, file.fileName)}
                       onKeyDown={e => {
                         if (!isCompleted) return;
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault();
-                          handleRowClick(file.fileId, file.status);
+                          handleRowClick(file.fileId, file.status, file.fileName);
                         }
                       }}
                     >
@@ -428,7 +439,7 @@ export const FileList = () => {
                 totalItems={totalItems}
                 pageSize={pageSize}
                 onPageChange={setPage}
-                onPageSizeChange={setPageSize}
+                onPageSizeChange={size => { setPageSize(size); setPage(1); }}
               />
             </div>
           )}
@@ -587,8 +598,8 @@ export const FileList = () => {
                 files.map(f => apiClient.delete(API_ENDPOINTS.FILE_DELETE(f.fileId)))
               );
               setConfirmDeleteAll(false);
-              // Refetch: step back a page if we just emptied a non-first page.
-              if (page > 1) setPage(p => p - 1);
+              // Only step back if we emptied the last page; earlier pages backfill from below.
+              if (page === totalPages && page > 1) setPage(p => p - 1);
               else fetchFiles();
             }}
           >


### PR DESCRIPTION
Closes #476 — the final piece (the drift-panel half landed in #480).

## Problem
`FileList` fetched a hard-capped `pageSize: 100` and rendered every row inside a fixed-height scroll box, so on the prod-scale target (millions of files) only the 100 most-recent uploads were ever reachable — truncation, not pagination.

## Change (frontend-only)
The backend `GET /files` already returns a proper 1-indexed `PagedResponse` (`page`/`pageSize`/`sort`/`source`), so no backend change was needed:
- Drive `page`/`pageSize`/`totalItems`/`totalPages` from the server response; reset to page 1 when page size or the monitor filter changes.
- **Monitor filter → server-side:** the "hide monitor files" toggle now fetches `?source=ANALYSIS` (ANALYSIS is the only non-monitor `FileSource`) instead of filtering a client array, so counts/pages stay authoritative. Removed the redundant client filter + `maxHeight` scroll box.
- **Mutations refetch:** delete / delete-page / merge refetch the current page (stepping back a page if the last row on a non-first page is removed) rather than mutating a local array.
- **Selector stays reachable:** pager shows whenever `totalItems > 10` (smallest page-size option), so bumping the size to a single page can't strand the user — the same fix as #479.
- **"Delete all" honesty:** with no bulk-delete endpoint (and fetching all ids would reintroduce an unbounded fetch), it now deletes only the current page; the modal states the scope and how many files remain elsewhere. Relabelled trigger/modal to **"Delete page"**.

## Verification
- `tsc --noEmit` clean; `docker compose up -d --build` succeeds.
- Playwright (11 files: 2 ANALYSIS + 9 monitor), zero console errors:
  - Default (hide monitor): 2 rows, request `…&source=ANALYSIS`, no pager.
  - Toggle monitor on: 11 rows, "Showing 1 to 11 of 11", request drops `source`.
  - Page size → 10: 2 pages; page 2 shows the 11th row ("Showing 11 to 11 of 11"), request `page=2&pageSize=10`.
  - Confirmed the old `pageSize:100` cap is gone.

With this, every truncating fetch identified in the pagination audit is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added page-based file browsing with pagination controls and page-size changes.
  * Improved compare/analysis selections so chosen files stay available across pages, including generated names.

* **Bug Fixes**
  * File deletions now refresh the current page correctly and handle edge cases when removing the last item on a page.
  * The delete action now applies to the current page instead of all files.
  * Empty-state messaging and filter resets now behave more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->