### PR TITLE
fix: footer version always identifies the build, never "dev"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# App Version — the footer version is baked in at build time, not set here.
+# The default lives in docker-compose.yml and is synced on every merge to main by
+# .github/workflows/app-version.yml. Export APP_VERSION to override it for a build.
+#
 # Memory & Upload Configuration
 # APP_MEMORY_MB: Total RAM (in MB) to allocate to the backend container.
 # Everything else is derived automatically from this one value:

--- a/.github/workflows/app-version.yml
+++ b/.github/workflows/app-version.yml
@@ -1,0 +1,75 @@
+name: Sync App Version
+
+# Keeps the VITE_APP_VERSION default in docker-compose.yml pointing at the latest
+# main commit, so a plain `docker compose up -d --build` bakes in a real version
+# with no local setup. Compose only interpolates ${...} from the shell env and .env
+# (which is gitignored), so the value has to live in the compose file itself.
+#
+# The commit below is made with GITHUB_TOKEN, which by design cannot trigger further
+# workflows — so this never retriggers publish-ghcr.yml or itself.
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Full history + tags so `git describe --tags` reaches the nearest tag.
+          fetch-depth: 0
+
+      - name: Resolve version
+        run: |
+          VERSION=$(git describe --tags --always 2>/dev/null || git rev-parse --short HEAD)
+          if [ -z "$VERSION" ] || [ "$VERSION" = "dev" ]; then
+            echo "::error::Resolved version is empty or 'dev' — refusing to write an untraceable version."
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Rewrite the VITE_APP_VERSION default
+        run: |
+          python3 - "$VERSION" <<'PY'
+          import re, sys
+
+          version = sys.argv[1]
+          path = "docker-compose.yml"
+
+          with open(path) as f:
+              content = f.read()
+
+          pattern = re.compile(r'(VITE_APP_VERSION: \$\{APP_VERSION:-)([^}]*)(\})')
+          if not pattern.search(content):
+              sys.exit("VITE_APP_VERSION default not found in docker-compose.yml — "
+                       "the anchor changed; update app-version.yml to match.")
+
+          updated = pattern.sub(lambda m: m.group(1) + version + m.group(3), content, count=1)
+
+          if updated == content:
+              print("Version already current; nothing to write.")
+          else:
+              with open(path, "w") as f:
+                  f.write(updated)
+              print(f"Wrote VITE_APP_VERSION default: {version}")
+          PY
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet docker-compose.yml; then
+            echo "docker-compose.yml already up to date — no commit needed."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docker-compose.yml
+          git commit -m "chore: sync app version to ${VERSION} [skip ci]"
+          git push

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Full history + tags, so `git describe --tags` can reach the nearest tag
+          # instead of degrading to a bare hash.
+          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -43,6 +47,10 @@ jobs:
 
           # Version string for the frontend footer (e.g. v0.1.1-113-g6e040b4)
           APP_VERSION=$(git describe --tags --always 2>/dev/null || echo "$SHORT_SHA")
+          if [ -z "$APP_VERSION" ] || [ "$APP_VERSION" = "dev" ]; then
+            echo "::error::Resolved APP_VERSION is empty or 'dev' — the build would not be traceable to a commit."
+            exit 1
+          fi
           echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
 
           # Convert repository owner to lowercase for Docker image naming

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,10 @@ services:
         VITE_API_BASE_URL: /api/v1
         VITE_SUPPORTED_FILE_TYPES: ${VITE_SUPPORTED_FILE_TYPES:-.pcap,.pcapng,.cap}
         VITE_NETWORK_DIAGRAM_CONVERSATION_LIMIT: ${VITE_NETWORK_DIAGRAM_CONVERSATION_LIMIT:-false}
-        VITE_APP_VERSION: ${APP_VERSION:-dev}
+        # The default below is rewritten on every merge to main by
+        # .github/workflows/app-version.yml — it is the version local builds bake in.
+        # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-150-g494ed72}
     container_name: tracepcap-nginx
     environment:
       # Memory allocation — nginx body limit and timeouts derived from this

