### PR TITLE
fix: version sync opens a PR instead of pushing to protected main

### DIFF
--- a/.github/workflows/app-version.yml
+++ b/.github/workflows/app-version.yml
@@ -5,19 +5,28 @@ name: Sync App Version
 # with no local setup. Compose only interpolates ${...} from the shell env and .env
 # (which is gitignored), so the value has to live in the compose file itself.
 #
-# The commit below is made with GITHUB_TOKEN, which by design cannot trigger further
-# workflows — so this never retriggers publish-ghcr.yml or itself.
+# main is a protected branch (changes must go through a PR), so this cannot push
+# directly. It opens a bump PR and enables auto-merge; the repo requires a PR but no
+# reviews, so the PR merges as soon as it is created. The merge is done with
+# GITHUB_TOKEN, which by design cannot trigger workflows — so the bump PR merging
+# does not retrigger this workflow or publish-ghcr.yml.
 
 on:
   push:
     branches:
       - main
 
+# Serialise runs so two quick merges to main can't open competing bump PRs.
+concurrency:
+  group: sync-app-version
+  cancel-in-progress: false
+
 jobs:
   sync-version:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -61,15 +70,32 @@ jobs:
               print(f"Wrote VITE_APP_VERSION default: {version}")
           PY
 
-      - name: Commit if changed
+      - name: Open and auto-merge a bump PR if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git diff --quiet docker-compose.yml; then
-            echo "docker-compose.yml already up to date — no commit needed."
+            echo "docker-compose.yml already up to date — no PR needed."
             exit 0
           fi
 
+          BRANCH="chore/sync-version-${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add docker-compose.yml
-          git commit -m "chore: sync app version to ${VERSION} [skip ci]"
-          git push
+          git commit -m "chore: sync app version to ${VERSION}"
+          git push --force-with-lease origin "$BRANCH"
+
+          # Reuse an existing open PR for this branch if the run is retried.
+          PR_URL=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // empty')
+          if [ -z "$PR_URL" ]; then
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: sync app version to ${VERSION}" \
+              --body "Automated: keeps the VITE_APP_VERSION default in docker-compose.yml pointing at the latest main commit. Opened by .github/workflows/app-version.yml.")
+          fi
+
+          # No reviews are required on main, so auto-merge lands this immediately.
+          gh pr merge "$PR_URL" --squash --auto --delete-branch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-150-g494ed72}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-152-g8595061}
     container_name: tracepcap-nginx
     environment:
       # Memory allocation — nginx body limit and timeouts derived from this


### PR DESCRIPTION
Follow-up to #529 (which merged, then its post-merge Sync App Version run failed).

## Problem

`app-version.yml` pushed the version bump straight to `main`. `main` is protected — *"Changes must be made through a pull request"* — so the push was rejected:

```
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (protected branch hook declined)
```

Every merge to main would red-X this workflow, and the compose default stopped tracking main (stuck at `v0.1.1-150-g494ed72`).

## Fix

- **`app-version.yml`** now opens a **bump PR and enables auto-merge** instead of pushing to main. The `main` rule requires a PR but **zero reviews** (confirmed via the API), so the PR lands as soon as it is opened. Auto-merge was enabled on the repo to support this.
  - Added a `concurrency` group so two quick merges to main can't open competing bump PRs.
  - Added `pull-requests: write` permission.
  - The merge uses `GITHUB_TOKEN`, which cannot trigger workflows — so the bump PR merging does not retrigger this workflow or `publish-ghcr.yml`.
- **`docker-compose.yml`** default refreshed to `v0.1.1-152-g8595061` — the value the failed run should have written, so main is accurate again.

## Test plan

- [x] Workflow YAML valid; `docker compose config` still parses
- [x] Confirmed `main` requires a PR but 0 approving reviews (so auto-merge lands immediately)
- [x] `allow_auto_merge` enabled on the repo
- [ ] **Real validation is the next merge to main** — after this PR merges, its own Sync App Version run should open+auto-merge a bump PR cleanly instead of failing. Watching that.

## Note

The bump PR itself will show up as brief churn in history (opened and squash-merged within one run, branch auto-deleted). That is the accepted tradeoff for respecting branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)