### PR TITLE
Add horizontal padding to the Pagination container

### DIFF
--- a/frontend/src/components/common/Pagination/Pagination.css
+++ b/frontend/src/components/common/Pagination/Pagination.css
@@ -3,7 +3,9 @@
   justify-content: space-between;
   align-items: center;
   margin-top: 0;
-  padding: 1rem 0;
+  /* Horizontal padding so the info text and nav don't hug the edges when the pager is dropped
+     directly into a bordered container (e.g. the monitor Subnets panel). */
+  padding: 0.75rem 1rem;
   gap: 1rem;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
## Bug (user-reported)
On the monitor **Subnets** panel, the pager's "Showing X of Y" text and the nav controls were flush against the left/right edges of the component with no gap.

## Cause
The shared `.pagination-container` had `padding: 1rem 0` — **vertical padding only**. Pagers that are dropped directly into a bordered container (the #477 batch: SubnetsPanel, ExternalEventsPanel, BaselineDefinitionPanel, etc.) had no horizontal breathing room. It only looked fine on ExtractedFiles/FileList because those were wrapped in a padded `<div>`.

## Fix
`padding: 1rem 0` → `padding: 0.75rem 1rem` on `.pagination-container`, so every pager gets horizontal padding regardless of placement. One-line CSS change; affects all pagers uniformly.

## Verification
Playwright: the extracted-files pager now reports `padding-left/right: 16px` (was `0`); screenshot confirms the info + nav sit with even gaps from the edges. Same component backs the Subnets pager, so it's fixed by the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)