### PR TITLE
Address CodeRabbit review on #537: carry-forward correctness, request versioning, a11y

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Only build a custom component if SGDS has no equivalent.
 
 ### Popups & info affordances
 
-- **Explainer / help content behind a `bi bi-info-circle`** must open an **SGDS `Modal`** (or, for a small inline hint, a click-toggled help block) — never rely on a native `title=` tooltip, which is unreliable and inconsistent across the app. The info-circle should be `role="button"` with `cursor: pointer` so it reads as clickable.
+- **Explainer / help content behind a `bi bi-info-circle`** must open an **SGDS `Modal`** (or, for a small inline hint, a click-toggled help block) — never rely on a native `title=` tooltip, which is unreliable and inconsistent across the app. Make the trigger a real `<button>` (with an `aria-label` and the icon `aria-hidden`) so it is focusable and keyboard-activatable; if an element genuinely cannot be a button, it needs `role="button"` **plus** `tabIndex={0}` and Enter/Space key handling — `role="button"` with only `cursor: pointer` is not clickable for keyboard users.
 - **Forms that create/edit a thing** (add evidence, override a label, add a snapshot) belong in an **SGDS `Modal`**, not an inline expanding panel — keep the surface uncluttered and the action focused.
 - Keep the copy inside these modals task-oriented: say what the thing is and how to act on it (e.g. "click a badge to inspect it and add evidence").
 

--- a/backend/src/main/java/com/tracepcap/common/adjudication/AdjudicationOverrideController.java
+++ b/backend/src/main/java/com/tracepcap/common/adjudication/AdjudicationOverrideController.java
@@ -5,6 +5,8 @@ import com.tracepcap.common.adjudication.dto.EvidenceRequest;
 import com.tracepcap.common.adjudication.dto.OverrideDto;
 import com.tracepcap.common.adjudication.dto.OverrideRequest;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -43,6 +45,10 @@ public class AdjudicationOverrideController {
 
   @GetMapping("/{fileId}/adjudications/{question}/{entityKey}/override")
   @Operation(summary = "The human override for a question about an entity, if one is set")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "Override found"),
