### PR TITLE
Wire the Top Hosts table into the Network Intelligence page

### DIFF
--- a/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
+++ b/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
@@ -38,6 +38,7 @@ export const NetworkIntelligencePage = () => {
   const [topHosts, setTopHosts] = useState<HostSummary[]>([]);
   const [topHostsLoading, setTopHostsLoading] = useState(false);
   const [topHostsSortBy, setTopHostsSortBy] = useState<SortBy>('bytes');
+  const [topHostsError, setTopHostsError] = useState<string | null>(null);
 
   const graphCardRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -90,10 +91,16 @@ export const NetworkIntelligencePage = () => {
     if (!fileId) return;
     let active = true;
     setTopHostsLoading(true);
+    setTopHostsError(null);
     intelligenceService
       .getTopHosts(fileId, topHostsSortBy, 100)
       .then(res => { if (active) setTopHosts(res.hosts); })
-      .catch(() => { if (active) setTopHosts([]); })
+      .catch(err => {
+        if (active) {
+          setTopHosts([]);
+          setTopHostsError(err instanceof Error ? err.message : 'Failed to load top hosts');
+        }
+      })
       .finally(() => { if (active) setTopHostsLoading(false); });
     return () => { active = false; };
   }, [fileId, topHostsSortBy]);
@@ -307,6 +314,12 @@ export const NetworkIntelligencePage = () => {
       {/* Top hosts table */}
       <Card className="mb-4">
         <Card.Body>
+          {topHostsError && (
+            <Alert variant="warning" className="py-2 mb-3">
+              <i className="bi bi-exclamation-triangle me-2" />
+              {topHostsError}
+            </Alert>
+          )}
           <TopHostsTable
             hosts={topHosts}
             loading={topHostsLoading}

--- a/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
+++ b/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
@@ -9,11 +9,14 @@ import {
   type ClusterGraphResponse,
   type IntelClusterFilters,
   type ClusterNode,
+  type HostSummary,
+  type SortBy,
 } from '@/features/intelligence/services/intelligenceService';
 import { conversationService } from '@/features/conversation/services/conversationService';
 import { ipOrgRuleService } from '@/features/intelligence/services/ipOrgRuleService';
 import { SummaryStatsBar } from '@components/intelligence/SummaryStatsBar/SummaryStatsBar';
 import { ClusterGraph } from '@components/intelligence/ClusterGraph/ClusterGraph';
+import { TopHostsTable } from '@components/intelligence/TopHostsTable/TopHostsTable';
 import { NetworkControls } from '@components/network/NetworkControls';
 import { toggleSet } from '@/features/network/constants';
 
@@ -30,6 +33,11 @@ export const NetworkIntelligencePage = () => {
   const [clusterData, setClusterData] = useState<ClusterGraphResponse | null>(null);
   const [clusterLoading, setClusterLoading] = useState(false);
   const [clusterError, setClusterError] = useState<string | null>(null);
+
+  // Top-hosts table (file-wide, up to 100 by the chosen metric; the table paginates client-side).
+  const [topHosts, setTopHosts] = useState<HostSummary[]>([]);
+  const [topHostsLoading, setTopHostsLoading] = useState(false);
+  const [topHostsSortBy, setTopHostsSortBy] = useState<SortBy>('bytes');
 
   const graphCardRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -76,6 +84,19 @@ export const NetworkIntelligencePage = () => {
     }).catch(() => {});
     return () => { active = false; };
   }, [fileId]);
+
+  // Load the top hosts, re-fetching when the sort metric changes (sorting is server-side).
+  useEffect(() => {
+    if (!fileId) return;
+    let active = true;
+    setTopHostsLoading(true);
+    intelligenceService
+      .getTopHosts(fileId, topHostsSortBy, 100)
+      .then(res => { if (active) setTopHosts(res.hosts); })
+      .catch(() => { if (active) setTopHosts([]); })
+      .finally(() => { if (active) setTopHostsLoading(false); });
+    return () => { active = false; };
+  }, [fileId, topHostsSortBy]);
 
   // ── Derive present-values from AnalysisData ───────────────────────────────
   const presentEdgeLegendKeys = useMemo(() => {
@@ -279,6 +300,18 @@ export const NetworkIntelligencePage = () => {
             activeFilterCount={activeFilterCount}
             selectedCluster={selectedCluster}
             onSelectedClusterChange={setSelectedCluster}
+          />
+        </Card.Body>
+      </Card>
+
+      {/* Top hosts table */}
+      <Card className="mb-4">
+        <Card.Body>
+          <TopHostsTable
+            hosts={topHosts}
+            loading={topHostsLoading}
+            sortBy={topHostsSortBy}
+            onSortByChange={setTopHostsSortBy}
           />
         </Card.Body>
       </Card>


### PR DESCRIPTION
## Background
While investigating your "Top hosts by … and 30 more" question, I found that `TopHostsTable` — a fully-built, sortable, client-side-paginated host table (migrated to the shared `Pagination` in #477) — **was never rendered anywhere.** It was orphaned code. The only file-wide "top hosts" view was the ClusterGraph cluster popup's top-5 *sample* ("…and N more"), which by design only receives a sample of IPs and can't show the full list.

The API was already there: `intelligenceService.getTopHosts(fileId, sortBy, limit=100)` → `GET /intelligence/{fileId}/top-hosts`, returning exactly the `HostSummary[]` shape the table consumes.

## Change
Render `TopHostsTable` in a card below the Cluster View on the Network Intelligence page:
- Fetches via `getTopHosts(fileId, sortBy, 100)`; sorting (Bytes/Packets/Conversations/Risks) re-fetches server-side.
- The table paginates the result **client-side at 20/page** (its existing behavior).

No backend change — purely wiring an existing component to an existing endpoint.

## Verification
Playwright on a 100-host file: the table renders below the cluster graph with the full sortable columns and pages at **"Showing 1 to 20 of 100 items"**; clicking the **Risks** sort re-fetches and re-renders cleanly. `tsc --noEmit` clean; `docker compose up -d --build` succeeds. Zero console errors. (Screenshot in the thread.)

## Note
This makes the #477 `TopHostsTable` pagination migration actually *reachable* — previously it was polishing a component nobody could see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Top hosts** table to the Network Intelligence page.
  * Users can now sort the top-hosts view, with results updating automatically.
* **Bug Fixes**
  * Improved data fetching behavior with loading, error, and cancellation handling for smoother page updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->