### PR TITLE
fix(network): give DHCP server its own graph icon, distinct from cluster

### DIFF
--- a/frontend/src/components/network/NetworkGraph/nodeIcons.ts
+++ b/frontend/src/components/network/NetworkGraph/nodeIcons.ts
@@ -19,7 +19,7 @@ export const NODE_TYPE_ICONS: Record<string, string> = {
   'ssh-server':      '\uf5c3', // bi-terminal
   'ftp-server':      '\uf3d5', // bi-folder-symlink
   'mail-server':     '\uf32f', // bi-envelope
-  'dhcp-server':     '\uf2ee', // bi-diagram-3
+  'dhcp-server':     '\uf1d6', // bi-broadcast
   'ntp-server':      '\uf293', // bi-clock
   'database-server': '\uf8c4', // bi-database
   router:            '\uf6ec', // bi-router

--- a/frontend/src/features/network/constants.ts
+++ b/frontend/src/features/network/constants.ts
@@ -55,7 +55,7 @@ export const NODE_TYPE_CONFIG: Record<NodeType, {
   'ssh-server':      { label: 'SSH Server',        icon: 'bi-terminal',        badgeClass: 'bg-info text-dark',    color: '#1abc9c' },
   'ftp-server':      { label: 'FTP Server',        icon: 'bi-folder-symlink',  badgeClass: 'bg-secondary',         color: '#16a085' },
   'mail-server':     { label: 'Mail Server',       icon: 'bi-envelope',        badgeClass: 'bg-danger',            color: '#e91e63' },
-  'dhcp-server':     { label: 'DHCP Server',       icon: 'bi-diagram-3',       badgeClass: 'bg-secondary',         color: '#8e44ad' },
+  'dhcp-server':     { label: 'DHCP Server',       icon: 'bi-broadcast',       badgeClass: 'bg-secondary',         color: '#8e44ad' },
   'ntp-server':      { label: 'NTP Server',        icon: 'bi-clock',           badgeClass: 'bg-dark',              color: '#6c3483' },
   'database-server': { label: 'Database Server',   icon: 'bi-database',        badgeClass: 'bg-danger',            color: '#e67e22' },
   router:            { label: 'Router / Gateway',  icon: 'bi-router',          badgeClass: 'bg-warning text-dark', color: '#d4ac0d' },


### PR DESCRIPTION
## Problem

On the network graph canvas, `dhcp-server` and `cluster` both rendered **`bi-diagram-3`** (``), so a DHCP server node was visually indistinguishable from a cluster node. Flagged by gemini during review of #546.

## Why it's not a one-line codepoint swap

`iconCodepoints.test.ts` enforces that `NODE_TYPE_ICONS[nodeType]` equals the codepoint of `NODE_TYPE_CONFIG[nodeType].icon` (the class name the legend renders from). The `` codepoint was **not** drifted — it faithfully matched the config's `'bi-diagram-3'`. So changing only the codepoint would break that test. The fix has to move the **class name** too.

## Change

Point `dhcp-server` at **`bi-broadcast`** (``) in both places:
- `features/network/constants.ts` — `NODE_TYPE_CONFIG` icon class (drives the legend)
- `components/network/NetworkGraph/nodeIcons.ts` — the WebGL codepoint table

`cluster` keeps `bi-diagram-3`, so the collision is resolved. `bi-broadcast` also fits DHCP's DISCOVER/OFFER broadcast semantics, and no other node type uses it.

## Verification

`iconCodepoints.test.ts` — **40 passed** (incl. the `NODE_TYPE_ICONS == NODE_TYPE_CONFIG` invariant for `dhcp-server`).

Follow-up to a review comment on #546; independent of that PR (main-based, frontend-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)