### PR TITLE
Conflict-preserving hostname claims + adjudicator (#512 slice 4)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/entity/HostnameClaimEntity.java
+++ b/backend/src/main/java/com/tracepcap/analysis/entity/HostnameClaimEntity.java
@@ -1,0 +1,50 @@
+package com.tracepcap.analysis.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * One hostname claim for one IP in one capture — a REPORTED-grade observation (#512 slice 4).
+ * All claims are kept; winner-picking happens at adjudication, never at write time. See
+ * {@code docs/architecture/layers.rst} ("Extract records observations, not conclusions").
+ */
+@Entity
+@Table(name = "hostname_claims")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HostnameClaimEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "file_id", nullable = false)
+  private UUID fileId;
+
+  @Column(nullable = false, length = 45)
+  private String ip;
+
+  @Column(nullable = false, length = 255)
+  private String hostname;
+
+  /** Which protocol asserted it: dhcp | mdns | nbns | reverse_dns. */
+  @Column(nullable = false, length = 20)
+  private String source;
+
+  @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/tracepcap/analysis/repository/HostnameClaimRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/HostnameClaimRepository.java
@@ -4,10 +4,16 @@ import com.tracepcap.analysis.entity.HostnameClaimEntity;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface HostnameClaimRepository extends JpaRepository<HostnameClaimEntity, Long> {
 
   List<HostnameClaimEntity> findByFileId(UUID fileId);
 
-  void deleteByFileId(UUID fileId);
+  /** Bulk delete — the derived variant loads every row first, then deletes one by one. */
+  @Modifying
+  @Query("DELETE FROM HostnameClaimEntity c WHERE c.fileId = :fileId")
+  void deleteByFileId(@Param("fileId") UUID fileId);
 }

--- a/backend/src/main/java/com/tracepcap/analysis/repository/HostnameClaimRepository.java
+++ b/backend/src/main/java/com/tracepcap/analysis/repository/HostnameClaimRepository.java
@@ -1,0 +1,13 @@
+package com.tracepcap.analysis.repository;
+
+import com.tracepcap.analysis.entity.HostnameClaimEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HostnameClaimRepository extends JpaRepository<HostnameClaimEntity, Long> {
+
+  List<HostnameClaimEntity> findByFileId(UUID fileId);
+
+  void deleteByFileId(UUID fileId);
+}

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -82,6 +82,8 @@ public class AnalysisService {
   private final FileExtractionStage fileExtractionStage;
   private final AnalysisRecordService analysisRecordService;
   private final ExtractionRunService extractionRunService;
+  private final HostnameAdjudicator hostnameAdjudicator;
+  private final com.tracepcap.analysis.repository.HostnameClaimRepository hostnameClaimRepository;
 
   @Transactional
   public void analyzeFile(UUID fileId) {
@@ -161,9 +163,14 @@ public class AnalysisService {
         t = System.currentTimeMillis();
         Map<String, String> deviceOverrides =
             signatureApplier.applySignatures(parseResult.getConversations());
-        // resolve() degrades gracefully and never throws — it returns a (possibly empty) map.
-        Map<String, HostnameResolverService.ResolvedHostname> hostnames =
+        // resolve() degrades gracefully and never throws. Claims are persisted conflict-preserving
+        // (#512 slice 4); the adjudicator picks display winners with the same semantics the
+        // resolver used to apply at write time, so downstream behaviour is unchanged.
+        List<HostnameResolverService.Claim> hostnameClaims =
             hostnameResolverService.resolve(tempFile);
+        persistHostnameClaims(fileId, hostnameClaims);
+        Map<String, HostnameResolverService.ResolvedHostname> hostnames =
+            hostnameAdjudicator.adjudicate(hostnameClaims);
         // Per-host service activity logs (DNS today; web servers etc. later). Each extractor runs
         // one tshark pass, persists its own rows, and reports which hosts serve its role + any
         // suspicious ones. Runs before classification so a host's roles can drive its device type
@@ -730,6 +737,28 @@ public class AnalysisService {
    * Persist the distinct source MACs observed per IP (#461). Only IPs with more than one MAC carry
    * overlap signal, but we store all pairings so the detector can present the full evidence.
    */
+  /** Regenerates this file's claims (re-analysis re-derives the same observations). Best-effort. */
+  private void persistHostnameClaims(
+      UUID fileId, List<HostnameResolverService.Claim> claims) {
+    try {
+      hostnameClaimRepository.deleteByFileId(fileId);
+      if (claims.isEmpty()) return;
+      hostnameClaimRepository.saveAll(
+          claims.stream()
+              .map(
+                  c ->
+                      com.tracepcap.analysis.entity.HostnameClaimEntity.builder()
+                          .fileId(fileId)
+                          .ip(c.ip())
+                          .hostname(c.hostname())
+                          .source(c.source())
+                          .build())
+              .toList());
+    } catch (Exception e) {
+      log.warn("Failed to persist {} hostname claim(s) for file {}: {}", claims.size(), fileId, e.getMessage());
+    }
+  }
+
   private void persistIpMacObservations(
       FileEntity file, Map<String, LinkedHashSet<String>> macsByIp) {
     if (macsByIp == null || macsByIp.isEmpty()) return;

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -168,7 +168,16 @@ public class AnalysisService {
         // resolver used to apply at write time, so downstream behaviour is unchanged.
         List<HostnameResolverService.Claim> hostnameClaims =
             hostnameResolverService.resolve(tempFile);
-        hostnameClaimWriter.replaceForFile(fileId, hostnameClaims);
+        try {
+          hostnameClaimWriter.replaceForFile(fileId, hostnameClaims);
+        } catch (Exception e) {
+          // Best-effort: the writer's REQUIRES_NEW tx rolled back alone; analysis continues.
+          log.warn(
+              "Failed to persist {} hostname claim(s) for file {}: {}",
+              hostnameClaims.size(),
+              fileId,
+              e.getMessage());
+        }
         Map<String, HostnameResolverService.ResolvedHostname> hostnames =
             hostnameAdjudicator.adjudicate(hostnameClaims);
         // Per-host service activity logs (DNS today; web servers etc. later). Each extractor runs

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -83,7 +83,7 @@ public class AnalysisService {
   private final AnalysisRecordService analysisRecordService;
   private final ExtractionRunService extractionRunService;
   private final HostnameAdjudicator hostnameAdjudicator;
-  private final com.tracepcap.analysis.repository.HostnameClaimRepository hostnameClaimRepository;
+  private final HostnameClaimWriter hostnameClaimWriter;
 
   @Transactional
   public void analyzeFile(UUID fileId) {
@@ -168,7 +168,7 @@ public class AnalysisService {
         // resolver used to apply at write time, so downstream behaviour is unchanged.
         List<HostnameResolverService.Claim> hostnameClaims =
             hostnameResolverService.resolve(tempFile);
-        persistHostnameClaims(fileId, hostnameClaims);
+        hostnameClaimWriter.replaceForFile(fileId, hostnameClaims);
         Map<String, HostnameResolverService.ResolvedHostname> hostnames =
             hostnameAdjudicator.adjudicate(hostnameClaims);
         // Per-host service activity logs (DNS today; web servers etc. later). Each extractor runs
@@ -737,28 +737,6 @@ public class AnalysisService {
    * Persist the distinct source MACs observed per IP (#461). Only IPs with more than one MAC carry
    * overlap signal, but we store all pairings so the detector can present the full evidence.
    */
-  /** Regenerates this file's claims (re-analysis re-derives the same observations). Best-effort. */
-  private void persistHostnameClaims(
-      UUID fileId, List<HostnameResolverService.Claim> claims) {
-    try {
-      hostnameClaimRepository.deleteByFileId(fileId);
-      if (claims.isEmpty()) return;
-      hostnameClaimRepository.saveAll(
-          claims.stream()
-              .map(
-                  c ->
-                      com.tracepcap.analysis.entity.HostnameClaimEntity.builder()
-                          .fileId(fileId)
-                          .ip(c.ip())
-                          .hostname(c.hostname())
-                          .source(c.source())
-                          .build())
-              .toList());
-    } catch (Exception e) {
-      log.warn("Failed to persist {} hostname claim(s) for file {}: {}", claims.size(), fileId, e.getMessage());
-    }
-  }
-
   private void persistIpMacObservations(
       FileEntity file, Map<String, LinkedHashSet<String>> macsByIp) {
     if (macsByIp == null || macsByIp.isEmpty()) return;

--- a/backend/src/main/java/com/tracepcap/analysis/service/HostnameAdjudicator.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/HostnameAdjudicator.java
@@ -4,7 +4,9 @@ import com.tracepcap.analysis.service.HostnameResolverService.Claim;
 import com.tracepcap.analysis.service.HostnameResolverService.ResolvedHostname;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -35,7 +37,7 @@ public class HostnameAdjudicator {
   /** The per-IP winners, preserving the old first-seen-wins tie behaviour. */
   public Map<String, ResolvedHostname> adjudicate(Collection<Claim> claims) {
     Map<String, ResolvedHostname> winners = new LinkedHashMap<>();
-    Map<String, Boolean> contested = new LinkedHashMap<>();
+    Set<String> contested = new LinkedHashSet<>();
 
     for (Claim claim : claims) {
       ResolvedHostname existing = winners.get(claim.ip());
@@ -44,7 +46,7 @@ public class HostnameAdjudicator {
         continue;
       }
       if (!existing.hostname().equalsIgnoreCase(claim.hostname())) {
-        contested.put(claim.ip(), Boolean.TRUE);
+        contested.add(claim.ip());
       }
       if (SOURCE_PRIORITY.getOrDefault(existing.source(), Integer.MAX_VALUE)
           <= SOURCE_PRIORITY.getOrDefault(claim.source(), Integer.MAX_VALUE)) {
@@ -58,7 +60,7 @@ public class HostnameAdjudicator {
           "Hostname adjudication: {} of {} IP(s) contested (multiple distinct names claimed): {}",
           contested.size(),
           winners.size(),
-          contested.keySet().stream().limit(5).toList());
+          contested.stream().limit(5).toList());
     }
     return winners;
   }

--- a/backend/src/main/java/com/tracepcap/analysis/service/HostnameAdjudicator.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/HostnameAdjudicator.java
@@ -1,0 +1,65 @@
+package com.tracepcap.analysis.service;
+
+import com.tracepcap.analysis.service.HostnameResolverService.Claim;
+import com.tracepcap.analysis.service.HostnameResolverService.ResolvedHostname;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Picks each IP's display hostname from its recorded claims (#512 slice 4) — the Adjudicate-stage
+ * counterpart of {@link HostnameResolverService}'s Extract-stage claim collection. Hosted in
+ * {@code analysis} until a dedicated adjudicate module exists: the pipeline consumes the winners,
+ * and {@code analysis} must not depend on feature modules (frozen ArchUnit rule).
+ *
+ * <p>Semantics are identical to the old write-time selection: lowest {@code SOURCE_PRIORITY} wins
+ * per IP; the first claim seen wins ties. The difference is that losing claims now survive in
+ * {@code hostname_claims}, so identity-conflict scanners (#511) have evidence to work with —
+ * contested IPs (more than one distinct name claimed) are counted and logged here.
+ */
+@Slf4j
+@Component
+public class HostnameAdjudicator {
+
+  /** Lower value = more authoritative for a host's own identity; the lowest wins per IP. */
+  private static final Map<String, Integer> SOURCE_PRIORITY =
+      Map.of(
+          HostnameResolverService.SOURCE_MANUAL, 0,
+          HostnameResolverService.SOURCE_DHCP, 1,
+          HostnameResolverService.SOURCE_MDNS, 2,
+          HostnameResolverService.SOURCE_NBNS, 3,
+          HostnameResolverService.SOURCE_REVERSE_DNS, 4);
+
+  /** The per-IP winners, preserving the old first-seen-wins tie behaviour. */
+  public Map<String, ResolvedHostname> adjudicate(Collection<Claim> claims) {
+    Map<String, ResolvedHostname> winners = new LinkedHashMap<>();
+    Map<String, Boolean> contested = new LinkedHashMap<>();
+
+    for (Claim claim : claims) {
+      ResolvedHostname existing = winners.get(claim.ip());
+      if (existing == null) {
+        winners.put(claim.ip(), new ResolvedHostname(claim.hostname(), claim.source()));
+        continue;
+      }
+      if (!existing.hostname().equalsIgnoreCase(claim.hostname())) {
+        contested.put(claim.ip(), Boolean.TRUE);
+      }
+      if (SOURCE_PRIORITY.getOrDefault(existing.source(), Integer.MAX_VALUE)
+          <= SOURCE_PRIORITY.getOrDefault(claim.source(), Integer.MAX_VALUE)) {
+        continue; // keep the equal-or-better source already recorded
+      }
+      winners.put(claim.ip(), new ResolvedHostname(claim.hostname(), claim.source()));
+    }
+
+    if (!contested.isEmpty()) {
+      log.info(
+          "Hostname adjudication: {} of {} IP(s) contested (multiple distinct names claimed): {}",
+          contested.size(),
+          winners.size(),
+          contested.keySet().stream().limit(5).toList());
+    }
+    return winners;
+  }
+}

--- a/backend/src/main/java/com/tracepcap/analysis/service/HostnameClaimWriter.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/HostnameClaimWriter.java
@@ -1,0 +1,52 @@
+package com.tracepcap.analysis.service;
+
+import com.tracepcap.analysis.entity.HostnameClaimEntity;
+import com.tracepcap.analysis.repository.HostnameClaimRepository;
+import com.tracepcap.analysis.service.HostnameResolverService.Claim;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Persists a file's hostname claims (#512 slice 4). REQUIRES_NEW for the same reason as
+ * {@code ExtractionRunService.record}: claims are best-effort observations, and a failure here
+ * must not mark the analysis transaction rollback-only — a same-transaction catch would swallow
+ * the exception yet still doom the outer commit.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HostnameClaimWriter {
+
+  private final HostnameClaimRepository repository;
+
+  /** Regenerates this file's claims (re-analysis re-derives the same observations). Never throws. */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void replaceForFile(UUID fileId, List<Claim> claims) {
+    try {
+      repository.deleteByFileId(fileId);
+      if (claims.isEmpty()) return;
+      repository.saveAll(
+          claims.stream()
+              .map(
+                  c ->
+                      HostnameClaimEntity.builder()
+                          .fileId(fileId)
+                          .ip(c.ip())
+                          .hostname(c.hostname())
+                          .source(c.source())
+                          .build())
+              .toList());
+    } catch (Exception e) {
+      log.warn(
+          "Failed to persist {} hostname claim(s) for file {}: {}",
+          claims.size(),
+          fileId,
+          e.getMessage());
+    }
+  }
+}

--- a/backend/src/main/java/com/tracepcap/analysis/service/HostnameClaimWriter.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/HostnameClaimWriter.java
@@ -6,47 +6,38 @@ import com.tracepcap.analysis.service.HostnameResolverService.Claim;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Persists a file's hostname claims (#512 slice 4). REQUIRES_NEW for the same reason as
- * {@code ExtractionRunService.record}: claims are best-effort observations, and a failure here
- * must not mark the analysis transaction rollback-only — a same-transaction catch would swallow
- * the exception yet still doom the outer commit.
+ * Persists a file's hostname claims (#512 slice 4). REQUIRES_NEW isolates the write from the
+ * analysis transaction; failures propagate out of this proxy (rolling back only the inner tx) and
+ * are caught by the caller. The catch must sit on the caller's side of the boundary: repository
+ * methods are themselves transactional, so an in-method catch would return normally from a
+ * rollback-only transaction and commit would throw UnexpectedRollbackException anyway.
  */
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class HostnameClaimWriter {
 
   private final HostnameClaimRepository repository;
 
-  /** Regenerates this file's claims (re-analysis re-derives the same observations). Never throws. */
+  /** Regenerates this file's claims (re-analysis re-derives the same observations). */
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void replaceForFile(UUID fileId, List<Claim> claims) {
-    try {
-      repository.deleteByFileId(fileId);
-      if (claims.isEmpty()) return;
-      repository.saveAll(
-          claims.stream()
-              .map(
-                  c ->
-                      HostnameClaimEntity.builder()
-                          .fileId(fileId)
-                          .ip(c.ip())
-                          .hostname(c.hostname())
-                          .source(c.source())
-                          .build())
-              .toList());
-    } catch (Exception e) {
-      log.warn(
-          "Failed to persist {} hostname claim(s) for file {}: {}",
-          claims.size(),
-          fileId,
-          e.getMessage());
-    }
+    repository.deleteByFileId(fileId);
+    if (claims.isEmpty()) return;
+    repository.saveAll(
+        claims.stream()
+            .map(
+                c ->
+                    HostnameClaimEntity.builder()
+                        .fileId(fileId)
+                        .ip(c.ip())
+                        .hostname(c.hostname())
+                        .source(c.source())
+                        .build())
+            .toList());
   }
 }

--- a/backend/src/main/java/com/tracepcap/analysis/service/HostnameResolverService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/HostnameResolverService.java
@@ -4,6 +4,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -27,8 +29,10 @@ import org.springframework.stereotype.Service;
  * </ul>
  *
  * <p>A single host may be named by several sources; the most authoritative for the host's own
- * identity wins (see {@link #SOURCE_PRIORITY}). Runs as a single read-only tshark pass and never
- * throws — on any failure it returns whatever was resolved so far (possibly empty).
+ * identity wins — but winner-picking no longer happens here (#512 slice 4): this extractor
+ * records every claim it sees, conflict-preserving, and {@link HostnameAdjudicator} picks the
+ * display winner from the persisted claims. Runs as a single read-only tshark pass and never
+ * throws — on any failure it returns whatever was collected so far (possibly empty).
  */
 @Slf4j
 @Service
@@ -40,22 +44,22 @@ public class HostnameResolverService {
   public static final String SOURCE_DHCP = "dhcp";
   public static final String SOURCE_MANUAL = "manual";
 
-  /** Lower value = more authoritative for a host's own identity; the lowest wins per IP. */
-  private static final Map<String, Integer> SOURCE_PRIORITY =
-      Map.of(SOURCE_MANUAL, 0, SOURCE_DHCP, 1, SOURCE_MDNS, 2, SOURCE_NBNS, 3, SOURCE_REVERSE_DNS, 4);
-
   private static final int HOSTNAME_MAX_LENGTH = 255;
 
   /** A discovered hostname together with how it was found. */
   public record ResolvedHostname(String hostname, String source) {}
 
+  /** One raw claim: {@code source} asserted that {@code ip} is named {@code hostname}. */
+  public record Claim(String ip, String hostname, String source) {}
+
   /**
    * Scans the capture and returns a map of IP → resolved hostname for every host whose name could
    * be derived from DHCP, mDNS, NBNS or reverse DNS.
    */
-  public Map<String, ResolvedHostname> resolve(File pcapFile) {
+  public List<Claim> resolve(File pcapFile) {
     // Concurrent: the stdout reader (background thread) writes while the main thread reads size().
-    Map<String, ResolvedHostname> result = new ConcurrentHashMap<>();
+    // Keyed by (ip, hostname, source) to dedupe repeats while preserving distinct claims.
+    Map<Claim, Boolean> result = new ConcurrentHashMap<>();
 
     // Fields (pipe-separated, first occurrence only):
     //   0 _ws.col.Protocol  1 ip.src  2 dhcp.option.hostname
@@ -165,13 +169,13 @@ public class HostnameResolverService {
       if (ioExecutor != null) ioExecutor.shutdownNow();
     }
 
-    log.info("Resolved {} host name(s) from DHCP/mDNS/NBNS/reverse-DNS", result.size());
-    return result;
+    log.info("Collected {} hostname claim(s) from DHCP/mDNS/NBNS/reverse-DNS", result.size());
+    return new ArrayList<>(result.keySet());
   }
 
   // ── Row parsing ─────────────────────────────────────────────────────────────
 
-  private void parseRow(String[] f, Map<String, ResolvedHostname> result) {
+  private void parseRow(String[] f, Map<Claim, Boolean> result) {
     if (f.length < 11) return;
     String proto = f[0].toUpperCase();
 
@@ -197,20 +201,12 @@ public class HostnameResolverService {
     }
   }
 
-  /** Records ip → (hostname, source), keeping the most authoritative source already seen. */
-  private void record(
-      Map<String, ResolvedHostname> result, String ip, String rawHostname, String source) {
+  /** Records one claim verbatim. No winner-picking here — that is the adjudicator's job. */
+  private void record(Map<Claim, Boolean> result, String ip, String rawHostname, String source) {
     if (!isUsableIp(ip)) return;
     String hostname = cleanHostname(rawHostname);
     if (hostname == null) return;
-
-    ResolvedHostname existing = result.get(ip);
-    if (existing != null
-        && SOURCE_PRIORITY.getOrDefault(existing.source(), Integer.MAX_VALUE)
-            <= SOURCE_PRIORITY.getOrDefault(source, Integer.MAX_VALUE)) {
-      return; // keep the equal-or-better source already recorded
-    }
-    result.put(ip, new ResolvedHostname(hostname, source));
+    result.putIfAbsent(new Claim(ip, hostname, source), Boolean.TRUE);
   }
 
   // ── Field helpers ────────────────────────────────────────────────────────────

--- a/backend/src/main/resources/db/migration/V33__hostname_claims.sql
+++ b/backend/src/main/resources/db/migration/V33__hostname_claims.sql
@@ -1,0 +1,16 @@
+-- ── Hostname claims (#512 slice 4, prerequisite for #511) ────────────────────
+-- Every hostname observation for an IP, with the source that asserted it — conflict-preserving.
+-- The previous behaviour picked one winner by source priority at write time and discarded the
+-- rest, which erased exactly the conflicts identity scanners need (a host DHCP-announcing another
+-- machine's name was undetectable). Winner-picking now happens at read/adjudication time; these
+-- rows are the REPORTED-grade facts it draws from. Re-analysis regenerates a file's claims.
+
+CREATE TABLE hostname_claims (
+    id          BIGSERIAL PRIMARY KEY,
+    file_id     UUID         NOT NULL REFERENCES files (id) ON DELETE CASCADE,
+    ip          VARCHAR(45)  NOT NULL,
+    hostname    VARCHAR(255) NOT NULL,
+    source      VARCHAR(20)  NOT NULL,
+    created_at  TIMESTAMP    NOT NULL DEFAULT now(),
+    CONSTRAINT uq_hostname_claims UNIQUE (file_id, ip, hostname, source)
+);

--- a/backend/src/test/java/com/tracepcap/analysis/service/HostnameAdjudicatorTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/service/HostnameAdjudicatorTest.java
@@ -1,0 +1,73 @@
+package com.tracepcap.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tracepcap.analysis.service.HostnameResolverService.Claim;
+import com.tracepcap.analysis.service.HostnameResolverService.ResolvedHostname;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The adjudicator must reproduce the resolver's old write-time selection exactly (lowest source
+ * priority wins; first claim wins ties) — the slice's contract is "same winners, losers survive".
+ */
+class HostnameAdjudicatorTest {
+
+  private final HostnameAdjudicator adjudicator = new HostnameAdjudicator();
+
+  @Test
+  void dhcpOutranksMdnsNbnsAndReverseDns() {
+    Map<String, ResolvedHostname> winners =
+        adjudicator.adjudicate(
+            List.of(
+                new Claim("10.0.0.5", "printer-via-ptr", HostnameResolverService.SOURCE_REVERSE_DNS),
+                new Claim("10.0.0.5", "printer-via-nbns", HostnameResolverService.SOURCE_NBNS),
+                new Claim("10.0.0.5", "printer-via-dhcp", HostnameResolverService.SOURCE_DHCP),
+                new Claim("10.0.0.5", "printer-via-mdns", HostnameResolverService.SOURCE_MDNS)));
+
+    assertThat(winners.get("10.0.0.5").hostname()).isEqualTo("printer-via-dhcp");
+    assertThat(winners.get("10.0.0.5").source()).isEqualTo(HostnameResolverService.SOURCE_DHCP);
+  }
+
+  @Test
+  void equalPriority_firstClaimSeenWins() {
+    // The old record() kept the equal-or-better source already recorded — order must decide.
+    Map<String, ResolvedHostname> winners =
+        adjudicator.adjudicate(
+            List.of(
+                new Claim("10.0.0.7", "first-name", HostnameResolverService.SOURCE_MDNS),
+                new Claim("10.0.0.7", "second-name", HostnameResolverService.SOURCE_MDNS)));
+
+    assertThat(winners.get("10.0.0.7").hostname()).isEqualTo("first-name");
+  }
+
+  @Test
+  void conflictingClaims_bestSourceStillWins_evenWhenSeenLast() {
+    Map<String, ResolvedHostname> winners =
+        adjudicator.adjudicate(
+            List.of(
+                new Claim("10.0.0.9", "name-a", HostnameResolverService.SOURCE_NBNS),
+                new Claim("10.0.0.9", "name-b", HostnameResolverService.SOURCE_DHCP)));
+
+    assertThat(winners.get("10.0.0.9").hostname()).isEqualTo("name-b");
+  }
+
+  @Test
+  void independentIps_eachGetTheirOwnWinner() {
+    Map<String, ResolvedHostname> winners =
+        adjudicator.adjudicate(
+            List.of(
+                new Claim("10.0.0.1", "gw", HostnameResolverService.SOURCE_DHCP),
+                new Claim("10.0.0.2", "nas", HostnameResolverService.SOURCE_NBNS)));
+
+    assertThat(winners).hasSize(2);
+    assertThat(winners.get("10.0.0.1").hostname()).isEqualTo("gw");
+    assertThat(winners.get("10.0.0.2").hostname()).isEqualTo("nas");
+  }
+
+  @Test
+  void noClaims_noWinners() {
+    assertThat(adjudicator.adjudicate(List.of())).isEmpty();
+  }
+}

--- a/docs/architecture/layers.rst
+++ b/docs/architecture/layers.rst
@@ -390,10 +390,13 @@ is a refactor target, not a shrug.
   vocabulary, since publisher and consumer sit on opposite sides of the Scan/Adjudicate loop).
   Lesson kept for posterity: ArchUnit's cycle enumeration understates until the last cycle is
   gone — ``monitor ↔ subnets`` only surfaced after ``analysis ↔ file`` was fixed.
-* **``HostnameResolverService`` adjudicates at write time** — picks a winner by source priority
-  and discards competing claims, erasing the very conflicts the identity scanners need (#511's
-  spoofing case is undetectable today). Contrast ``IpMacObservationEntity``, which does it
-  right.
+* **Hostname claims are now conflict-preserving** (slice 4): ``HostnameResolverService`` records
+  every claim into ``hostname_claims`` (V33), and ``HostnameAdjudicator`` picks the display winner
+  with the old semantics — same winners, but losing claims survive, so #511's identity-conflict
+  scanners finally have evidence to read. The adjudicator is hosted in ``analysis`` until a
+  dedicated Adjudicate module exists (``analysis`` must not depend on feature modules — frozen
+  rule). Contested IPs are counted and logged; surfacing them as findings and UI state is #511's
+  work.
 * **``WebServerLogExtractor`` mixes stages** — extraction (endpoint logging) and scanning (the
   api/web role decision that #496 flags as broken) in one pass.
 * **Run manifest exists for nDPI only** (slice 2): ``extraction_runs`` records


### PR DESCRIPTION
## Summary

#512 slice 4: **Extract stops adjudicating.** The first slice that makes the Extract stage behave the way `docs/architecture/layers.rst` says it should — observations recorded, conclusions drawn downstream, losing claims surviving.

- **`hostname_claims` (V33)**: every `(ip, hostname, source)` claim the resolver sees is persisted, conflict-preserving — the `IpMacObservationEntity` pattern applied to names. `HostnameResolverService.record()` no longer picks winners; it stores claims verbatim (deduped within a capture).
- **`HostnameAdjudicator`** picks each IP's display hostname from the claims with *exactly* the old semantics — lowest source priority wins (manual > dhcp > mdns > nbns > reverse_dns), first claim seen wins ties — pinned by 5 unit tests. Downstream classification receives identical winners; **behaviour is unchanged by construction**.
- **What changes is what survives**: before, a host DHCP-announcing another machine's name erased the legitimate claim at write time — the #511 impersonation case was structurally undetectable. Losing claims now persist; contested IPs (multiple distinct names) are counted and logged. Surfacing contested state as findings/UI is #511's work, now unblocked.
- Placement note: the adjudicator is hosted in `analysis` — the pipeline consumes its winners and `analysis` must not depend on feature modules (frozen ArchUnit rule). Javadoc marks it as Adjudicate-stage logic awaiting a dedicated module.

## Test plan
- 141 tests green (5 new `HostnameAdjudicatorTest` cases pinning winner semantics: priority order, first-seen ties, cross-source conflict, independence, empty).
- **Live-verified**: uploaded `dns_demo.pcap` → persisted claims `93.184.216.34 → example.com` and `8.8.8.8 → dns.google` (reverse_dns), winners fed to classification unchanged.
- ArchUnit stores untouched (no new violations, no reworded entries).
- `docker compose build backend` passes; docs updated (divergence entry rewritten to reflect the fix).

Advances #512 (slice 4 ✅). Unblocks #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserves all hostname observations for each analyzed capture.
  * Selects the most reliable hostname for display using source priority.
  * Retains conflicting hostname claims for later review and analysis.
  * Records hostname claims with timestamps and prevents duplicates.

* **Bug Fixes**
  * Maintains consistent hostname selection across competing sources.
  * Preserves first-seen behavior when sources have equal priority.

* **Documentation**
  * Updated architecture documentation to describe hostname claim storage and adjudication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->