### PR TITLE
Paginate the list/table renders the audit missed (#475)

### DIFF
--- a/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
+++ b/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
@@ -184,6 +184,14 @@ export const ConversationDetail = ({
     packetPageClamped * packetPageSize,
   );
 
+  // Switching conversations: reset the packet page and collapse any expanded hex row so the new
+  // conversation starts at page 1. Declared before the highlight effect so a deep-link's page jump
+  // still wins when both run on a conversation change.
+  useEffect(() => {
+    setPacketPage(1);
+    setExpandedPacketId(null);
+  }, [conversation.id]);
+
   // When deep-linked to a specific packet, switch to the Packets tab, jump to the page that
   // contains it, and scroll it into view.
   useEffect(() => {

--- a/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
+++ b/frontend/src/components/conversation/ConversationDetail/ConversationDetail.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/utils/appColors';
 import { getProtocolColor } from '@/features/network/constants';
 import { deviceTypeLabel, deviceTypeColor } from '@/utils/deviceType';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import { HexViewer } from '../HexViewer/HexViewer';
 import { SessionTab } from '../SessionTab/SessionTab';
 import { DeviceClassificationPopup } from '@components/common/DeviceClassificationPopup/DeviceClassificationPopup';
@@ -171,17 +172,31 @@ export const ConversationDetail = ({
   const [extractedCount, setExtractedCount] = useState<number | null>(null);
   const [expandedPacketId, setExpandedPacketId] = useState<string | null>(null);
   const [devicePopup, setDevicePopup] = useState<DeviceClassificationInfo | null>(null);
+  const [packetPage, setPacketPage] = useState(1);
+  const [packetPageSize, setPacketPageSize] = useState(50);
   const highlightRowRef = useRef<HTMLTableRowElement>(null);
 
-  // When deep-linked to a specific packet, switch to the Packets tab and scroll it into view.
+  const allPackets = conversation.packets ?? [];
+  const packetTotalPages = Math.ceil(allPackets.length / packetPageSize);
+  const packetPageClamped = Math.min(packetPage, Math.max(1, packetTotalPages));
+  const visiblePackets = allPackets.slice(
+    (packetPageClamped - 1) * packetPageSize,
+    packetPageClamped * packetPageSize,
+  );
+
+  // When deep-linked to a specific packet, switch to the Packets tab, jump to the page that
+  // contains it, and scroll it into view.
   useEffect(() => {
     if (highlightPacketNumber == null) return;
     setActiveTab('packets');
+    const idx = allPackets.findIndex(p => p.packetNumber === highlightPacketNumber);
+    if (idx >= 0) setPacketPage(Math.floor(idx / packetPageSize) + 1);
     const t = setTimeout(() => {
       highlightRowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }, 150);
     return () => clearTimeout(t);
-  }, [highlightPacketNumber, conversation.id]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightPacketNumber, conversation.id, packetPageSize]);
 
   const openDevicePopup = (
     cls: HostClassification,
@@ -555,8 +570,8 @@ export const ConversationDetail = ({
                   </tr>
                 </thead>
                 <tbody>
-                  {conversation.packets && conversation.packets.length > 0 ? (
-                    conversation.packets.map((packet, index) => (
+                  {allPackets.length > 0 ? (
+                    visiblePackets.map((packet, index) => (
                       <>
                         <tr
                           key={packet.id}
@@ -570,7 +585,7 @@ export const ConversationDetail = ({
                           }}
                           className={expandedPacketId === packet.id ? 'table-active' : undefined}
                         >
-                          <td className="text-muted">{index + 1}</td>
+                          <td className="text-muted">{(packetPageClamped - 1) * packetPageSize + index + 1}</td>
                           <td className={getDirectionClass(packet)}>
                             <strong>{getDirectionIndicator(packet)}</strong>
                           </td>
@@ -662,6 +677,18 @@ export const ConversationDetail = ({
                 </tbody>
               </table>
             </div>
+            {allPackets.length > 10 && (
+              <div className="p-2 border-top">
+                <Pagination
+                  currentPage={packetPageClamped}
+                  totalPages={packetTotalPages}
+                  totalItems={allPackets.length}
+                  pageSize={packetPageSize}
+                  onPageChange={setPacketPage}
+                  onPageSizeChange={size => { setPacketPageSize(size); setPacketPage(1); }}
+                />
+              </div>
+            )}
           </Card.Body>
         )}
 

--- a/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
+++ b/frontend/src/components/monitor/DeviceDriftPanel/DeviceDriftPanel.tsx
@@ -4,6 +4,7 @@ import { Button } from '@govtechsg/sgds-react';
 import { apiClient } from '@/services/api/client';
 import type { NetworkSnapshot, AbsentEntity } from '@/features/monitor/types/monitor.types';
 import { EntityDetailModal } from '@components/common/EntityDetailModal';
+import { Pagination } from '@components/common/Pagination/Pagination';
 
 /** Deterministic hue (0–360) from any string. */
 function stringHue(s: string): number {
@@ -43,6 +44,8 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
   const [absentMacs, setAbsentMacs] = useState<AbsentEntity[]>([]);
   const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const BADGE_PAGE_SIZE = 50;
 
   const sorted = [...snapshots].sort((a, b) => a.snapshotOrder - b.snapshotOrder);
   const latestSnap = sorted[sorted.length - 1];
@@ -103,6 +106,16 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
   const visibleActive = q ? activeMacs.filter(mac => mac.toLowerCase().includes(q)) : activeMacs;
   const visibleAbsent = q ? absentMacs.filter(e => e.key.toLowerCase().includes(q)) : absentMacs;
 
+  // One paginated stream over active-then-absent badges, so a large device set doesn't render
+  // hundreds of badges at once. Clamp in render so the search shrinking the list can't strand us.
+  const combined: Array<{ active: true; mac: string } | { active: false; entity: AbsentEntity }> = [
+    ...visibleActive.map(mac => ({ active: true as const, mac })),
+    ...visibleAbsent.map(entity => ({ active: false as const, entity })),
+  ];
+  const totalPages = Math.ceil(combined.length / BADGE_PAGE_SIZE);
+  const currentPage = Math.min(page, Math.max(1, totalPages));
+  const pageItems = combined.slice((currentPage - 1) * BADGE_PAGE_SIZE, currentPage * BADGE_PAGE_SIZE);
+
   return (
     <>
       <div className="mb-3">
@@ -111,39 +124,48 @@ export const DeviceDriftPanel = ({ snapshots }: DeviceDriftPanelProps) => {
           className="form-control form-control-sm"
           placeholder="Search MAC addresses…"
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={e => { setSearch(e.target.value); setPage(1); }}
         />
       </div>
       <div className="d-flex flex-wrap gap-2">
-        {visibleActive.map(mac => (
+        {pageItems.map(item => item.active ? (
           <Button
-            key={mac}
+            key={item.mac}
             type="button"
             variant="secondary"
             size="sm"
             className="border-0 py-0 px-1"
-            style={{ fontSize: '0.75em', ...hashBadgeStyle(mac) }}
-            onClick={() => setSelectedMac({ mac, fileId: latestFileId, isActive: true, lastSeenTime: latestStartTime })}
+            style={{ fontSize: '0.75em', ...hashBadgeStyle(item.mac) }}
+            onClick={() => setSelectedMac({ mac: item.mac, fileId: latestFileId, isActive: true, lastSeenTime: latestStartTime })}
             title="View device history"
           >
-            {mac}
+            {item.mac}
           </Button>
-        ))}
-        {visibleAbsent.map(entity => (
+        ) : (
           <Button
-            key={entity.key}
+            key={item.entity.key}
             type="button"
             variant="secondary"
             size="sm"
             className="text-decoration-line-through border-0 py-0 px-1"
-            style={{ fontSize: '0.75em', opacity: 0.5, ...hashBadgeStyle(entity.key) }}
-            onClick={() => setSelectedAbsent(entity)}
-            title={`Last seen in ${entity.lastSeenFileName}`}
+            style={{ fontSize: '0.75em', opacity: 0.5, ...hashBadgeStyle(item.entity.key) }}
+            onClick={() => setSelectedAbsent(item.entity)}
+            title={`Last seen in ${item.entity.lastSeenFileName}`}
           >
-            {entity.key}
+            {item.entity.key}
           </Button>
         ))}
       </div>
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={combined.length}
+          pageSize={BADGE_PAGE_SIZE}
+          onPageChange={setPage}
+          showPageSizeSelector={false}
+        />
+      )}
       {absentMacs.length > 0 && (
         <small className="text-muted d-block mt-2">
           <i className="bi bi-info-circle me-1"></i>

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -100,6 +100,9 @@ function IpBadgeGroup({
   onActiveClick: (ip: string) => void;
 }) {
   const [page, setPage] = useState(1);
+  // Reset to page 1 when the filtered set changes (e.g. the parent's search box) so a
+  // cleared/narrowed search can't leave us on a now-out-of-range page.
+  useEffect(() => { setPage(1); }, [items.length, absentItems.length]);
   if (items.length === 0 && absentItems.length === 0) return null;
 
   // Paginate active-then-absent badges so a large group can't render hundreds at once.

--- a/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
+++ b/frontend/src/components/monitor/IpDriftPanel/IpDriftPanel.tsx
@@ -8,6 +8,7 @@ import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
 import { customPrivateRangeService } from '@/features/intelligence/services/customPrivateRangeService';
 import type { CustomPrivateRange, IpClassification } from '@/features/intelligence/types/customPrivateRange.types';
 import { EntityDetailModal } from '@components/common/EntityDetailModal';
+import { Pagination } from '@components/common/Pagination/Pagination';
 
 interface IpDriftPanelProps {
   snapshots: NetworkSnapshot[];
@@ -85,6 +86,8 @@ function hashBadgeStyle(s: string): CSSProperties {
   } as CSSProperties;
 }
 
+const BADGE_GROUP_PAGE_SIZE = 50;
+
 function IpBadgeGroup({
   items,
   absentItems,
@@ -96,38 +99,60 @@ function IpBadgeGroup({
   onAbsentClick: (e: AbsentEntity) => void;
   onActiveClick: (ip: string) => void;
 }) {
+  const [page, setPage] = useState(1);
   if (items.length === 0 && absentItems.length === 0) return null;
+
+  // Paginate active-then-absent badges so a large group can't render hundreds at once.
+  const combined: Array<{ active: true; ip: string } | { active: false; entity: AbsentEntity }> = [
+    ...items.map(ip => ({ active: true as const, ip })),
+    ...absentItems.map(entity => ({ active: false as const, entity })),
+  ];
+  const totalPages = Math.ceil(combined.length / BADGE_GROUP_PAGE_SIZE);
+  const currentPage = Math.min(page, Math.max(1, totalPages));
+  const pageItems = combined.slice((currentPage - 1) * BADGE_GROUP_PAGE_SIZE, currentPage * BADGE_GROUP_PAGE_SIZE);
+
   return (
-    <div className="d-flex flex-wrap gap-2">
-      {items.map(ip => (
-        <Button
-          key={ip}
-          type="button"
-          variant="secondary"
-          size="sm"
-          className="border-0 py-0 px-1"
-          style={{ fontSize: '0.75em', ...hashBadgeStyle(ip) }}
-          onClick={() => onActiveClick(ip)}
-          title="Click for details & notes"
-        >
-          {ip}
-        </Button>
-      ))}
-      {absentItems.map(entity => (
-        <Button
-          key={entity.key}
-          type="button"
-          variant="secondary"
-          size="sm"
-          className="text-decoration-line-through border-0 py-0 px-1"
-          style={{ fontSize: '0.75em', opacity: 0.5, ...hashBadgeStyle(entity.key) }}
-          onClick={() => onAbsentClick(entity)}
-          title={`Last seen in ${entity.lastSeenFileName}`}
-        >
-          {entity.key}
-        </Button>
-      ))}
-    </div>
+    <>
+      <div className="d-flex flex-wrap gap-2">
+        {pageItems.map(item => item.active ? (
+          <Button
+            key={item.ip}
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="border-0 py-0 px-1"
+            style={{ fontSize: '0.75em', ...hashBadgeStyle(item.ip) }}
+            onClick={() => onActiveClick(item.ip)}
+            title="Click for details & notes"
+          >
+            {item.ip}
+          </Button>
+        ) : (
+          <Button
+            key={item.entity.key}
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="text-decoration-line-through border-0 py-0 px-1"
+            style={{ fontSize: '0.75em', opacity: 0.5, ...hashBadgeStyle(item.entity.key) }}
+            onClick={() => onAbsentClick(item.entity)}
+            title={`Last seen in ${item.entity.lastSeenFileName}`}
+          >
+            {item.entity.key}
+          </Button>
+        ))}
+      </div>
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={combined.length}
+          pageSize={BADGE_GROUP_PAGE_SIZE}
+          onPageChange={setPage}
+          showPageSizeSelector={false}
+        />
+      )}
+    </>
   );
 }
 

--- a/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
+++ b/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
@@ -50,6 +50,9 @@ function BadgeGroup({
   onActiveClick: (name: string) => void;
 }) {
   const [page, setPage] = useState(1);
+  // Reset to page 1 when the filtered set changes (e.g. the parent's search box) so a
+  // cleared/narrowed search can't leave us on a now-out-of-range page.
+  useEffect(() => { setPage(1); }, [items.length, absentItems.length]);
   if (items.length === 0 && absentItems.length === 0) return null;
 
   // Paginate active-then-absent badges so a large group can't render hundreds at once.

--- a/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
+++ b/frontend/src/components/monitor/ProtocolDriftPanel/ProtocolDriftPanel.tsx
@@ -8,6 +8,7 @@ import type {
   AbsentEntity,
 } from '@/features/monitor/types/monitor.types';
 import { EntityDetailModal } from '@components/common/EntityDetailModal';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import type { EntityType } from '@/features/notes/services/entityNotesService';
 
 function stringHue(s: string): number {
@@ -35,6 +36,8 @@ type EntityGroup = {
   absent: AbsentEntity[];
 };
 
+const BADGE_GROUP_PAGE_SIZE = 50;
+
 function BadgeGroup({
   items,
   absentItems,
@@ -46,38 +49,60 @@ function BadgeGroup({
   onAbsentClick: (e: AbsentEntity) => void;
   onActiveClick: (name: string) => void;
 }) {
+  const [page, setPage] = useState(1);
   if (items.length === 0 && absentItems.length === 0) return null;
+
+  // Paginate active-then-absent badges so a large group can't render hundreds at once.
+  const combined: Array<{ active: true; name: string } | { active: false; entity: AbsentEntity }> = [
+    ...items.map(name => ({ active: true as const, name })),
+    ...absentItems.map(entity => ({ active: false as const, entity })),
+  ];
+  const totalPages = Math.ceil(combined.length / BADGE_GROUP_PAGE_SIZE);
+  const currentPage = Math.min(page, Math.max(1, totalPages));
+  const pageItems = combined.slice((currentPage - 1) * BADGE_GROUP_PAGE_SIZE, currentPage * BADGE_GROUP_PAGE_SIZE);
+
   return (
-    <div className="d-flex flex-wrap gap-2">
-      {items.map(name => (
-        <Button
-          key={name}
-          type="button"
-          variant="secondary"
-          size="sm"
-          className="border-0 py-0 px-1"
-          style={{ fontSize: '0.75em', ...hashBadgeStyle(name) }}
-          onClick={() => onActiveClick(name)}
-          title="Click for details & notes"
-        >
-          {name}
-        </Button>
-      ))}
-      {absentItems.map(entity => (
-        <Button
-          key={entity.key}
-          type="button"
-          variant="secondary"
-          size="sm"
-          className="text-decoration-line-through border-0 py-0 px-1"
-          style={{ fontSize: '0.75em', opacity: 0.5, ...hashBadgeStyle(entity.key) }}
-          onClick={() => onAbsentClick(entity)}
-          title={`Last seen in ${entity.lastSeenFileName}`}
-        >
-          {entity.key}
-        </Button>
-      ))}
-    </div>
+    <>
+      <div className="d-flex flex-wrap gap-2">
+        {pageItems.map(item => item.active ? (
+          <Button
+            key={item.name}
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="border-0 py-0 px-1"
+            style={{ fontSize: '0.75em', ...hashBadgeStyle(item.name) }}
+            onClick={() => onActiveClick(item.name)}
+            title="Click for details & notes"
+          >
+            {item.name}
+          </Button>
+        ) : (
+          <Button
+            key={item.entity.key}
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="text-decoration-line-through border-0 py-0 px-1"
+            style={{ fontSize: '0.75em', opacity: 0.5, ...hashBadgeStyle(item.entity.key) }}
+            onClick={() => onAbsentClick(item.entity)}
+            title={`Last seen in ${item.entity.lastSeenFileName}`}
+          >
+            {item.entity.key}
+          </Button>
+        ))}
+      </div>
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={combined.length}
+          pageSize={BADGE_GROUP_PAGE_SIZE}
+          onPageChange={setPage}
+          showPageSizeSelector={false}
+        />
+      )}
+    </>
   );
 }
 

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -5,6 +5,7 @@ import { subnetService } from '@/features/subnets/services/subnetService';
 import type { SubnetDefinition } from '@/features/subnets/types/subnet.types';
 import type { SubnetOverrideInput } from '@/features/monitor/types/monitor.types';
 import { ChangeEventBadge } from '@/components/monitor/ChangeEventBadge/ChangeEventBadge';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import { SnapshotSecurityTab } from '@/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab';
 import { NetworkInsightsPanel } from '@/components/monitor/NetworkInsightsPanel/NetworkInsightsPanel';
 import { NetworkGraph } from '@/components/network/NetworkGraph';
@@ -123,6 +124,8 @@ export const SnapshotDetailModal = ({
   onHide,
 }: SnapshotDetailModalProps) => {
   const [activeTab, setActiveTab] = useState<Tab>(initialTab ?? 'diagram');
+  const [changesPage, setChangesPage] = useState(1);
+  const CHANGES_PAGE_SIZE = 15;
 
   // Diagram tab state
   const sorted = useMemo(() => [...snapshots].sort((a, b) => a.snapshotOrder - b.snapshotOrder), [snapshots]);
@@ -575,16 +578,36 @@ export const SnapshotDetailModal = ({
                   ? 'This is the baseline snapshot — no changes are compared against it.'
                   : 'No change events detected for this snapshot.'}
               </p>
-            ) : (
-              snapshotEvents.map(event => (
-                <ChangeEventBadge
-                  key={event.id}
-                  event={event}
-                  snapshots={snapshots}
-                  onPatch={onPatchChange}
-                />
-              ))
-            )}
+            ) : (() => {
+              const totalPages = Math.ceil(snapshotEvents.length / CHANGES_PAGE_SIZE);
+              const currentPage = Math.min(changesPage, Math.max(1, totalPages));
+              const visible = snapshotEvents.slice(
+                (currentPage - 1) * CHANGES_PAGE_SIZE,
+                currentPage * CHANGES_PAGE_SIZE,
+              );
+              return (
+                <>
+                  {visible.map(event => (
+                    <ChangeEventBadge
+                      key={event.id}
+                      event={event}
+                      snapshots={snapshots}
+                      onPatch={onPatchChange}
+                    />
+                  ))}
+                  {totalPages > 1 && (
+                    <Pagination
+                      currentPage={currentPage}
+                      totalPages={totalPages}
+                      totalItems={snapshotEvents.length}
+                      pageSize={CHANGES_PAGE_SIZE}
+                      onPageChange={setChangesPage}
+                      showPageSizeSelector={false}
+                    />
+                  )}
+                </>
+              );
+            })()}
           </div>
         )}
 

--- a/frontend/src/components/network/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/components/network/NodeDetails/NodeDetails.tsx
@@ -5,6 +5,7 @@ import type { GraphNode, GraphEdge } from '@/features/network/types';
 import { NODE_TYPE_CONFIG, getProtocolColor } from '@/features/network/constants';
 import { deviceTypeLabel, deviceTypeColor } from '@/utils/deviceType';
 import { HostnameSourceBadge } from '@components/common/HostnameSourceBadge/HostnameSourceBadge';
+import { Pagination } from '@components/common/Pagination/Pagination';
 import { NodeClassificationPopup } from '@components/common/NodeClassificationPopup/NodeClassificationPopup';
 import { EntityDetailModal } from '@components/common/EntityDetailModal';
 import { RoleSection } from '@components/common/EntityDetailModal/sections/RoleSection';
@@ -63,6 +64,9 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
   const navigate = useNavigate();
   const [classificationPopupOpen, setClassificationPopupOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>('details');
+  const [peersPage, setPeersPage] = useState(1);
+  const [historyPage, setHistoryPage] = useState(1);
+  const HISTORY_PAGE_SIZE = 10;
   const [nestedIp, setNestedIp] = useState<string | null>(null);
 
   // Notes state
@@ -186,6 +190,20 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
   });
 
   const peers = Array.from(peerMap.entries()).sort((a, b) => b[1].bytes - a[1].bytes);
+  const PEERS_PAGE_SIZE = 15;
+  const peersTotalPages = Math.ceil(peers.length / PEERS_PAGE_SIZE);
+  const peersPageClamped = Math.min(peersPage, Math.max(1, peersTotalPages));
+  const visiblePeers = peers.slice(
+    (peersPageClamped - 1) * PEERS_PAGE_SIZE,
+    peersPageClamped * PEERS_PAGE_SIZE,
+  );
+
+  const historyTotalPages = Math.ceil(history.length / HISTORY_PAGE_SIZE);
+  const historyPageClamped = Math.min(historyPage, Math.max(1, historyTotalPages));
+  const visibleHistory = history.slice(
+    (historyPageClamped - 1) * HISTORY_PAGE_SIZE,
+    historyPageClamped * HISTORY_PAGE_SIZE,
+  );
 
   const typeInfo = NODE_TYPE_CONFIG[node.data.nodeType] ?? NODE_TYPE_CONFIG['unknown'];
 
@@ -451,7 +469,7 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                         </tr>
                       </thead>
                       <tbody>
-                        {peers.map(([ip, info]) => (
+                        {visiblePeers.map(([ip, info]) => (
                           <tr
                             key={ip}
                             className="node-details-peer-row"
@@ -490,6 +508,16 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                       </tbody>
                     </table>
                   </div>
+                  {peersTotalPages > 1 && (
+                    <Pagination
+                      currentPage={peersPageClamped}
+                      totalPages={peersTotalPages}
+                      totalItems={peers.length}
+                      pageSize={PEERS_PAGE_SIZE}
+                      onPageChange={setPeersPage}
+                      showPageSizeSelector={false}
+                    />
+                  )}
                 </div>
               </>
             )}
@@ -526,7 +554,7 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                         </tr>
                       </thead>
                       <tbody>
-                        {history.map(entry => (
+                        {visibleHistory.map(entry => (
                           <tr
                             key={entry.fileId}
                             className={entry.fileId === fileId ? 'table-active' : ''}
@@ -581,6 +609,16 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                         ))}
                       </tbody>
                     </table>
+                    {historyTotalPages > 1 && (
+                      <Pagination
+                        currentPage={historyPageClamped}
+                        totalPages={historyTotalPages}
+                        totalItems={history.length}
+                        pageSize={HISTORY_PAGE_SIZE}
+                        onPageChange={setHistoryPage}
+                        showPageSizeSelector={false}
+                      />
+                    )}
                   </div>
                 )}
               </div>

--- a/frontend/src/components/network/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/components/network/NodeDetails/NodeDetails.tsx
@@ -121,11 +121,15 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
     });
   }, [entityType, entityKey]);
 
-  // Reset history when the entity changes so a reused modal reloads fresh.
+  // Reset history when the entity changes so a reused modal reloads fresh. Also reset the peers
+  // and history page counters — NodeDetails isn't remounted between node selections, so without
+  // this a user on page 3 of one node lands on page 3 of the next node's (shorter) data.
   useEffect(() => {
     setHistory([]);
     setHistoryRoles({});
     setHistoryError(null);
+    setPeersPage(1);
+    setHistoryPage(1);
   }, [entityType, entityKey]);
 
   // Load history when History tab is first opened


### PR DESCRIPTION
Fixes the Tier-1 gaps found when re-auditing #475 properly (after a user spotted an unpaginated Changes tab). See the [reopened #475 accounting](https://github.com/NotYuSheng/TracePcap/issues/475) — the original audit triaged container components by filename and missed the lists they host, and the drift panels were flagged but only their *data source* (#480) was fixed, never the badge rendering.

## Changes (all use the shared `common/Pagination`)

| Component | Was | Now |
|---|---|---|
| **ConversationDetail** — packets table | rendered **every packet** (backend loads them uncapped) — a 15k-packet conversation = 15k DOM rows | pages at 50; a `?highlight` deep-link jumps to the page holding that packet |
| **SnapshotDetailModal** — Changes tab | `snapshotEvents.map()`, all events | pages at 15 (matches the already-paged network-wide `ChangeEventsSection`) — *the user-spotted one* |
| **NodeDetails** — peers + history | all peers of a node; full capture history | peers 15/pg, history 10/pg |
| **IpDriftPanel / ProtocolDriftPanel** — badge clouds | all badges | per-group pagination (50/pg) inside the shared badge-group component, preserving subnet / app-vs-protocol grouping |
| **DeviceDriftPanel** — MAC badge cloud | all badges | combined active/absent list paged at 50 |

All clamp the page in render and reset on search/filter change, so a shrinking list can't strand the view (the lessons from #479/#481).

## Verification (Playwright, real over-threshold data, zero console errors)
- **ConversationDetail:** the 15,075-packet conversation renders **50 rows** ("Showing 1 to 50 of 15075"), page 3 → "101 to 150". Previously 15k rows in the DOM.
- **Drift panels:** a 213-IP group pages at 50 ("1 to 50 of 213"); app/protocol groups "1 to 50 of 125" / "of 85".
- **Changes tab:** a 30-event snapshot pages at 15 ("1 to 15 of 30").
- `tsc --noEmit` clean; `docker compose up -d --build` succeeds.

## Not in this PR
Tier-2 (chat log, filter-option lists, per-payload hex, LLM timelines) — documented as conventionally-acceptable in #475, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination to several detail and monitoring views, including packets, device/IP/protocol badges, snapshot changes, node connections, and history.
  * Large lists now load in smaller pages with navigation controls, making tables and badge groups easier to scan.
  * Deep links to specific packet rows continue to work correctly with the new paged view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->