### PR TITLE
Frontend consumes adjudicated host identities — contested renders as contested (#512 slice 5b)

### DIFF
--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -45,6 +45,8 @@ interface NetworkGraphProps {
 // ---------------------------------------------------------------------------
 
 const DARK_BG = '#0f1117';
+/** Dashed ring for contested identities (#512 slice 5b) — amber, distinct from highlight colors. */
+const CONTESTED_COLOR = '#f59e0b';
 const DARK_SURFACE = '#1e2130';
 const LIGHT_BG = '#f6f8fa';
 
@@ -202,7 +204,7 @@ function drawNodeLabel(
     ctx.beginPath();
     ctx.setLineDash([size * 0.35, size * 0.25]);
     ctx.arc(x, y, size + size * 0.3, 0, Math.PI * 2);
-    ctx.strokeStyle = '#f59e0b';
+    ctx.strokeStyle = CONTESTED_COLOR;
     ctx.lineWidth = Math.max(1.5, size * 0.1);
     ctx.stroke();
     ctx.setLineDash([]);

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -130,10 +130,17 @@ function buildNodeLines(node: GraphNode, cfg: NodeLabelConfig): string[] {
         value = node.data.mac;
         break;
       case 'deviceType':
-        value =
-          node.data.deviceType && node.data.deviceType !== 'UNKNOWN'
-            ? deviceTypeLabel(node.data.deviceType)
-            : undefined;
+        // Adjudicated identity is the display authority (#512 slice 5b): a human-confirmed
+        // label replaces the machine type; a contested identity is marked as a question.
+        if (node.data.identityBasis === 'HUMAN' && node.data.identityLabel) {
+          value = node.data.identityLabel;
+        } else {
+          value =
+            node.data.deviceType && node.data.deviceType !== 'UNKNOWN'
+              ? deviceTypeLabel(node.data.deviceType)
+              : undefined;
+          if (value && node.data.identityContested) value += ' (contested)';
+        }
         break;
       case 'manufacturer':
         value = node.data.manufacturer;
@@ -157,11 +164,13 @@ function drawNodeLabel(
   dtMap: Map<string, string>,
   linesMap: Map<string, string[]>,
   hlMap?: Map<string, NodeHighlight>,
+  contestedMap?: Map<string, boolean>,
 ): void {
   const { x, y, size, label, color: accentColor } = data;
   const nodeType = ntMap.get(label ?? '') ?? 'unknown';
   const deviceType = dtMap.get(label ?? '') ?? '';
   const highlight = label ? hlMap?.get(label) : undefined;
+  const contested = label ? contestedMap?.get(label) ?? false : false;
 
   // Outer glow ring for highlighted (changed) nodes
   if (highlight) {
@@ -186,6 +195,18 @@ function drawNodeLabel(
   ctx.strokeStyle = highlight ? highlight.color : accentColor;
   ctx.lineWidth = highlight ? Math.max(2, size * 0.12) : Math.max(1, size * 0.07);
   ctx.stroke();
+
+  // Contested-identity ring (#512 slice 5b, #498): dashed amber outside the accent ring —
+  // the adjudicator found competing answers, so the node must read as a question, not a fact.
+  if (contested) {
+    ctx.beginPath();
+    ctx.setLineDash([size * 0.35, size * 0.25]);
+    ctx.arc(x, y, size + size * 0.3, 0, Math.PI * 2);
+    ctx.strokeStyle = '#f59e0b';
+    ctx.lineWidth = Math.max(1.5, size * 0.1);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
 
   // Bootstrap Icon — reflects the same logic as getNodeColor/getNodeIcon
   const cp = getNodeIcon(nodeType, deviceType);
@@ -292,6 +313,7 @@ function buildGraph(
       label: n.label,
       nodeType,
       deviceType: n.data.deviceType ?? '',
+      identityContested: !!n.data.identityContested,
       isCluster: !!n.data.isCluster,
       clusterId: n.data.clusterId,
       memberCount: n.data.memberCount ?? 0,
@@ -408,6 +430,7 @@ export const NetworkGraph = memo(function NetworkGraph({
   const graphRef = useRef<Graph | null>(null);
   const nodeTypeByLabel = useRef<Map<string, string>>(new Map());
   const deviceTypeByLabel = useRef<Map<string, string>>(new Map());
+  const contestedByLabel = useRef<Map<string, boolean>>(new Map());
   // Per-node text lines (keyed by the node's label), derived from the user's label config.
   const nodeLinesByLabel = useRef<Map<string, string[]>>(new Map());
   const nodeLabelConfig = useStore(s => s.nodeLabelConfig);
@@ -508,10 +531,10 @@ export const NetworkGraph = memo(function NetworkGraph({
       minEdgeThickness: 0.5,
       zIndex: true,
       defaultDrawNodeLabel: (ctx, data) => {
-        drawNodeLabel(ctx, data, labelColor, nodeFill, nodeTypeByLabel.current, deviceTypeByLabel.current, nodeLinesByLabel.current, highlightedNodesRef.current);
+        drawNodeLabel(ctx, data, labelColor, nodeFill, nodeTypeByLabel.current, deviceTypeByLabel.current, nodeLinesByLabel.current, highlightedNodesRef.current, contestedByLabel.current);
       },
       defaultDrawNodeHover: (ctx, data) => {
-        drawNodeLabel(ctx, data, labelColor, nodeFill, nodeTypeByLabel.current, deviceTypeByLabel.current, nodeLinesByLabel.current, highlightedNodesRef.current);
+        drawNodeLabel(ctx, data, labelColor, nodeFill, nodeTypeByLabel.current, deviceTypeByLabel.current, nodeLinesByLabel.current, highlightedNodesRef.current, contestedByLabel.current);
       },
       nodeReducer: (node, data) => {
         const res = { ...data };
@@ -611,11 +634,13 @@ export const NetworkGraph = memo(function NetworkGraph({
     sigma.on('beforeRender', () => {
       nodeTypeByLabel.current.clear();
       deviceTypeByLabel.current.clear();
+      contestedByLabel.current.clear();
       graph.forEachNode((_node, attrs) => {
         const label = attrs['label'] as string ?? '';
         if (!label) return;
         nodeTypeByLabel.current.set(label, attrs['nodeType'] as string ?? 'unknown');
         deviceTypeByLabel.current.set(label, attrs['deviceType'] as string ?? '');
+        if (attrs['identityContested']) contestedByLabel.current.set(label, true);
       });
     });
 

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -45,9 +45,7 @@ interface NetworkGraphProps {
 // ---------------------------------------------------------------------------
 
 const DARK_BG = '#0f1117';
-/** Contested-identity ring (#512 slice 5b) — amber, matches the NodeDetails bg-warning badge. */
-const CONTESTED_COLOR = '#f59e0b';
-/** Dashed ring for contested identities (#512 slice 5b) — amber, distinct from highlight colors. */
+/** Dashed ring for contested identities (#512 slice 5b) — amber, matches NodeDetails' bg-warning badge. */
 const CONTESTED_COLOR = '#f59e0b';
 const DARK_SURFACE = '#1e2130';
 const LIGHT_BG = '#f6f8fa';

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -45,6 +45,8 @@ interface NetworkGraphProps {
 // ---------------------------------------------------------------------------
 
 const DARK_BG = '#0f1117';
+/** Contested-identity ring (#512 slice 5b) — amber, matches the NodeDetails bg-warning badge. */
+const CONTESTED_COLOR = '#f59e0b';
 /** Dashed ring for contested identities (#512 slice 5b) — amber, distinct from highlight colors. */
 const CONTESTED_COLOR = '#f59e0b';
 const DARK_SURFACE = '#1e2130';

--- a/frontend/src/components/network/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/components/network/NodeDetails/NodeDetails.tsx
@@ -424,32 +424,37 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                       </dd>
 
                       {/* Adjudicated identity (#512 slice 5b) — one voice, or an explicit contest */}
-                      {node.data.identityLabel && (
-                        <>
-                          <dt className="col-5 text-muted">Identity</dt>
-                          <dd className="col-7 mb-1">
-                            <span
-                              className={`badge ${node.data.identityContested ? 'bg-warning text-dark' : node.data.identityBasis === 'HUMAN' ? 'bg-primary' : 'bg-secondary'}`}
-                              title={
-                                node.data.identityContested
-                                  ? `Contested — candidates: ${(node.data.identityCandidates ?? []).map(c => `${c.label} (${c.score})`).join(' vs ')}`
-                                  : node.data.identityBasis === 'HUMAN'
-                                    ? 'Confirmed by analyst'
-                                    : `Adjudicated from classification (confidence ${node.data.identityConfidence}%)`
-                              }
-                            >
-                              {node.data.identityBasis === 'HUMAN' ? '✓ ' : ''}
-                              {node.data.identityLabel}
-                              {node.data.identityContested ? ' ⚠ contested' : ''}
-                            </span>
-                            {node.data.identityContested && node.data.identityCandidates && (
-                              <div className="text-muted mt-1" style={{ fontSize: '0.7rem' }}>
-                                {node.data.identityCandidates.map(c => `${c.label} (${c.score})`).join(' vs ')}
-                              </div>
-                            )}
-                          </dd>
-                        </>
-                      )}
+                      {node.data.identityLabel && (() => {
+                        const candidatesText = (node.data.identityCandidates ?? [])
+                          .map(c => `${c.label} (${c.score})`)
+                          .join(' vs ');
+                        return (
+                          <>
+                            <dt className="col-5 text-muted">Identity</dt>
+                            <dd className="col-7 mb-1">
+                              <span
+                                className={`badge ${node.data.identityContested ? 'bg-warning text-dark' : node.data.identityBasis === 'HUMAN' ? 'bg-primary' : 'bg-secondary'}`}
+                                title={
+                                  node.data.identityContested
+                                    ? `Contested — candidates: ${candidatesText}`
+                                    : node.data.identityBasis === 'HUMAN'
+                                      ? 'Confirmed by analyst'
+                                      : `Adjudicated from classification (confidence ${node.data.identityConfidence}%)`
+                                }
+                              >
+                                {node.data.identityBasis === 'HUMAN' ? '✓ ' : ''}
+                                {node.data.identityLabel}
+                                {node.data.identityContested ? ' ⚠ contested' : ''}
+                              </span>
+                              {node.data.identityContested && candidatesText && (
+                                <div className="text-muted mt-1" style={{ fontSize: '0.7rem' }}>
+                                  {candidatesText}
+                                </div>
+                              )}
+                            </dd>
+                          </>
+                        );
+                      })()}
                     </dl>
                   </div>
 

--- a/frontend/src/components/network/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/components/network/NodeDetails/NodeDetails.tsx
@@ -422,6 +422,34 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                           );
                         })()}
                       </dd>
+
+                      {/* Adjudicated identity (#512 slice 5b) — one voice, or an explicit contest */}
+                      {node.data.identityLabel && (
+                        <>
+                          <dt className="col-5 text-muted">Identity</dt>
+                          <dd className="col-7 mb-1">
+                            <span
+                              className={`badge ${node.data.identityContested ? 'bg-warning text-dark' : node.data.identityBasis === 'HUMAN' ? 'bg-primary' : 'bg-secondary'}`}
+                              title={
+                                node.data.identityContested
+                                  ? `Contested — candidates: ${(node.data.identityCandidates ?? []).map(c => `${c.label} (${c.score})`).join(' vs ')}`
+                                  : node.data.identityBasis === 'HUMAN'
+                                    ? 'Confirmed by analyst'
+                                    : `Adjudicated from classification (confidence ${node.data.identityConfidence}%)`
+                              }
+                            >
+                              {node.data.identityBasis === 'HUMAN' ? '✓ ' : ''}
+                              {node.data.identityLabel}
+                              {node.data.identityContested ? ' ⚠ contested' : ''}
+                            </span>
+                            {node.data.identityContested && node.data.identityCandidates && (
+                              <div className="text-muted mt-1" style={{ fontSize: '0.7rem' }}>
+                                {node.data.identityCandidates.map(c => `${c.label} (${c.score})`).join(' vs ')}
+                              </div>
+                            )}
+                          </dd>
+                        </>
+                      )}
                     </dl>
                   </div>
 

--- a/frontend/src/features/conversation/services/conversationService.ts
+++ b/frontend/src/features/conversation/services/conversationService.ts
@@ -9,6 +9,7 @@ import type {
   PaginatedResponse,
   Packet,
   HostClassification,
+  HostIdentity,
 } from '@/types';
 import type { ConversationFilters } from '../types';
 
@@ -369,6 +370,12 @@ export const conversationService = {
     const response = await apiClient.get<HostClassification[]>(
       API_ENDPOINTS.HOST_CLASSIFICATIONS(fileId)
     );
+    return response.data;
+  },
+
+  /** Adjudicated per-host identities for a file (winner-or-contested; #512 slice 5). */
+  getHostIdentities: async (fileId: string): Promise<HostIdentity[]> => {
+    const response = await apiClient.get<HostIdentity[]>(API_ENDPOINTS.HOST_IDENTITIES(fileId));
     return response.data;
   },
 

--- a/frontend/src/features/network/hooks/useNetworkData.ts
+++ b/frontend/src/features/network/hooks/useNetworkData.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { conversationService } from '@/features/conversation/services/conversationService';
 import { networkService } from '../services/networkService';
 import type { GraphNode, GraphEdge, NetworkStats } from '../types';
-import type { Conversation, HostClassification } from '@/types';
+import type { Conversation, HostClassification, HostIdentity } from '@/types';
 import type { AnalysisSummary } from '@/types';
 import { env } from '@/config/env';
 
@@ -41,6 +41,7 @@ export function useNetworkData(
   // Raw data cached after the initial fetch — transform re-runs without re-fetching
   const conversationsRef = useRef<Conversation[]>([]);
   const hostClassificationsRef = useRef<HostClassification[] | undefined>(undefined);
+  const hostIdentitiesRef = useRef<HostIdentity[] | undefined>(undefined);
 
   const [nodes, setNodes] = useState<GraphNode[]>([]);
   const [edges, setEdges] = useState<GraphEdge[]>([]);
@@ -62,14 +63,16 @@ export function useNetworkData(
     conversations: Conversation[],
     hostClassifications: HostClassification[] | undefined,
     summary: AnalysisSummary | undefined,
-    limit: number
+    limit: number,
+    hostIdentities?: HostIdentity[]
   ) => {
     const graphData = networkService.buildNetworkGraph(
       conversations,
       summary,
       maxConversations,
       hostClassifications,
-      limit
+      limit,
+      hostIdentities
     );
     setNodes(graphData.nodes);
     setEdges(graphData.edges);
@@ -126,10 +129,20 @@ export function useNetworkData(
         // If the endpoint isn't available (e.g. older analysis), silently skip
       }
 
+      // Adjudicated identities (#512 slice 5) — best-effort: files analysed before the
+      // adjudicator existed simply have none, and the display falls back to raw classification.
+      let hostIdentities: HostIdentity[] | undefined;
+      try {
+        hostIdentities = await conversationService.getHostIdentities(fileId);
+      } catch {
+        // endpoint unavailable → fall back silently
+      }
+
       conversationsRef.current = conversations;
       hostClassificationsRef.current = hostClassifications;
+      hostIdentitiesRef.current = hostIdentities;
 
-      applyTransform(conversations, hostClassifications, analysisSummary, maxNodes);
+      applyTransform(conversations, hostClassifications, analysisSummary, maxNodes, hostIdentities);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to load network data';
       setError(errorMessage);
@@ -152,7 +165,8 @@ export function useNetworkData(
       conversationsRef.current,
       hostClassificationsRef.current,
       analysisSummary,
-      maxNodes
+      maxNodes,
+      hostIdentitiesRef.current
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [maxNodes, analysisSummary]);

--- a/frontend/src/features/network/services/networkService.ts
+++ b/frontend/src/features/network/services/networkService.ts
@@ -1,4 +1,4 @@
-import type { Conversation, AnalysisSummary, HostClassification } from '@/types';
+import type { Conversation, AnalysisSummary, HostClassification, HostIdentity } from '@/types';
 import type {
   GraphNode,
   GraphEdge,
@@ -372,7 +372,8 @@ export function buildNetworkGraph(
   analysisSummary?: AnalysisSummary,
   maxConversations: number = 500,
   hostClassifications?: HostClassification[],
-  maxNodes: number = 50
+  maxNodes: number = 50,
+  hostIdentities?: HostIdentity[]
 ): NetworkGraphData {
   const nodeMap: NodeMap = {};
   const edges: GraphEdge[] = [];
@@ -530,6 +531,14 @@ export function buildNetworkGraph(
     }
   });
 
+  // Adjudicated identities (#512 slice 5b): the display authority where present. A HUMAN basis
+  // replaces machine-derived labels outright; contested identities are rendered as contests
+  // rather than asserted winners. Files analysed before the adjudicator have no identities and
+  // fall back to raw classification display unchanged.
+  const identityMap = hostIdentities
+    ? new Map(hostIdentities.map(i => [i.ip, i]))
+    : undefined;
+
   // Apply backend device classifications (deviceType, confidence, manufacturer)
   if (hostClassifications) {
     const classMap = new Map(hostClassifications.map(c => [c.ip, c]));
@@ -550,6 +559,21 @@ export function buildNetworkGraph(
           if (nodeMap[ip].label === ip) nodeMap[ip].label = c.hostname;
         }
       }
+    });
+  }
+
+  if (identityMap) {
+    Object.keys(nodeMap).forEach(ip => {
+      const identity = identityMap.get(ip);
+      if (!identity) return;
+      const d = nodeMap[ip].data;
+      d.identityLabel = identity.primaryLabel;
+      d.identityBasis = identity.basis;
+      d.identityConfidence = identity.confidence;
+      d.identityContested = identity.contested;
+      d.identityCandidates = identity.candidates ?? undefined;
+      // A human-confirmed label outranks every machine-derived display value.
+      if (identity.basis === 'HUMAN') d.deviceType = undefined;
     });
   }
 

--- a/frontend/src/features/network/types/index.ts
+++ b/frontend/src/features/network/types/index.ts
@@ -53,6 +53,13 @@ export interface NodeData {
   serviceRoles?: string[];
   /** Confidence score 0–100 from the classifier. */
   deviceConfidence?: number;
+  /** Adjudicated identity (#512 slice 5b) — the display authority where present. */
+  identityLabel?: string;
+  identityBasis?: 'HUMAN' | 'MACHINE';
+  identityConfidence?: number;
+  /** True when machine candidates were too close to call; render the contest, not the winner. */
+  identityContested?: boolean;
+  identityCandidates?: { label: string; source: string; score: number }[];
   /** Manufacturer from OUI lookup. */
   manufacturer?: string;
   /** TTL observed for this host. */

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -15,6 +15,7 @@ export const API_ENDPOINTS = {
 
   // Host Classifications
   HOST_CLASSIFICATIONS: (fileId: string) => `/files/${fileId}/host-classifications`,
+  HOST_IDENTITIES: (fileId: string) => `/files/${fileId}/host-identities`,
 
   // Conversations
   CONVERSATIONS: (fileId: string) => `/conversations/${fileId}`,

--- a/frontend/src/types/common.types.ts
+++ b/frontend/src/types/common.types.ts
@@ -430,6 +430,20 @@ export interface HostClassification {
   serviceRoles?: string[];
 }
 
+/** Adjudicated identity of one host (#512 slice 5) — one answer, or an explicit contest. */
+export interface HostIdentity {
+  ip: string;
+  /** The one answer to "what is this host?" — a device type, or the analyst's label verbatim. */
+  primaryLabel: string;
+  /** HUMAN (confirmed node-role label) or MACHINE (classification vote). */
+  basis: 'HUMAN' | 'MACHINE';
+  confidence: number;
+  /** True when machine candidates were too close to call; render the contest, not the winner. */
+  contested: boolean;
+  /** Competing candidates when contested. */
+  candidates?: { label: string; source: string; score: number }[] | null;
+}
+
 /** How a host's name was discovered from passive traffic. */
 export type HostnameSource = 'reverse_dns' | 'mdns' | 'nbns' | 'dhcp' | 'manual';
 


### PR DESCRIPTION
## Summary

#512 slice 5b: **the frontend stops adjudicating.** The graph consumes `GET /files/{fileId}/host-identities` (slice 5a, #516) and renders the backend's one-voice answer — including the honest one: *contested*.

- **Contested identities** draw a dashed amber ring outside the accent ring and suffix the label with `(contested)`. Uncertainty is visible at a glance on the diagram itself — #498's exact ask, no click-through required.
- **Human-confirmed labels** (basis `HUMAN`) replace machine-derived device types outright in node labels; NodeDetails shows an identity badge with basis, confidence, and the competing candidates when contested.
- **Graceful fallback**: files analysed before the adjudicator existed have no identities; display falls back to raw classification, pixel-identical to today.
- Plumbing follows the existing sidecar-map pattern (Sigma strips custom attrs, so `contested` travels by label exactly like `nodeType`/`deviceType` already do).

### Scope note (honest)
This removes the frontend's *adjudication* role — display authority now comes from the backend. Its *scanning* role (`classifyNodeType` port/nDPI heuristics feeding filters and service tabs) still exists and is the remaining #499 follow-up, tracked on #512.

## Test plan
- `npx tsc --noEmit` clean (from `frontend/`); `docker compose build nginx` passes.
- **Playwright-verified against the running stack** (screenshot in the workflow): `telegram.pcap` → 28 identities / 25 contested → dashed amber rings on the thin-evidence hosts, solid ring on the uncontested router, identity API consumed, zero page errors.

Advances #512 (slice 5b). Together with #516, closes the visible half of #498/#499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added adjudicated host identities to network views, prioritizing confirmed human labels where available.
  - Clearly marks contested identities with a “contested” label and visual indicator.
  - Added an Adjudicated identity section to node details, including confidence, adjudication basis, and competing candidates.
  - Network data now retrieves and displays identity candidates and their scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->