+    @ApiResponse(responseCode = "204", description = "No override set for this entity")
+  })
   public ResponseEntity<OverrideDto> get(
       @PathVariable UUID fileId,
       @PathVariable String question,
@@ -67,6 +73,7 @@ public class AdjudicationOverrideController {
 
   @DeleteMapping("/{fileId}/adjudications/{question}/{entityKey}/override")
   @Operation(summary = "Clear the human override, letting the machine vote decide again")
+  @ApiResponses(@ApiResponse(responseCode = "204", description = "Override cleared"))
   public ResponseEntity<Void> delete(
       @PathVariable UUID fileId,
       @PathVariable String question,

--- a/backend/src/main/java/com/tracepcap/common/adjudication/HumanOverrideService.java
+++ b/backend/src/main/java/com/tracepcap/common/adjudication/HumanOverrideService.java
@@ -52,6 +52,16 @@ public class HumanOverrideService {
     entity.setLabel(label);
     entity.setRationale(rationale);
     entity.setActor(currentActor.username()); // server-side, from the token — never the client
+    // A human writing the answer makes it THIS file's own statement, whatever the row was before.
+    // Re-affirming a CARRIED_FORWARD row must flip it to MANUAL and clear the stale flags —
+    // otherwise the stale warning survives the re-affirmation, and the next snapshot's
+    // carry-forward would regenerate (i.e. silently discard) the analyst's fresh answer along
+    // with the other carried rows. The baseline resets to null; the next carry re-derives it
+    // from this file, so drift detection restarts from the re-affirmed state.
+    entity.setOrigin("MANUAL");
+    entity.setStaleSince(null);
+    entity.setStaleFields(null);
+    entity.setObservedProperties(null);
     HumanOverrideEntity saved = repository.save(entity);
     log.info(
         "Human override: {} '{}' for {} in file {} by {}",

--- a/backend/src/main/java/com/tracepcap/insights/service/HostIdentityService.java
+++ b/backend/src/main/java/com/tracepcap/insights/service/HostIdentityService.java
@@ -95,7 +95,12 @@ public class HostIdentityService implements Adjudicator {
   @Transactional
   public void adjudicateFile(UUID fileId) {
     List<ClassifiedHost> hosts = hostClassificationLookup.classifiedHosts(fileId);
-    if (hosts.isEmpty()) return;
+    if (hosts.isEmpty()) {
+      // A re-analysis that classified nothing must not leave the previous run's identities
+      // standing — stale verdicts about hosts that no longer exist are worse than none.
+      hostIdentityRepository.deleteByFileId(fileId);
+      return;
+    }
 
     // A generic human override ("I disagree, it's X") ranks above everything — the most direct
     // statement of identity there is. Keyed by this adjudicator's own question().
@@ -169,26 +174,27 @@ public class HostIdentityService implements Adjudicator {
 
   private HostIdentityEntity fromOverride(
       UUID fileId, ClassifiedHost host, com.tracepcap.common.adjudication.HumanOverrideEntity override) {
-    return HostIdentityEntity.builder()
-        .fileId(fileId)
-        .ip(host.ip())
-        .primaryLabel(override.getLabel())
-        .basis(HostIdentityEntity.BASIS_HUMAN)
-        .confidence(100)
-        .contested(false)
-        .updatedAt(LocalDateTime.now())
-        .build();
+    return humanIdentity(fileId, host, override.getLabel());
   }
 
-  private HostIdentityEntity fromHuman(
-      UUID fileId, ClassifiedHost host, NodeRoleEntity human) {
+  private HostIdentityEntity fromHuman(UUID fileId, ClassifiedHost host, NodeRoleEntity human) {
+    return humanIdentity(fileId, host, human.getRoleLabel());
+  }
+
+  /**
+   * A human-decided identity: their label IS the answer (confidence 100, never contested), but the
+   * machine's candidates + reasons are still carried so the UI can keep explaining what the
+   * classifier thought — overriding the verdict must not erase the explanation it overrode.
+   */
+  private HostIdentityEntity humanIdentity(UUID fileId, ClassifiedHost host, String label) {
     return HostIdentityEntity.builder()
         .fileId(fileId)
         .ip(host.ip())
-        .primaryLabel(human.getRoleLabel())
+        .primaryLabel(label)
         .basis(HostIdentityEntity.BASIS_HUMAN)
         .confidence(100)
         .contested(false)
+        .candidates(machineCandidates(host))
         .updatedAt(LocalDateTime.now())
         .build();
   }
@@ -259,7 +265,12 @@ public class HostIdentityService implements Adjudicator {
 
     List<Map.Entry<String, Integer>> ranked =
         scores.entrySet().stream()
-            .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+            // Label tie-breaker: equal scores must rank the same way on every run, or identical
+            // persisted evidence could flip the primary candidate between adjudications.
+            .sorted(
+                Map.Entry.<String, Integer>comparingByValue()
+                    .reversed()
+                    .thenComparing(Map.Entry::getKey))
             .toList();
     String winner = ranked.get(0).getKey();
     int best = ranked.get(0).getValue();

--- a/backend/src/main/java/com/tracepcap/insights/service/LabelStalenessService.java
+++ b/backend/src/main/java/com/tracepcap/insights/service/LabelStalenessService.java
@@ -61,14 +61,20 @@ public class LabelStalenessService implements LabelStalenessCheck {
   @Override
   public List<Drift> carryForwardAndValidate(UUID prevFileId, UUID newFileId) {
     if (newFileId == null) return List.of();
-    // Always clear stale carried rows so a reorder/re-add regenerates cleanly.
+    // Always clear stale carried rows — roles AND overrides — so a reorder/re-add regenerates
+    // cleanly, and so a file disconnected from any predecessor (prevFileId null) doesn't keep
+    // carried overrides standing from whatever it was previously chained to.
     nodeRoleRepository.deleteByFileIdAndOrigin(newFileId, ORIGIN_CARRIED_FORWARD);
+    for (String question : OVERRIDE_QUESTIONS) {
+      humanOverrideRepository.deleteByQuestionAndFileIdAndOrigin(
+          question, newFileId, ORIGIN_CARRIED_FORWARD);
+    }
     if (prevFileId == null) return List.of();
 
     List<Drift> drifts = new ArrayList<>();
     // Overrides carry independently of node roles — a network can have adjudication overrides and
     // not a single confirmed role, and an early return on the role branch used to silently skip
-    // (and leave uncleaned) every carried override.
+    // every carried override.
     drifts.addAll(carryForwardOverrides(prevFileId, newFileId));
 
     List<NodeRoleEntity> confirmed =
@@ -136,16 +142,14 @@ public class LabelStalenessService implements LabelStalenessCheck {
   /**
    * Carries human adjudication overrides (host-identity + the evidence axes) forward from the
    * previous snapshot onto the new file and flags those whose classifying evidence drifted (#499).
-   * Mirrors the node-role carry-forward above: CARRIED_FORWARD rows are regenerated each call; an
-   * override the analyst set directly on the new file (origin MANUAL) is left untouched. Staleness is
-   * sticky — it persists until the analyst re-affirms or clears the override.
+   * Callers must first clear this file's existing CARRIED_FORWARD rows (done unconditionally in
+   * {@link #carryForwardAndValidate}, ahead of the {@code prevFileId == null} short-circuit, so a
+   * file disconnected from any predecessor still loses its carried overrides). Mirrors the
+   * node-role carry-forward above: an override the analyst set directly on the new file (origin
+   * MANUAL) is left untouched. Staleness is sticky — it persists until the analyst re-affirms or
+   * clears the override.
    */
   private List<Drift> carryForwardOverrides(UUID prevFileId, UUID newFileId) {
-    // Regenerate carried rows cleanly for every question.
-    for (String question : OVERRIDE_QUESTIONS) {
-      humanOverrideRepository.deleteByQuestionAndFileIdAndOrigin(
-          question, newFileId, ORIGIN_CARRIED_FORWARD);
-    }
 
     List<Drift> drifts = new ArrayList<>();
     for (String question : OVERRIDE_QUESTIONS) {

--- a/backend/src/main/java/com/tracepcap/insights/service/LabelStalenessService.java
+++ b/backend/src/main/java/com/tracepcap/insights/service/LabelStalenessService.java
@@ -65,9 +65,15 @@ public class LabelStalenessService implements LabelStalenessCheck {
     nodeRoleRepository.deleteByFileIdAndOrigin(newFileId, ORIGIN_CARRIED_FORWARD);
     if (prevFileId == null) return List.of();
 
+    List<Drift> drifts = new ArrayList<>();
+    // Overrides carry independently of node roles — a network can have adjudication overrides and
+    // not a single confirmed role, and an early return on the role branch used to silently skip
+    // (and leave uncleaned) every carried override.
+    drifts.addAll(carryForwardOverrides(prevFileId, newFileId));
+
     List<NodeRoleEntity> confirmed =
         nodeRoleRepository.findByFileIdAndConfirmedByHumanTrue(prevFileId);
-    if (confirmed.isEmpty()) return List.of();
+    if (confirmed.isEmpty()) return drifts;
 
     // Entities already labelled directly on the new file — don't overwrite them.
     Set<String> ownKeys =
@@ -76,7 +82,6 @@ public class LabelStalenessService implements LabelStalenessCheck {
             .map(r -> r.getEntityType() + "|" + r.getEntityKey())
             .collect(Collectors.toSet());
 
-    List<Drift> drifts = new ArrayList<>();
     for (NodeRoleEntity prev : confirmed) {
       if (ownKeys.contains(prev.getEntityType() + "|" + prev.getEntityKey())) continue;
 
@@ -125,7 +130,6 @@ public class LabelStalenessService implements LabelStalenessCheck {
       nodeRoleRepository.save(carried);
     }
 
-    drifts.addAll(carryForwardOverrides(prevFileId, newFileId));
     return drifts;
   }
 
@@ -157,7 +161,10 @@ public class LabelStalenessService implements LabelStalenessCheck {
               .collect(Collectors.toSet());
 
       for (HumanOverrideEntity prev : prevOverrides) {
-        if (ORIGIN_CARRIED_FORWARD.equals(prev.getOrigin())) continue; // don't chain carried→carried
+        // Carried rows DO carry again: in a monitor chain each snapshot only sees its immediate
+        // predecessor, so skipping CARRIED_FORWARD rows made an override vanish after one hop
+        // (manual on A → carried to B → gone from C). The original actor and sticky staleness
+        // ride along; the node-role carry above has always chained the same way.
         if (ownKeys.contains(prev.getEntityKey())) continue;
 
         // Overrides are keyed by IP (host-identity/axes are per-host). Reuse the IP property snapshot.

--- a/backend/src/test/java/com/tracepcap/insights/service/HostIdentityServiceTest.java
+++ b/backend/src/test/java/com/tracepcap/insights/service/HostIdentityServiceTest.java
@@ -73,7 +73,12 @@ class HostIdentityServiceTest {
   void humanOverride_ranksAboveEverything_neverContested() {
     // Even a strong, uncontested machine winner is replaced by an explicit human override.
     when(lookup.classifiedHosts(fileId))
-        .thenReturn(List.of(host("10.0.0.9", "IOT", 90, 200, "SERVER", 30)));
+        .thenReturn(
+            List.of(
+                new ClassifiedHost(
+                    "10.0.0.9", "IOT", 90, 200, "SERVER", 30,
+                    List.of("MAC OUI is Espressif (+40)"),
+                    List.of("received on 443 (+30)"))));
     when(roleRepo.findByFileIdAndConfirmedByHumanTrue(any())).thenReturn(List.of());
     com.tracepcap.common.adjudication.HumanOverrideEntity override =
         com.tracepcap.common.adjudication.HumanOverrideEntity.builder()
@@ -93,6 +98,13 @@ class HostIdentityServiceTest {
     assertThat(id.getBasis()).isEqualTo(HostIdentityEntity.BASIS_HUMAN);
     assertThat(id.getConfidence()).isEqualTo(100);
     assertThat(id.isContested()).isFalse();
+    // Overriding the verdict must not erase the machine's explanation: the classifier's
+    // candidates and their reasons stay visible so the UI can still show what was overridden.
+    assertThat(id.getCandidates()).hasSize(2);
+    assertThat(id.getCandidates().get(0)).containsEntry("label", "IOT");
+    assertThat(id.getCandidates().get(0).get("reasons"))
+        .isEqualTo(List.of("MAC OUI is Espressif (+40)"));
+    assertThat(id.getCandidates().get(1)).containsEntry("label", "SERVER");
   }
 
   @Test
@@ -160,6 +172,53 @@ class HostIdentityServiceTest {
     @SuppressWarnings("unchecked")
     List<String> reasons = (List<String>) serverCandidate.get("reasons");
     assertThat(reasons).anyMatch(r -> r.contains("analyst (bob)") && r.contains("runs sshd"));
+  }
+
+  @Test
+  void manualEvidence_canOvertakeTheMachineWinner() {
+    // Machine: IOT 90 vs SERVER 30. Analyst adds +100 SERVER evidence → SERVER 130 beats IOT 90:
+    // the winner flips, at the margin-based confidence (40 → 67%), uncontested.
+    when(lookup.classifiedHosts(fileId))
+        .thenReturn(
+            List.of(
+                new ClassifiedHost(
+                    "10.0.0.8", "IOT", 60, 90, "SERVER", 30,
+                    List.of("low traffic volume (+40)"),
+                    List.of("received on 22 (+30)"))));
+    when(roleRepo.findByFileIdAndConfirmedByHumanTrue(any())).thenReturn(List.of());
+    com.tracepcap.common.adjudication.ManualEvidenceEntity ev =
+        com.tracepcap.common.adjudication.ManualEvidenceEntity.builder()
+            .question("host-identity")
+            .fileId(fileId)
+            .entityKey("10.0.0.8")
+            .label("SERVER")
+            .weight(100)
+            .reason("runs sshd, confirmed via console")
+            .actor("bob")
+            .build();
+    when(evidenceRepo.findByQuestionAndFileId("host-identity", fileId)).thenReturn(List.of(ev));
+
+    service.adjudicateFile(fileId);
+
+    HostIdentityEntity id = adjudicated().get(0);
+    assertThat(id.getPrimaryLabel()).isEqualTo("SERVER");
+    assertThat(id.getBasis()).isEqualTo(HostIdentityEntity.BASIS_MACHINE);
+    assertThat(id.getConfidence()).isEqualTo(67); // round((130-90) * 100 / 60)
+    assertThat(id.isContested()).isFalse();
+    assertThat(id.getCandidates().get(0)).containsEntry("label", "SERVER");
+    assertThat(id.getCandidates().get(0)).containsEntry("score", 130);
+    assertThat(id.getCandidates().get(1)).containsEntry("label", "IOT");
+  }
+
+  @Test
+  void reAnalysisWithNoHosts_clearsPreviousIdentities() {
+    when(lookup.classifiedHosts(fileId)).thenReturn(List.of());
+
+    service.adjudicateFile(fileId);
+
+    // Stale verdicts about hosts that no longer classify must not survive the re-analysis.
+    verify(identityRepo).deleteByFileId(fileId);
+    verify(identityRepo, org.mockito.Mockito.never()).saveAll(any());
   }
 
   @Test

--- a/frontend/src/components/common/AdjudicationPanel/AdjudicationPanel.tsx
+++ b/frontend/src/components/common/AdjudicationPanel/AdjudicationPanel.tsx
@@ -150,6 +150,11 @@ export function AdjudicationPanel({ fileId, question, entityKey, title, verdict,
         setOverride(o);
         setEvidence(ev);
       })
+      .catch(err => {
+        if (seq !== refreshSeq.current) return;
+        console.error('Failed to load adjudication data:', err);
+        setActionError('Failed to load adjudication data. Please retry.');
+      })
       .finally(() => {
         if (seq === refreshSeq.current) setLoading(false);
       });

--- a/frontend/src/components/common/AdjudicationPanel/AdjudicationPanel.tsx
+++ b/frontend/src/components/common/AdjudicationPanel/AdjudicationPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, Form, Modal } from '@govtechsg/sgds-react';
 import { Alert } from '@components/common/Alert';
 import { Spinner } from '@components/common/Spinner/Spinner';
@@ -135,17 +135,24 @@ export function AdjudicationPanel({ fileId, question, entityKey, title, verdict,
     setEvWeight(40);
   };
 
+  // Monotonic sequence guarding refresh commits: the panel is reused across entities, so a slow
+  // response for node A must not land after the panel has moved on to node B.
+  const refreshSeq = useRef(0);
   const refresh = () => {
+    const seq = ++refreshSeq.current;
     setLoading(true);
     Promise.all([
       adjudicationService.getOverride(fileId, question, entityKey),
       adjudicationService.listEvidence(fileId, question, entityKey),
     ])
       .then(([o, ev]) => {
+        if (seq !== refreshSeq.current) return; // superseded — a newer entity/refresh owns the panel
         setOverride(o);
         setEvidence(ev);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (seq === refreshSeq.current) setLoading(false);
+      });
   };
 
   useEffect(() => {
@@ -342,8 +349,27 @@ export function AdjudicationPanel({ fileId, question, entityKey, title, verdict,
                 {override.staleFields && override.staleFields.length > 0 && (
                   <>: {override.staleFields.join('; ')}</>
                 )}
-                . Re-affirm with “I disagree” or revert to the machine verdict.
+                . Re-affirm the answer, or revert to the machine verdict below.
               </div>
+              <Button
+                variant="outline-primary"
+                size="sm"
+                className="py-0 mt-1"
+                style={{ fontSize: '0.72rem' }}
+                onClick={() =>
+                  runAction('Re-affirming the override', async () => {
+                    // Re-saving the same answer flips the row to MANUAL server-side, clearing the
+                    // stale flags and re-baselining drift from this snapshot.
+                    await adjudicationService.setOverride(
+                      fileId, question, entityKey, override.label, override.rationale ?? undefined);
+                    refresh();
+                    onChanged();
+                  })
+                }
+                disabled={busy}
+              >
+                <i className="bi bi-check-lg me-1" />Re-affirm “{override.label}”
+              </Button>
             </Alert>
           )}
 
@@ -445,22 +471,26 @@ export function AdjudicationPanel({ fileId, question, entityKey, title, verdict,
                     {ev.actor === me && (
                       <>
                         {' '}
-                        <i
-                          role="button"
+                        <button
+                          type="button"
                           aria-label="Edit evidence"
                           title="Edit"
-                          className="bi bi-pencil ms-1"
-                          style={{ cursor: 'pointer' }}
+                          className="btn btn-link p-0 ms-1 text-muted align-baseline"
+                          style={{ fontSize: 'inherit' }}
                           onClick={() => handleEditEvidence(ev)}
-                        />
-                        <i
-                          role="button"
+                        >
+                          <i className="bi bi-pencil" aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
                           aria-label="Delete evidence"
                           title="Delete"
-                          className="bi bi-trash ms-1"
-                          style={{ cursor: 'pointer' }}
+                          className="btn btn-link p-0 ms-1 text-muted align-baseline"
+                          style={{ fontSize: 'inherit' }}
                           onClick={() => handleDeleteEvidence(ev)}
-                        />
+                        >
+                          <i className="bi bi-trash" aria-hidden="true" />
+                        </button>
                       </>
                     )}
                   </li>

--- a/frontend/src/components/common/EntityDetailModal/sections/RoleSection.tsx
+++ b/frontend/src/components/common/EntityDetailModal/sections/RoleSection.tsx
@@ -56,13 +56,15 @@ export function RoleSection({ fileId, role: r, readOnly, raisedModal }: RoleSect
       <h6 className="border-bottom pb-1 mb-2 d-flex align-items-center justify-content-between">
         <span>
           Role <span className="text-muted fw-normal" style={{ fontSize: '0.75rem' }}>· analyst-assigned name</span>
-          <i
-            role="button"
+          <button
+            type="button"
             aria-label="What is a role label?"
-            className="bi bi-info-circle ms-1 text-muted"
-            style={{ fontSize: '0.72rem', cursor: 'pointer' }}
+            className="btn btn-link p-0 ms-1 text-muted"
+            style={{ fontSize: '0.72rem', lineHeight: 1 }}
             onClick={() => setShowRoleHelp(v => !v)}
-          />
+          >
+            <i className="bi bi-info-circle" aria-hidden="true" />
+          </button>
         </span>
         {!r.roleEditing && !r.roleLoading && (
           <div className="d-flex gap-1">

--- a/frontend/src/components/network/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/components/network/NodeDetails/NodeDetails.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Badge, Modal } from '@govtechsg/sgds-react';
 import { useNavigate } from 'react-router-dom';
 import type { GraphNode, GraphEdge } from '@/features/network/types';
@@ -67,12 +67,20 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
   const [nestedIp, setNestedIp] = useState<string | null>(null);
 
   // Live adjudicated identity: seeded from the graph node, re-fetched after an override/evidence
-  // change so the panel reflects the new verdict without reloading the whole graph.
+  // change so the panel reflects the new verdict without reloading the whole graph. The ref always
+  // holds the CURRENT node's IP (a closure over the prop would compare stale-to-stale), so a slow
+  // response for node A is dropped once the reused panel has switched to node B.
   const [liveIdentity, setLiveIdentity] = useState<HostIdentity | null>(null);
+  const currentIpRef = useRef(node.data.ip);
+  currentIpRef.current = node.data.ip;
   const refreshIdentity = () => {
+    const forIp = node.data.ip;
     conversationService
       .getHostIdentities(fileId)
-      .then(list => setLiveIdentity(list.find(i => i.ip === node.data.ip) ?? null))
+      .then(list => {
+        if (forIp !== currentIpRef.current) return; // superseded by a node switch
+        setLiveIdentity(list.find(i => i.ip === forIp) ?? null);
+      })
       .catch(() => {});
   };
 
@@ -437,16 +445,18 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                       <span className="text-muted fw-normal" style={{ fontSize: '0.8rem' }}>
                         Evidence weighed
                       </span>
-                      <i
-                        role="button"
+                      <button
+                        type="button"
                         aria-label="How Identity and this evidence relate"
-                        className="bi bi-info-circle ms-1 text-muted"
-                        style={{ cursor: 'pointer', fontSize: '0.8rem' }}
+                        className="btn btn-link p-0 ms-1 text-muted"
+                        style={{ fontSize: '0.8rem', lineHeight: 1 }}
                         onClick={e => {
                           e.stopPropagation();
                           setEvidenceInfoOpen(true);
                         }}
-                      />
+                      >
+                        <i className="bi bi-info-circle" aria-hidden="true" />
+                      </button>
                     </h6>
                     {/* Facts only, no per-axis badge — a badge picks one label, which is a
                         conclusion, and conclusions belong to the Identity verdict alone (#499).
@@ -460,12 +470,21 @@ export function NodeDetails({ node, edges, fileId, onClose, changeHighlight, zIn
                         <div key={key} className="mb-1">
                           <div
                             role="button"
+                            tabIndex={0}
+                            aria-expanded={expanded}
                             title={`Inspect ${meta.label} — ${meta.caption}`}
                             className="d-flex align-items-center gap-2"
                             style={{ fontSize: '0.8rem', cursor: 'pointer' }}
                             onClick={e => {
                               e.stopPropagation();
                               setExpandedAxis(expanded ? null : key);
+                            }}
+                            onKeyDown={e => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                setExpandedAxis(expanded ? null : key);
+                              }
                             }}
                           >
                             <span className="text-muted" style={{ minWidth: '100px' }}>{meta.label}</span>

--- a/frontend/src/features/network/services/networkService.ts
+++ b/frontend/src/features/network/services/networkService.ts
@@ -297,17 +297,6 @@ export function buildNetworkGraph(
     }
     updateNodeStats(nodeMap[dst.ip], conv, 'received', protocol);
 
-    // Accumulate nDPI appName on BOTH endpoints — the identification is a fact about the
-    // conversation, and either side "did WhatsApp on the wire". Mirrors the backend's symmetric
-    // profile accumulation (DeviceClassifierService.addToProfile runs for src and dst); the old
-    // dst-only version hid the app from hosts that only ever initiated.
-    if (conv.appName) {
-      for (const ip of [src.ip, dst.ip]) {
-        if (!ndpiAppSets[ip]) ndpiAppSets[ip] = new Set();
-        ndpiAppSets[ip].add(conv.appName.toUpperCase());
-      }
-    }
-
     // Create edge
     edges.push(createEdge(conv, src.ip, dst.ip));
 
@@ -339,6 +328,18 @@ export function buildNetworkGraph(
     const [s0, d0] = conv.endpoints;
     if (nodeMap[s0.ip]) applyRoleFromInitiator(nodeMap[s0.ip], conv);
     if (nodeMap[d0.ip]) applyRoleFromInitiator(nodeMap[d0.ip], conv);
+
+    // Accumulate nDPI appName on BOTH endpoints — the identification is a fact about the
+    // conversation, and either side "did WhatsApp on the wire" (mirrors the backend's symmetric
+    // profile accumulation). Runs over the FULL conversation set, like role above: a fact must
+    // not appear or vanish depending on what fit under the rendering cap (#521).
+    if (conv.appName) {
+      for (const ip of [s0.ip, d0.ip]) {
+        if (!nodeMap[ip]) continue; // not on the diagram — nothing to annotate
+        if (!ndpiAppSets[ip]) ndpiAppSets[ip] = new Set();
+        ndpiAppSets[ip].add(conv.appName.toUpperCase());
+      }
+    }
   });
 
   // Node type comes from the backend's adjudicated host identity (see applyIdentities below).
@@ -483,10 +484,12 @@ function nodeTypeFromIdentityLabel(label: string | undefined): NodeType {
   // The endpoint already returns confirmed labels only; the roleLabel check is just null-safety.
   if (nodeRoles && nodeRoles.length > 0) {
     // MACs are case-insensitive identifiers; normalise both sides so a stored DEVICE key
-    // ("A4:83:E7:…") still matches a lowercase capture-derived node MAC.
+    // ("A4:83:E7:…") still matches a lowercase capture-derived node MAC. Only L2 nodes join the
+    // map: DEVICE roles are created for MAC-identified entities, and a shared/gateway MAC on an
+    // IP node must not steal the label meant for the L2 device itself.
     const nodeByMac = new Map<string, GraphNode>();
     for (const n of Object.values(nodeMap)) {
-      if (n.data.mac) nodeByMac.set(n.data.mac.toLowerCase(), n);
+      if (n.data.isL2 && n.data.mac) nodeByMac.set(n.data.mac.toLowerCase(), n);
     }
     for (const r of nodeRoles) {
       if (!r.roleLabel) continue;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -31,11 +31,16 @@ export const useStore = create<StoreState>()(
           themeMode: state.themeMode,
           nodeLabelConfig: state.nodeLabelConfig,
         }),
-        // Coerce any legacy persisted shape (customText was a string) into the current shape.
-        onRehydrateStorage: () => state => {
-          if (state?.nodeLabelConfig) {
-            state.nodeLabelConfig = normalizeNodeLabelConfig(state.nodeLabelConfig);
+        // Coerce any legacy persisted shape (customText was a string; fields added since the
+        // config was saved) into the current shape. Done in merge — which produces the hydrated
+        // state — rather than by mutating the store afterwards, which would bypass subscribers.
+        merge: (persisted, current) => {
+          const p = (persisted ?? {}) as Partial<StoreState>;
+          const merged = { ...current, ...p };
+          if (p.nodeLabelConfig) {
+            merged.nodeLabelConfig = normalizeNodeLabelConfig(p.nodeLabelConfig);
           }
+          return merged;
         },
       }
     ),

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -5197,8 +5197,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK"
+          "204": {
+            "description": "Override cleared"
           }
         },
         "summary": "Clear the human override, letting the machine vote decide again",
@@ -5244,7 +5244,17 @@
                 }
               }
             },
-            "description": "OK"
+            "description": "Override found"
+          },
+          "204": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/OverrideDto"
+                }
+              }
+            },
+            "description": "No override set for this entity"
           }
         },
         "summary": "The human override for a question about an entity, if one is set",


### PR DESCRIPTION
Follow-up to #537, addressing the CodeRabbit review that landed after merge. 15 of 17 comments verified accurate and fixed; 2 deferred with tracking issues.

## Carry-forward correctness (monitor mode) — the serious ones

- **Re-affirming a carried override left it stale and disposable.** `HumanOverrideService.override()` updated an existing `CARRIED_FORWARD` row without touching origin/stale metadata, so re-affirming kept the stale warning *and* the next snapshot's carry-forward regenerated (i.e. silently discarded) the analyst's fresh answer along with the other carried rows. Writing an override now always makes it `MANUAL` and clears `staleSince` / `staleFields` / the baseline.
- **Override carry-forward was unreachable** whenever the previous snapshot had no confirmed node roles — the node-role early return skipped it, leaving carried overrides neither copied nor cleaned. Override processing now runs independently of the role branch.
- **Overrides vanished after one hop.** Carried rows were skipped as carry-forward sources, so manual-on-A → carried-to-B → *absent from C*. They now chain (preserving original actor and sticky staleness), matching how node roles have always behaved.

## Adjudication

- Re-analysis producing zero classified hosts now clears the previous identities instead of leaving stale verdicts standing.
- A human verdict retains the machine's `candidates` + `reasons` — overriding the verdict shouldn't erase the explanation it overrode. `fromOverride`/`fromHuman` collapse into one `humanIdentity` helper.
- Deterministic label tie-break for equal-score candidates (identical evidence could otherwise rank differently between runs).
- `204` responses documented on the override GET/DELETE; baseline regenerated.

## Frontend

- **Request versioning** in `AdjudicationPanel.refresh` (sequence guard) and `NodeDetails.refreshIdentity` (ref-compared IP) — a slow response for node A can no longer commit onto node B.
- **Working Re-affirm action** on the stale-override alert. It previously told the analyst to "re-affirm with I disagree", but an existing override hides that editor, so the instruction was impossible to follow.
- **nDPI service facts now use the full conversation set**, not the render-capped subset — a fact must not appear/vanish with the node cap (same truncation class #521 removed elsewhere).
- **DEVICE role labels restricted to L2 nodes** — a shared/gateway MAC on an IP node could otherwise steal the label meant for the L2 device.
- **Store hydration** normalises inside persist's `merge` rather than mutating state afterwards (which bypassed Zustand subscribers).
- **Accessibility**: icon triggers (evidence edit/delete, info-circles) are real `<button>`s with `aria-label` + `aria-hidden` icons; expandable axis rows gain `tabIndex` / `aria-expanded` / Enter-Space handling. CLAUDE.md's info-circle rule updated — `role="button"` + `cursor: pointer` alone isn't keyboard-operable.

## Tests
- Assert a human override retains machine candidates and reasons
- New: evidence overtakes the machine winner (label flips, 67% margin confidence, uncontested)
- New: empty classification clears identities and saves nothing

## Deferred
- **#539** — endpoint-agnostic app names (`DNS`, `SSH`, `SMB`, `MDNS`) in `server-apps`/`iot-apps` score *both* conversation sides, so clients collect server/IoT votes. Real, but it's classifier tuning that needs before/after evaluation on sample captures, not a drive-by edit.
- **#535** — Escape closing the parent modal ahead of nested ones (pre-existing, already tracked).

## Verification
- Frontend 77/77 + `tsc -b` clean; `HostIdentityServiceTest` green in a Maven container
- Full stack rebuilt; OpenAPI baseline regenerated against the running backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
