### PR TITLE
Server/client classification: TLS/low-port no longer forces a Web Server label (#496)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/spi/ServiceLogRoles.java
+++ b/backend/src/main/java/com/tracepcap/analysis/spi/ServiceLogRoles.java
@@ -13,9 +13,17 @@ public final class ServiceLogRoles {
   /** Host acts as a DNS resolver. */
   public static final String DNS = "dns";
 
-  /** Host serves web (HTML/TLS) content. */
+  /** Host serves cleartext web (HTML) content — observed HTTP responses. */
   public static final String WEB = "web";
 
   /** Host serves API-like (JSON/REST) responses. */
   public static final String API = "api";
+
+  /**
+   * Host completed a TLS handshake as the server (sent a ServerHello) on a web-facing port, but no
+   * cleartext HTTP was observed. Weaker, port-qualified evidence toward a web role than {@link #WEB}
+   * — any router admin UI or IoT control channel terminates TLS, so on its own it must not force a
+   * Web Server verdict over contrary hardware evidence (#496).
+   */
+  public static final String TLS = "tls";
 }

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/DeviceClassifierService.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/DeviceClassifierService.java
@@ -261,15 +261,24 @@ public class DeviceClassifierService implements HostClassifier {
     String cat = conv.getCategory();
     if (cat != null && !cat.isBlank()) p.categories.add(cat);
 
-    if (isSrc) {
-      // This host initiated the conversation
-      p.initiatedCount++;
-      if (conv.getDstPort() != null) p.dstPorts.add(conv.getDstPort());
-      p.peers.add(conv.getDstIp());
-    } else {
-      // This host received the conversation
-      if (conv.getDstPort() != null) p.receivedOnPorts.add(conv.getDstPort());
-      p.peers.add(conv.getSrcIp());
+    // Peers are direction-independent — this host talked to the other endpoint either way.
+    p.peers.add(isSrc ? conv.getDstIp() : conv.getSrcIp());
+
+    // Direction comes from the MEASURED initiator (#496), NOT from srcIp/dstIp — those are sorted by
+    // IP order and do not say who opened the connection. When the initiator is unknown (UDP/ICMP/ARP
+    // or a mid-flow capture) we record nothing directional: guessing from ports is the bug this
+    // removes, not the fallback.
+    String initiatorIp = conv.getInitiatorIp();
+    if (initiatorIp != null) {
+      if (initiatorIp.equals(ip)) {
+        p.measuredInitiations++;
+      } else {
+        // This host is the responder — its peer opened the connection. The port it was reached on is
+        // its own port in the flow (srcPort when it sorted as src, dstPort otherwise).
+        p.measuredResponses++;
+        Integer myPort = isSrc ? conv.getSrcPort() : conv.getDstPort();
+        if (myPort != null) p.respondedOnPorts.add(myPort);
+      }
     }
   }
 

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/HostProfile.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/HostProfile.java
@@ -6,15 +6,28 @@ import java.util.Set;
 /**
  * Per-host traffic profile accumulated from all conversations involving a host, used as input to the
  * device-classification signals. Not persisted.
+ *
+ * <p>Directional facts come from the MEASURED connection initiator (SYN without ACK, #496), never
+ * from the conversation's {@code srcIp}/{@code dstIp} — those are normalised by IP sort order and do
+ * not identify who opened the connection. Flows with no measured initiator (UDP/ICMP/ARP, or a
+ * capture that joined mid-stream) contribute nothing directional: unknown is left unknown, never
+ * backfilled from ports.
  */
 public class HostProfile {
   public long totalBytes = 0;
   public long totalPackets = 0;
   public int conversationCount = 0;
-  public int initiatedCount = 0;
+
+  /** Flows in which this host was the MEASURED initiator (it sent SYN without ACK). */
+  public int measuredInitiations = 0;
+
+  /** Flows in which this host was the MEASURED responder (its peer opened the connection). */
+  public int measuredResponses = 0;
+
+  /** Ports this host received a connection ON, as the measured responder (its own port in the flow). */
+  public final Set<Integer> respondedOnPorts = new LinkedHashSet<>();
+
   public final Set<String> apps = new LinkedHashSet<>();
   public final Set<String> categories = new LinkedHashSet<>();
-  public final Set<Integer> dstPorts = new LinkedHashSet<>();
-  public final Set<Integer> receivedOnPorts = new LinkedHashSet<>();
   public final Set<String> peers = new LinkedHashSet<>();
 }

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/TrafficPatternSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/TrafficPatternSignal.java
@@ -8,9 +8,9 @@ import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
 import org.springframework.stereotype.Component;
 
 /**
- * Behavioural traffic patterns: high peer fan-out → router; inbound-only on well-known ports →
- * server; low variety + low volume → IoT; mostly-outbound with varied apps → mobile/laptop;
- * DNS/NTP-only → infra (router/server).
+ * Behavioural traffic patterns: high peer fan-out → router; answers connections it never opens (by
+ * the MEASURED initiator, #496) → server; low variety + low volume → IoT; mostly-opens with varied
+ * apps → mobile/laptop; DNS/NTP-only → infra (router/server).
  */
 @Component
 public class TrafficPatternSignal implements DeviceClassificationSignal {
@@ -31,13 +31,15 @@ public class TrafficPatternSignal implements DeviceClassificationSignal {
       board.add(DeviceTypes.ROUTER, 15, p.peers.size() + " peers (moderate fan-out) → +15");
     }
 
-    // Only receives on well-known ports, never initiates → server.
-    boolean receivesOnWellKnown = p.receivedOnPorts.stream().anyMatch(port -> port < 1024);
-    boolean neverInitiates = p.initiatedCount == 0;
-    if (neverInitiates && receivesOnWellKnown) {
-      board.add(DeviceTypes.SERVER, 35, "Inbound-only on a well-known port → +35");
-    } else if (neverInitiates) {
-      board.add(DeviceTypes.SERVER, 15, "Never initiates connections → +15");
+    // Answers connections but never opens one → server. Direction is the MEASURED initiator (#496),
+    // not srcIp/dstIp; a host with only direction-unknown flows (measuredResponses == 0) is NOT
+    // voted server by default. A well-known responding port strengthens but no longer decides.
+    boolean answersButNeverInitiates = p.measuredResponses > 0 && p.measuredInitiations == 0;
+    boolean respondsOnWellKnown = p.respondedOnPorts.stream().anyMatch(port -> port < 1024);
+    if (answersButNeverInitiates && respondsOnWellKnown) {
+      board.add(DeviceTypes.SERVER, 35, "Answers connections it never opens, on a well-known port → +35");
+    } else if (answersButNeverInitiates) {
+      board.add(DeviceTypes.SERVER, 15, "Answers connections it never opens → +15");
     }
 
     // Low variety + low volume → IoT.
@@ -45,9 +47,10 @@ public class TrafficPatternSignal implements DeviceClassificationSignal {
       board.add(DeviceTypes.IOT, 20, "Low app variety + low volume → +20");
     }
 
-    // Mostly initiates traffic (client-like) with varied apps → mobile/laptop.
-    double initiateRatio =
-        p.conversationCount > 0 ? (double) p.initiatedCount / p.conversationCount : 0;
+    // Mostly opens connections (client-like) with varied apps → mobile/laptop. Ratio is over MEASURED
+    // flows only (#496) — flows with no known initiator can neither confirm nor deny client-ness.
+    int measuredFlows = p.measuredInitiations + p.measuredResponses;
+    double initiateRatio = measuredFlows > 0 ? (double) p.measuredInitiations / measuredFlows : 0;
     if (initiateRatio > 0.7 && p.apps.size() > 3) {
       board.add(DeviceTypes.MOBILE, 10, "Mostly-outbound with varied apps → +10");
       board.add(DeviceTypes.LAPTOP_DESKTOP, 10, "Mostly-outbound with varied apps → +10");

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/WebServerSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/WebServerSignal.java
@@ -8,15 +8,33 @@ import com.tracepcap.analysis.spi.ServiceLogRoles;
 import org.springframework.stereotype.Component;
 
 /**
- * Classifies a host as a {@code WEB_SERVER} when it was observed serving HTTP/TLS but not in an
- * API-like way (see {@link com.tracepcap.hostclassification.service.classifier.signals.ApiServerSignal}). Like
- * {@link DnsServerSignal}, this is authoritative observed evidence, so it carries a dominant weight
- * that outranks the heuristic signals.
+ * Votes {@code WEB_SERVER}, graded by how strong the evidence is (#496 AC #4/#6):
+ *
+ * <ul>
+ *   <li><b>{@code web} role — served cleartext HTTP.</b> Authoritative observed evidence, like
+ *       {@link DnsServerSignal}: it carries a dominant weight that outranks the heuristic signals.
+ *   <li><b>{@code tls} role — completed a TLS ServerHello on a web port, no HTTP seen.</b> Real but
+ *       weaker: every router admin UI and IoT control channel terminates TLS. A moderate weight, so
+ *       strong contrary hardware evidence (router OUI + TTL 255 + high fan-out) can outrank it and a
+ *       close call renders <em>contested</em> rather than a false-confident Web Server.
+ * </ul>
+ *
+ * API-like HTTP servers are tagged {@code api} instead of {@code web}/{@code tls} (see {@link
+ * ApiServerSignal}), so this never double-counts them.
  */
 @Component
 public class WebServerSignal implements DeviceClassificationSignal {
 
-  static final int WEIGHT = 1000;
+  /** Cleartext HTTP served — authoritative, dominant (mirrors {@link DnsServerSignal}). */
+  static final int WEIGHT_HTTP = 1000;
+
+  /**
+   * TLS-only, port-qualified — evidence toward, not proof. Sits in the band (45, 105): above the
+   * "answers-only on a well-known port" SERVER vote (35) + TTL (10) so a genuine HTTPS-only host
+   * still leans WEB_SERVER, yet below router hardware (OUI 40 + TTL 255 → 30 = 70, or + fan-out 35 =
+   * 105) so a router serving its own admin UI over TLS resolves to ROUTER.
+   */
+  static final int WEIGHT_TLS = 60;
 
   @Override
   public String name() {
@@ -26,7 +44,10 @@ public class WebServerSignal implements DeviceClassificationSignal {
   @Override
   public void contribute(HostContext ctx, ScoreBoard board) {
     if (ctx.hasServiceRole(ServiceLogRoles.WEB)) {
-      board.add(DeviceTypes.WEB_SERVER, WEIGHT, "Served HTTP/TLS → +" + WEIGHT);
+      board.add(DeviceTypes.WEB_SERVER, WEIGHT_HTTP, "Served HTTP → +" + WEIGHT_HTTP);
+    } else if (ctx.hasServiceRole(ServiceLogRoles.TLS)) {
+      board.add(
+          DeviceTypes.WEB_SERVER, WEIGHT_TLS, "Served TLS on a web port → +" + WEIGHT_TLS);
     }
   }
 }

--- a/backend/src/main/java/com/tracepcap/hostlog/service/WebServerLogExtractor.java
+++ b/backend/src/main/java/com/tracepcap/hostlog/service/WebServerLogExtractor.java
@@ -55,8 +55,16 @@ public class WebServerLogExtractor implements HostServiceLogExtractor {
 
   private static final String ROLE_WEB = ServiceLogRoles.WEB;
   private static final String ROLE_API = ServiceLogRoles.API;
+  private static final String ROLE_TLS = ServiceLogRoles.TLS;
 
   private static final int PATH_MAX_LENGTH = 2048;
+
+  /**
+   * TLS server ports that count as web-facing. A ServerHello on one of these is evidence toward a web
+   * role; a ServerHello on any other port (SIP-TLS 5061, IMAPS 993, …) is a TLS service but not a web
+   * server, so it contributes no web evidence at all (#496 AC #3 — port-qualified, not "any port").
+   */
+  private static final Set<Integer> WEB_TLS_PORTS = Set.of(443, 4433, 8443);
 
   private final HttpEndpointLogRepository httpEndpointLogRepository;
 
@@ -112,25 +120,29 @@ public class WebServerLogExtractor implements HostServiceLogExtractor {
         },
         f -> parseHttpFrame(f, endpoints, serverStats, pendingByStream));
 
-    // TLS pass — ServerHello source IP is the TLS server.
+    // TLS pass — ServerHello source IP:port is the TLS server. Port-qualified: only ServerHellos on
+    // web-facing ports (WEB_TLS_PORTS) count as web evidence; TLS on other ports is a different
+    // service and is ignored here (#496 AC #3).
     runPass(
         pcap,
         "tls.handshake.type==2",
-        new String[] {"ip.src"},
+        new String[] {"ip.src", "tcp.srcport"},
         f -> {
           String ip = trimToNull(f[0]);
-          if (ip != null) tlsServers.add(ip);
+          Integer port = f.length > 1 ? parseIntOrNull(firstValue(f[1])) : null;
+          if (ip != null && isWebFacingTlsPort(port)) tlsServers.add(ip);
         });
 
     persist(file, endpoints);
 
-    // Assign each server a role: api-like HTTP servers → "api", other HTTP servers and TLS-only
-    // servers → "web".
+    // Assign each server a role: api-like HTTP servers → "api", other HTTP servers → "web"
+    // (authoritative — they served HTTP). TLS-only servers get the weaker "tls" role: real evidence
+    // toward a web role, but not proof that outranks contrary hardware evidence (#496 AC #4/#6).
     Map<String, String> roleByServerIp = new LinkedHashMap<>();
     for (Map.Entry<String, WebServerStats> e : serverStats.entrySet()) {
       roleByServerIp.put(e.getKey(), isApiLike(e.getValue()) ? ROLE_API : ROLE_WEB);
     }
-    for (String ip : tlsServers) roleByServerIp.putIfAbsent(ip, ROLE_WEB);
+    for (String ip : tlsServers) roleByServerIp.putIfAbsent(ip, ROLE_TLS);
 
     log.info(
         "HTTP endpoint log: {} endpoint row(s) across {} HTTP server(s); {} TLS server(s)",
@@ -254,6 +266,14 @@ public class WebServerLogExtractor implements HostServiceLogExtractor {
     if (agg.serverSoftware == null && serverSoftware != null) agg.serverSoftware = serverSoftware;
     if (agg.requestFrame == null && requestFrame != null) agg.requestFrame = requestFrame;
     if (agg.responseFrame == null && responseFrame != null) agg.responseFrame = responseFrame;
+  }
+
+  /**
+   * Whether a TLS ServerHello on this port counts as web evidence (#496 AC #3). Only web-facing TLS
+   * ports qualify; a null port or a non-web port (SIP-TLS, IMAPS, …) is not a web server.
+   */
+  static boolean isWebFacingTlsPort(Integer port) {
+    return port != null && WEB_TLS_PORTS.contains(port);
   }
 
   /** A server is "API-like" when JSON dominates its responses, or it uses REST write verbs / api paths. */

--- a/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/service/NetworkIntelligenceService.java
@@ -508,7 +508,8 @@ public class NetworkIntelligenceService {
     List<HostFacts> webHosts =
         hostClassificationLookup.hostFacts(fileId).stream()
             .filter(h -> hasRole(h, ServiceLogRoles.API)
-                || hasRole(h, ServiceLogRoles.WEB))
+                || hasRole(h, ServiceLogRoles.WEB)
+                || hasRole(h, ServiceLogRoles.TLS))
             .toList();
     if (webHosts.isEmpty()) return List.of();
 

--- a/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/TrafficPatternSignalTest.java
+++ b/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/TrafficPatternSignalTest.java
@@ -1,0 +1,71 @@
+package com.tracepcap.hostclassification.service.classifier.signals;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.HostProfile;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The SERVER vote must follow the MEASURED connection initiator (#496), not the sorted conversation
+ * endpoints — a host is a server because it answers connections it never opens, not because it holds
+ * a low port.
+ */
+class TrafficPatternSignalTest {
+
+  private final TrafficPatternSignal signal = new TrafficPatternSignal();
+
+  private HostContext ctx(HostProfile p) {
+    return new HostContext("10.0.0.1", p, null, null, null, null, null, Set.of());
+  }
+
+  @Test
+  void answersButNeverInitiates_onWellKnownPort_votesServer() {
+    HostProfile p = new HostProfile();
+    p.conversationCount = 3;
+    p.totalPackets = 1000; // avoid the low-volume IoT vote
+    p.measuredResponses = 3;
+    p.measuredInitiations = 0;
+    p.respondedOnPorts.add(443);
+
+    ScoreBoard board = new ScoreBoard();
+    signal.contribute(ctx(p), board);
+
+    assertThat(board.winner(DeviceTypes.UNKNOWN)).isEqualTo(DeviceTypes.SERVER);
+  }
+
+  @Test
+  void directionUnknownFlowsOnly_doNotVoteServer() {
+    // UDP/ICMP/ARP or a mid-flow capture: no measured initiator, so nothing directional is recorded.
+    HostProfile p = new HostProfile();
+    p.conversationCount = 4;
+    p.totalPackets = 1000;
+    p.measuredResponses = 0;
+    p.measuredInitiations = 0;
+
+    ScoreBoard board = new ScoreBoard();
+    signal.contribute(ctx(p), board);
+
+    assertThat(board.scores()).doesNotContainKey(DeviceTypes.SERVER);
+  }
+
+  @Test
+  void mostlyOpensConnections_withVariedApps_votesClient() {
+    HostProfile p = new HostProfile();
+    p.conversationCount = 8;
+    p.totalPackets = 5000;
+    p.measuredInitiations = 8;
+    p.measuredResponses = 0;
+    p.apps.addAll(Set.of("Netflix", "WhatsApp", "Spotify", "Chrome"));
+
+    ScoreBoard board = new ScoreBoard();
+    signal.contribute(ctx(p), board);
+
+    assertThat(board.scores()).doesNotContainKey(DeviceTypes.SERVER);
+    assertThat(board.scores())
+        .containsKeys(DeviceTypes.MOBILE, DeviceTypes.LAPTOP_DESKTOP);
+  }
+}

--- a/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/WebApiServerSignalTest.java
+++ b/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/WebApiServerSignalTest.java
@@ -35,7 +35,40 @@ class WebApiServerSignalTest {
     apiSignal.contribute(ctx(Set.of("web")), board);
     webSignal.contribute(ctx(Set.of("web")), board);
 
+    // Cleartext HTTP is authoritative — it stays dominant.
     assertThat(board.winner(DeviceTypes.UNKNOWN)).isEqualTo(DeviceTypes.WEB_SERVER);
+  }
+
+  @Test
+  void tlsOnlyRole_withNoContraryEvidence_classifiesWebServer() {
+    ScoreBoard board = new ScoreBoard();
+    apiSignal.contribute(ctx(Set.of("tls")), board);
+    webSignal.contribute(ctx(Set.of("tls")), board);
+
+    // #496 AC #3 — TLS is evidence toward a web role; with nothing contrary it wins.
+    assertThat(board.winner(DeviceTypes.UNKNOWN)).isEqualTo(DeviceTypes.WEB_SERVER);
+    assertThat(board.scores()).containsEntry(DeviceTypes.WEB_SERVER, WebServerSignal.WEIGHT_TLS);
+  }
+
+  @Test
+  void tlsOnlyRole_losesToStrongRouterHardware() {
+    ScoreBoard board = new ScoreBoard();
+    // Router OUI (+40) + TTL 255 (+30) + high fan-out (+35) = 105, the AC #6 scenario.
+    board.add(DeviceTypes.ROUTER, 105, "router OUI + TTL 255 + fan-out");
+    apiSignal.contribute(ctx(Set.of("tls")), board);
+    webSignal.contribute(ctx(Set.of("tls")), board);
+
+    // #496 AC #6 — a router serving its own admin UI over TLS classifies as Router, not Web Server.
+    assertThat(board.winner(DeviceTypes.UNKNOWN)).isEqualTo(DeviceTypes.ROUTER);
+  }
+
+  @Test
+  void httpEvidence_outranksTlsEvidence_whenBothPresent() {
+    ScoreBoard board = new ScoreBoard();
+    webSignal.contribute(ctx(Set.of("web", "tls")), board);
+
+    // HTTP is authoritative; the vote is the HTTP weight, not the TLS weight, and not both summed.
+    assertThat(board.scores()).containsEntry(DeviceTypes.WEB_SERVER, WebServerSignal.WEIGHT_HTTP);
   }
 
   @Test

--- a/backend/src/test/java/com/tracepcap/hostlog/service/WebServerLogExtractorTest.java
+++ b/backend/src/test/java/com/tracepcap/hostlog/service/WebServerLogExtractorTest.java
@@ -121,6 +121,17 @@ class WebServerLogExtractorTest {
   }
 
   @Test
+  void tlsServerHello_countsOnlyOnWebFacingPorts() {
+    // #496 AC #3 — TLS is port-qualified: 443/4433/8443 are web-facing; SIP-TLS/IMAPS and null are not.
+    assertThat(WebServerLogExtractor.isWebFacingTlsPort(443)).isTrue();
+    assertThat(WebServerLogExtractor.isWebFacingTlsPort(8443)).isTrue();
+    assertThat(WebServerLogExtractor.isWebFacingTlsPort(4433)).isTrue();
+    assertThat(WebServerLogExtractor.isWebFacingTlsPort(5061)).isFalse(); // SIP-TLS
+    assertThat(WebServerLogExtractor.isWebFacingTlsPort(993)).isFalse(); // IMAPS
+    assertThat(WebServerLogExtractor.isWebFacingTlsPort(null)).isFalse();
+  }
+
+  @Test
   void repeatedEndpoint_aggregatesCountAndStatuses() {
     exchange("10.0.0.10", "10.0.0.1", "GET", "/api/x", "200", "application/json", "");
     exchange("10.0.0.10", "10.0.0.1", "GET", "/api/x", "200", "application/json", "");


### PR DESCRIPTION
Finishes the backend half of #496. Prior PRs closed part of it: **#528** recorded who opened a connection as a MEASURED fact (SYN-without-ACK) and migrated the frontend node role off `port < 1024`; **#537** reworked the frontend rendering and added human adjudication. But the machine verdict is still the ScoreBoard winner, so three acceptance criteria were untouched. This PR closes them.

## Acceptance criteria

| AC | Status |
|----|--------|
| 1 — role uses SYN/who-initiated, not `port < 1024` | Frontend done in #528; **backend classifier fixed here (Part A)** |
| 2 — node's own port, not an OR across both ends | Done (#528) |
| 3 — serving TLS is *evidence*, port-qualified, not proof | **Part B** |
| 4 — a single ServerHello no longer outranks all hardware signals | **Part C** |
| 5 — dead `8080`/`8443` map entries | Done (#537) |
| 6 — router-OUI host serving admin UI over TLS → Router | **Part B + C** |

## Changes

**Part A — classifier uses the MEASURED initiator (AC #1).** `HostProfile`'s directional fields were built from the *sorted* `srcIp`/`dstIp` — "whichever endpoint sorted first," not who opened the connection (the exact signal #528 said was destroyed at parse time). `addToProfile` now reads `conv.getInitiatorIp()`; a null initiator (UDP/ICMP/ARP/mid-flow) records nothing directional rather than guessing. `TrafficPatternSignal`'s SERVER vote becomes "answers connections it never opens," with `port < 1024` demoted to a strengthener. This was the *only* signal consuming direction from the conversation — every other signal is direction-independent (OUI/TTL/app) or gets direction from a protocol-semantic extractor (DNS/Web/API).

**Part B — TLS is port-qualified evidence (AC #3).** New `ServiceLogRoles.TLS = "tls"`. `WebServerLogExtractor` captures `tcp.srcport` in the ServerHello pass and tags a TLS-only host with `tls` only on a web-facing port (443/4433/8443). HTTP-served hosts keep the authoritative `web`/`api` roles.

**Part C — graded weight so hardware can win (AC #4/#6).** `WebServerSignal` votes `WEIGHT_HTTP = 1000` for served HTTP (authoritative) but `WEIGHT_TLS = 60` for TLS-only — above "answers-only on a well-known port" (~45) yet below router hardware (OUI 40 + TTL 255 → 30 = 70, or + fan-out = 105). A router serving its admin UI over TLS resolves to **ROUTER**; a close call renders **contested** instead of a false-confident 100% Web Server.

## Verification

- Backend unit suite: **163 passed, 0 failed** (1 docker-gated skipped). New/updated: `WebApiServerSignalTest`, `TrafficPatternSignalTest`, `WebServerLogExtractorTest`.
- Live on `demo_all_rules.pcap` (rebuilt backend):
  - `203.0.113.30` (serves TLS) → role `['tls']` → `WEB_SERVER` **conf 17, contested** — was `WEB_SERVER` **100% non-contested** before.
  - Actual-HTTP servers (`10.10.0.2`, `203.0.113.51`, `93.184.216.34`) stay `WEB_SERVER` **100%**.
  - `203.0.113.10` — the issue's `:4434` responder the port rule called a client — now votes **SERVER** via measured direction.

Closes #496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved network host classification using measured connection direction.
  * Refined web-server detection to distinguish cleartext HTTP from TLS-only evidence.
  * TLS web-server evidence is now limited to web-facing ports and cannot override stronger device signals.
  * TLS-only services are included in web/API server results.

* **UI**
  * Centralized network graph icon selection with consistent device and node icons.
* **Tests**
  * Added coverage for traffic classification, TLS port handling, server-role scoring, and icon consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->