--- a/frontend/src/components/common/Layout/MainLayout.tsx
+++ b/frontend/src/components/common/Layout/MainLayout.tsx
@@ -167,7 +167,7 @@ export const MainLayout = () => {
               <small>TracePcap &copy; 2026 - Network Traffic Analysis and Visualization Tool</small>
               <br />
               <small className="text-muted opacity-75">
-                {typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : ''}
+                {__APP_VERSION__}
               </small>
             </Col>
           </Row>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,17 +5,28 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 import { execSync } from 'child_process'
 
+// The VITE_APP_VERSION build arg is the primary source: the Docker build context excludes
+// .git, so the git call below only ever resolves on a bare-metal build.
 function getAppVersion(envFallback?: string): string {
+  // Vite's loadEnv populates the `env` object but not process.env, so accept the loaded value.
+  const supplied = (envFallback || process.env.VITE_APP_VERSION || '').trim();
+  if (supplied) return supplied;
+
   try {
     // stdio: silence git's stderr ("fatal: not a git repository") in non-git build contexts.
-    return execSync('git describe --tags --always', {
+    const described = execSync('git describe --tags --always', {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
+    if (described) return described;
   } catch {
-    // Vite's loadEnv populates the `env` object but not process.env, so accept the loaded value.
-    return envFallback || process.env.VITE_APP_VERSION || 'dev';
+    // Fall through to the error below — an unidentifiable build must not ship.
   }
+
+  throw new Error(
+    'Cannot resolve app version: VITE_APP_VERSION was not supplied and `git describe` is ' +
+      'unavailable. Pass the VITE_APP_VERSION build arg (see docker-compose.yml).'
+  );
 }
 
 const VALID_RESOLUTIONS = ['110m', '50m', '10m'] as const;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,12 @@ import { execSync } from 'child_process'
 
 // The VITE_APP_VERSION build arg is the primary source: the Docker build context excludes
 // .git, so the git call below only ever resolves on a bare-metal build.
-function getAppVersion(envFallback?: string): string {
+//
+// `isBuild` gates the failure: only a build produces a shippable artifact, so only a build
+// must refuse to proceed without a real version (#500). The dev server and vitest compile
+// __APP_VERSION__ for a process that is never deployed, so they degrade to a label instead
+// of breaking in .git-less checkouts (zip downloads, test containers).
+function getAppVersion(isBuild: boolean, envFallback?: string): string {
   // Vite's loadEnv populates the `env` object but not process.env, so accept the loaded value.
   const supplied = (envFallback || process.env.VITE_APP_VERSION || '').trim();
   if (supplied) return supplied;
@@ -20,8 +25,10 @@ function getAppVersion(envFallback?: string): string {
     }).trim();
     if (described) return described;
   } catch {
-    // Fall through to the error below — an unidentifiable build must not ship.
+    // Fall through — either fail the build, or label a non-shipping process below.
   }
+
+  if (!isBuild) return 'local-dev';
 
   throw new Error(
     'Cannot resolve app version: VITE_APP_VERSION was not supplied and `git describe` is ' +
@@ -33,7 +40,7 @@ const VALID_RESOLUTIONS = ['110m', '50m', '10m'] as const;
 type MapResolution = (typeof VALID_RESOLUTIONS)[number];
 
 // https://vite.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd());
   const rawResolution = env.VITE_MAP_RESOLUTION ?? '50m';
   const resolution: MapResolution = (VALID_RESOLUTIONS as readonly string[]).includes(rawResolution)
@@ -55,7 +62,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     define: {
-      __APP_VERSION__: JSON.stringify(getAppVersion(env.VITE_APP_VERSION)),
+      __APP_VERSION__: JSON.stringify(getAppVersion(command === 'build', env.VITE_APP_VERSION)),
     },
     plugins: [react(), worldMapPlugin],
     resolve: {

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -16,7 +16,8 @@ COPY frontend ./
 ARG VITE_API_BASE_URL=/api/v1
 ARG VITE_SUPPORTED_FILE_TYPES=.pcap,.pcapng,.cap
 ARG VITE_NETWORK_DIAGRAM_CONVERSATION_LIMIT=false
-ARG VITE_APP_VERSION=dev
+# No default: an unsupplied version must fail the build, not bake in an untraceable one.
+ARG VITE_APP_VERSION
 # OIDC/Keycloak auth (off by default; enabled via docker-compose.prod.yml)
 ARG VITE_AUTH_ENABLED=false
 ARG VITE_OIDC_AUTHORITY=


### PR DESCRIPTION
Closes #500

## Summary

Makes the `VITE_APP_VERSION` build arg the single source of truth. Previously every layer independently bottomed out at `dev`, so a deployed instance could not be traced back to the commit it was built from.

All three defects in the issue are addressed:

- **Defect 1** (`.git` excluded from the Docker context, so `git describe` always failed) — the git call is demoted to a bare-metal-only fallback. It could never resolve inside the builder stage, so it was never really the primary path despite being written as one.
- **Defect 2** (fallback chain lands on `dev`) — `ARG VITE_APP_VERSION=dev` loses its default, and vite now **throws** where it used to return `dev`. An unidentifiable build fails instead of shipping.
- **Defect 3** (shallow checkout) — `fetch-depth: 0` so `git describe --tags` reaches the nearest tag rather than degrading to a bare hash.

## Local builds: how `docker compose up -d --build` still works with zero setup

New `app-version.yml` workflow rewrites the default in `docker-compose.yml` on every merge to main:

```yaml
VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-150-g494ed72}
                                 # ^ CI rewrites this
```

A dev pulls main and builds — the version is already in the repo. No script, no local setup.

**Why `docker-compose.yml` and not `.env.example`:** compose only interpolates `${...}` from the shell env and `.env`. It never reads `.env.example`, and wiring it via `env_file:` does not work either — `env_file` populates the *container runtime env*, not the shell doing interpolation, so the value would reach the running container but never reach `npm run build` where it gets baked in. `.env` itself is gitignored, so CI cannot write to it. That leaves the compose file as the only tracked file plain compose reads for a build arg.

GHCR images do not depend on this file — `publish-ghcr.yml` computes `git describe` live, so published images are always exact.

## Test plan

- [x] Bare-metal, no arg → resolves via `git describe` (`v0.1.1-150-g494ed72`)
- [x] Build arg supplied → wins over git
- [x] No `.git` + no arg (the Docker builder stage) → throws with an actionable message, instead of the old silent `dev`
- [x] `docker compose build` with no `.env` → **fails** (previously baked in `dev`)
- [x] Clean checkout, plain `docker compose up -d --build` → `v0.1.1-150-g494ed72` confirmed baked into the shipped JS bundle
- [x] `APP_VERSION` export still overrides the CI-written default
- [x] Workflow rewrite step run verbatim against the real `docker-compose.yml` → valid YAML, compose accepts it; hard-fails if the anchor line ever changes shape
- [x] `tsc --noEmit` clean; `__APP_VERSION__` confirmed defined under vitest, so the removed footer guard is safe

## Reviewer notes

- **Branch protection:** the bump commit is pushed by `github-actions[bot]`. If `main` requires reviews, that push will be rejected and needs a bypass or a PAT. Worth confirming before merge.
- **One commit behind:** CI's bump is itself a commit, so the compose default names the merge commit before it. Fine for a local dev footer; this is why GHCR images compute the version live instead.
- **Path filters:** `e2e.yml` and `system-tests.yml` filter on `docker-compose.yml`, so version bumps will appear in their diffs on later PRs. The bump commit itself cannot trigger workflows (GITHUB_TOKEN), which is also what prevents a loop with `publish-ghcr.yml`.
- Pre-existing eslint error at `vite.config.ts:1` (triple-slash reference) confirmed present on `main` and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)