### PR TITLE
feat(network): protocol edge-colour legend + curved parallel edges (#497)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@govtechsg/sgds": "^2.3.6",
         "@govtechsg/sgds-react": "^2.7.7",
+        "@sigma/edge-curve": "^3.1.0",
         "@sigma/node-image": "^3.0.0",
         "@types/html2canvas": "^0.5.35",
         "@xyflow/react": "^12.10.2",
@@ -1997,6 +1998,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sigma/edge-curve": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sigma/edge-curve/-/edge-curve-3.1.0.tgz",
+      "integrity": "sha512-OFWkfAXEsm+X8l1K4K49cC0psB0gQ+gqxKA08HG5piNPdzrDZ5gG9Gza6htZ5AirOVwd/4/uq/gPpD5En+H+3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "sigma": ">=3.0.0-beta.10"
+      }
     },
     "node_modules/@sigma/node-image": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@govtechsg/sgds": "^2.3.6",
     "@govtechsg/sgds-react": "^2.7.7",
+    "@sigma/edge-curve": "^3.1.0",
     "@sigma/node-image": "^3.0.0",
     "@types/html2canvas": "^0.5.35",
     "@xyflow/react": "^12.10.2",

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.css
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.css
@@ -158,6 +158,38 @@
   box-shadow: 0 0 4px currentColor;
 }
 
+/* Line swatch for edge-protocol legend entries — a rule, not a dot, so it reads
+   as a connection stroke rather than a node. */
+.ng-legend-line {
+  width: 16px;
+  height: 3px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+/* Separates the node section from the edge-protocol section. */
+.ng-legend-divider {
+  height: 1px;
+  margin: 3px 0;
+  background: rgba(13, 17, 23, 0.12);
+}
+
+[data-graph-theme='dark'] .ng-legend-divider {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.ng-legend-heading {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(31, 35, 40, 0.55);
+}
+
+[data-graph-theme='dark'] .ng-legend-heading {
+  color: rgba(201, 209, 217, 0.55);
+}
+
 .ng-legend-label {
   font-size: 11px;
   color: rgba(31, 35, 40, 0.85);

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.css
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.css
@@ -144,6 +144,38 @@
   border-color: rgba(255, 255, 255, 0.1);
 }
 
+/*
+ * On-screen the legend caps its height to the canvas and scrolls when the protocol list is long
+ * (a protocol-zoo capture can list ~20 edge colours). Scrolling needs pointer events, so this
+ * corner no longer pans the graph underneath — an acceptable trade for a legend panel. Not applied
+ * to the forceLight (PDF-capture) render, which keeps full height so the export isn't clipped.
+ */
+.ng-legend--scroll {
+  max-height: calc(100% - 32px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  pointer-events: auto;
+}
+
+/* Slim, unobtrusive scrollbar that reads in both canvas themes. */
+.ng-legend--scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(13, 17, 23, 0.28) transparent;
+}
+.ng-legend--scroll::-webkit-scrollbar {
+  width: 6px;
+}
+.ng-legend--scroll::-webkit-scrollbar-thumb {
+  background: rgba(13, 17, 23, 0.28);
+  border-radius: 3px;
+}
+[data-graph-theme='dark'] .ng-legend--scroll {
+  scrollbar-color: rgba(255, 255, 255, 0.28) transparent;
+}
+[data-graph-theme='dark'] .ng-legend--scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.28);
+}
+
 .ng-legend-item {
   display: flex;
   align-items: center;

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -4,10 +4,12 @@ import ELK from 'elkjs';
 const ELK_WORKER_URL = `${import.meta.env.BASE_URL}elk-worker.min.js`;
 import Graph from 'graphology';
 import Sigma from 'sigma';
+import { EdgeArrowProgram } from 'sigma/rendering';
+import { EdgeCurvedArrowProgram, indexParallelEdgesIndex } from '@sigma/edge-curve';
 import circular from 'graphology-layout/circular';
 import noverlap from 'graphology-layout-noverlap';
 import type { GraphNode, GraphEdge } from '@/features/network/types';
-import { getProtocolColor, NODE_TYPE_CONFIG } from '@/features/network/constants';
+import { getProtocolColor, NODE_TYPE_CONFIG, buildProtocolLegend, DEFAULT_EDGE_COLOR } from '@/features/network/constants';
 import { makeVolumeEdgeColor } from '@/utils/volumeColor';
 import { deviceTypeIcon, deviceTypeLabel, DEVICE_TYPES } from '@/utils/deviceType';
 import { useStore } from '@/store';
@@ -289,6 +291,60 @@ export function edgeBytesRange(edges: GraphEdge[]): { min: number; max: number }
 }
 
 // ---------------------------------------------------------------------------
+// Parallel-edge curvature
+// ---------------------------------------------------------------------------
+
+/**
+ * Curvature for the edge at `index` within a parallel group of `maxIndex + 1` edges. Zero-index
+ * edges stay flat; the rest fan out symmetrically. `amplitude` keeps big groups from curving so hard
+ * they cross each other. Mirrors the reference implementation from `@sigma/edge-curve`.
+ */
+function getCurvature(index: number, maxIndex: number): number {
+  if (maxIndex <= 0) return 0;
+  if (index < 0) return -getCurvature(-index, maxIndex);
+  const amplitude = 3.5;
+  const maxCurvature = (amplitude * (1 - Math.exp(-maxIndex / amplitude))) / maxIndex;
+  return (maxCurvature * index) / maxIndex;
+}
+
+/**
+ * When two nodes are joined by more than one edge — a different protocol/app per edge, or one in
+ * each direction — straight strokes would draw on top of each other and hide all but one colour
+ * (#497). Curve the parallels apart so every edge (and its protocol colour) is visible; edges with a
+ * single connection between their endpoints stay straight. Reads the parallel-group indices that
+ * `indexParallelEdgesIndex` writes and sets each edge's render `type` + `curvature` accordingly.
+ */
+function applyParallelEdgeCurvature(graph: Graph): void {
+  indexParallelEdgesIndex(graph, {
+    edgeIndexAttribute: 'parallelIndex',
+    edgeMinIndexAttribute: 'parallelMinIndex',
+    edgeMaxIndexAttribute: 'parallelMaxIndex',
+  });
+  graph.forEachEdge((edge, attrs) => {
+    const parallelIndex = attrs.parallelIndex as number | null | undefined;
+    const parallelMinIndex = attrs.parallelMinIndex as number | null | undefined;
+    const parallelMaxIndex = attrs.parallelMaxIndex as number | null | undefined;
+
+    if (typeof parallelMinIndex === 'number') {
+      // Group spans both directions: the middle edge stays straight, the rest curve.
+      graph.mergeEdgeAttributes(edge, {
+        type: parallelIndex ? 'curved' : 'arrow',
+        curvature: getCurvature(parallelIndex as number, parallelMaxIndex as number),
+      });
+    } else if (typeof parallelIndex === 'number') {
+      // Same-direction parallels: curve them all (index 0 gets 0 curvature → renders straight).
+      graph.mergeEdgeAttributes(edge, {
+        type: 'curved',
+        curvature: getCurvature(parallelIndex, parallelMaxIndex as number),
+      });
+    } else {
+      // The only edge between its endpoints — keep it a straight arrow.
+      graph.setEdgeAttribute(edge, 'type', 'arrow');
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Build a graphology graph from GraphNode[] / GraphEdge[]
 // ---------------------------------------------------------------------------
 
@@ -360,6 +416,9 @@ function buildGraph(
       protocol: e.data.protocol,
     });
   }
+
+  // Curve edges that share a node pair so overlapping strokes don't hide each other's colour.
+  applyParallelEdgeCurvature(graph);
 
   return graph;
 }
@@ -496,6 +555,17 @@ export const NetworkGraph = memo(function NetworkGraph({
     [hiddenNodesList]
   );
 
+  // Edge-colour legend entries for the protocols present in the current graph.
+  // Only meaningful when edges are coloured by protocol — in volume mode the
+  // strokes encode byte counts, not protocols, so the swatches would mislead.
+  const protocolLegend = useMemo(
+    () =>
+      edgeColorMode === 'protocol'
+        ? buildProtocolLegend(edges.map(e => e.data.protocol))
+        : { entries: [], hasUnmapped: false },
+    [edges, edgeColorMode]
+  );
+
   const hiddenNeighbors = useMemo<GraphNode[]>(() => {
     if (!hoveredNode || crossEdges.length === 0) return [];
     const neighborIds = new Set<string>();
@@ -550,6 +620,12 @@ export const NetworkGraph = memo(function NetworkGraph({
       renderLabels: true,
       renderEdgeLabels: false,
       defaultEdgeType: 'arrow',
+      // 'arrow' = straight (single edge between a pair); 'curved' = fanned-out parallels, set per
+      // edge by applyParallelEdgeCurvature so overlapping protocol colours stay distinguishable.
+      edgeProgramClasses: {
+        arrow: EdgeArrowProgram,
+        curved: EdgeCurvedArrowProgram,
+      },
       labelDensity: 1,
       labelGridCellSize: 60,
       labelRenderedSizeThreshold: -Infinity, // always call drawNodeLabel at every zoom level
@@ -639,7 +715,17 @@ export const NetworkGraph = memo(function NetworkGraph({
             const t = sigma.graphToViewport(graph.getNodeAttributes(target) as { x: number; y: number });
             labelCtx.beginPath();
             labelCtx.moveTo(s.x, s.y);
-            labelCtx.lineTo(t.x, t.y);
+            // Curved parallels must bow the same way here as Sigma draws them on screen, or the PDF
+            // would show overlapping straight lines again. Same control point Sigma uses: the
+            // midpoint offset perpendicular to the edge by `curvature` (#497).
+            const curvature = (attrs['curvature'] as number) ?? 0;
+            if (attrs['type'] === 'curved' && curvature !== 0) {
+              const cx = (s.x + t.x) / 2 + (t.y - s.y) * curvature;
+              const cy = (s.y + t.y) / 2 - (t.x - s.x) * curvature;
+              labelCtx.quadraticCurveTo(cx, cy, t.x, t.y);
+            } else {
+              labelCtx.lineTo(t.x, t.y);
+            }
             labelCtx.strokeStyle = (attrs['color'] as string) ?? '#999';
             labelCtx.lineWidth = Math.max(0.6, (attrs['size'] as number) ?? 1);
             labelCtx.globalAlpha = 0.75;
@@ -997,6 +1083,26 @@ export const NetworkGraph = memo(function NetworkGraph({
             <i className="bi bi-question-circle ng-legend-icon" style={{ color: NODE_TYPE_CONFIG['unknown'].color }} />
             <span className="ng-legend-label">Unknown</span>
           </div>
+        )}
+
+        {/* ── Edge-protocol colours — line swatches, driven by PROTOCOL_COLORS ── */}
+        {(protocolLegend.entries.length > 0 || protocolLegend.hasUnmapped) && (
+          <>
+            <div className="ng-legend-divider" />
+            <div className="ng-legend-heading">Edges</div>
+            {protocolLegend.entries.map(({ color, label }) => (
+              <div key={color} className="ng-legend-item">
+                <span className="ng-legend-line" style={{ background: color }} />
+                <span className="ng-legend-label">{label}</span>
+              </div>
+            ))}
+            {protocolLegend.hasUnmapped && (
+              <div className="ng-legend-item">
+                <span className="ng-legend-line" style={{ background: DEFAULT_EDGE_COLOR }} />
+                <span className="ng-legend-label">Other</span>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -1047,7 +1047,9 @@ export const NetworkGraph = memo(function NetworkGraph({
       )}
 
       {/* ── Node-type legend — data-driven, matches getNodeColor/getNodeIcon ── */}
-      <div className="ng-legend">
+      {/* Scrollable on-screen so a long protocol list can't overflow the canvas; the PDF-capture
+          render (forceLight) keeps the full height so nothing is clipped in the export. */}
+      <div className={`ng-legend${forceLight ? '' : ' ng-legend--scroll'}`}>
         {/* Specific service nodeTypes present in this graph */}
         {Object.entries(NODE_TYPE_CONFIG)
           .filter(([type]) => !GENERIC_NODE_TYPES.has(type) && type !== 'cluster' &&

--- a/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
+++ b/frontend/src/components/network/NetworkGraph/NetworkGraph.tsx
@@ -300,7 +300,9 @@ export function edgeBytesRange(edges: GraphEdge[]): { min: number; max: number }
  * they cross each other. Mirrors the reference implementation from `@sigma/edge-curve`.
  */
 function getCurvature(index: number, maxIndex: number): number {
-  if (maxIndex <= 0) return 0;
+  // `!maxIndex` also rejects undefined/null/NaN (a missing parallel-index attribute) — those would
+  // otherwise sail past `<= 0` and produce NaN curvature.
+  if (!maxIndex || maxIndex <= 0) return 0;
   if (index < 0) return -getCurvature(-index, maxIndex);
   const amplitude = 3.5;
   const maxCurvature = (amplitude * (1 - Math.exp(-maxIndex / amplitude))) / maxIndex;
@@ -719,7 +721,9 @@ export const NetworkGraph = memo(function NetworkGraph({
             // would show overlapping straight lines again. Same control point Sigma uses: the
             // midpoint offset perpendicular to the edge by `curvature` (#497).
             const curvature = (attrs['curvature'] as number) ?? 0;
-            if (attrs['type'] === 'curved' && curvature !== 0) {
+            // Number.isFinite guards against a NaN curvature (missing/malformed index) reaching
+            // quadraticCurveTo, which would silently drop the stroke.
+            if (attrs['type'] === 'curved' && Number.isFinite(curvature) && curvature !== 0) {
               const cx = (s.x + t.x) / 2 + (t.y - s.y) * curvature;
               const cy = (s.y + t.y) / 2 - (t.x - s.x) * curvature;
               labelCtx.quadraticCurveTo(cx, cy, t.x, t.y);

--- a/frontend/src/features/network/__tests__/protocolLegend.test.ts
+++ b/frontend/src/features/network/__tests__/protocolLegend.test.ts
@@ -1,4 +1,10 @@
-import { buildProtocolLegend, PROTOCOL_COLORS, DEFAULT_EDGE_COLOR } from '../constants';
+import {
+  buildProtocolLegend,
+  getProtocolColor,
+  normalizeProtocol,
+  PROTOCOL_COLORS,
+  DEFAULT_EDGE_COLOR,
+} from '../constants';
 
 describe('buildProtocolLegend', () => {
   it('lists only protocols present in the graph, in PROTOCOL_COLORS order', () => {
@@ -47,5 +53,62 @@ describe('buildProtocolLegend', () => {
 
   it('returns an empty legend for no edges', () => {
     expect(buildProtocolLegend([])).toEqual({ entries: [], hasUnmapped: false });
+  });
+
+  it('folds version-suffixed variants into their base entry (not a grey Other)', () => {
+    const { entries, hasUnmapped } = buildProtocolLegend(['TLSv1.2', 'TLSv1.3', 'SSHv2', 'IGMPv3']);
+    expect(hasUnmapped).toBe(false);
+    expect(entries).toEqual([
+      // Only TLS present (no HTTPS), so the shared #3498db entry is labelled "TLS".
+      { color: PROTOCOL_COLORS.TLS, label: 'TLS' },
+      { color: PROTOCOL_COLORS.IGMP, label: 'IGMP' },
+      { color: PROTOCOL_COLORS.SSH, label: 'SSH' },
+    ]);
+  });
+});
+
+describe('normalizeProtocol', () => {
+  it('returns an exact curated match unchanged', () => {
+    expect(normalizeProtocol('icmpv6')).toBe('ICMPV6'); // distinct entry, not folded to ICMP
+    expect(normalizeProtocol('RSTP')).toBe('RSTP');
+  });
+
+  it('resolves explicit aliases', () => {
+    expect(normalizeProtocol('SSL')).toBe('TLS');
+    expect(normalizeProtocol('SIP/SDP')).toBe('SIP');
+    expect(normalizeProtocol('FTP-DATA')).toBe('FTP');
+  });
+
+  it('strips a trailing version suffix and folds to the base', () => {
+    expect(normalizeProtocol('TLSv1.2')).toBe('TLS');
+    expect(normalizeProtocol('SSHv2')).toBe('SSH');
+    expect(normalizeProtocol('IGMPv3')).toBe('IGMP');
+    expect(normalizeProtocol('SMB2')).toBe('SMB');
+  });
+
+  it('leaves pure-numeric / raw-ethertype names untouched (stays grey)', () => {
+    expect(normalizeProtocol('802.11')).toBe('802.11');
+    expect(normalizeProtocol('0X5E00')).toBe('0X5E00');
+    expect(getProtocolColor('0X5E00')).toBe(DEFAULT_EDGE_COLOR);
+  });
+
+  it('drives getProtocolColor so a variant paints its base colour', () => {
+    expect(getProtocolColor('TLSv1.3')).toBe(PROTOCOL_COLORS.TLS);
+    expect(getProtocolColor('SSHv2')).toBe(PROTOCOL_COLORS.SSH);
+    expect(getProtocolColor('WHOIS')).toBe(DEFAULT_EDGE_COLOR); // genuinely unmapped
+  });
+});
+
+describe('PROTOCOL_COLORS palette', () => {
+  it('gives every non-aliased protocol a unique colour (legend groups by colour)', () => {
+    // HTTPS/TLS and STP/RSTP and ICMP/ICMPV6 deliberately share; everything else must be unique.
+    const sharedByDesign = new Set(['TLS', 'RSTP', 'ICMPV6']);
+    const seen = new Map<string, string>();
+    for (const [proto, color] of Object.entries(PROTOCOL_COLORS)) {
+      if (sharedByDesign.has(proto)) continue;
+      const prev = seen.get(color);
+      expect(prev, `${proto} shares ${color} with ${prev}`).toBeUndefined();
+      seen.set(color, proto);
+    }
   });
 });

--- a/frontend/src/features/network/__tests__/protocolLegend.test.ts
+++ b/frontend/src/features/network/__tests__/protocolLegend.test.ts
@@ -1,0 +1,51 @@
+import { buildProtocolLegend, PROTOCOL_COLORS, DEFAULT_EDGE_COLOR } from '../constants';
+
+describe('buildProtocolLegend', () => {
+  it('lists only protocols present in the graph, in PROTOCOL_COLORS order', () => {
+    // Deliberately out of definition order on input.
+    const { entries } = buildProtocolLegend(['UDP', 'HTTP', 'DNS']);
+    expect(entries).toEqual([
+      { color: PROTOCOL_COLORS.HTTP, label: 'HTTP' },
+      { color: PROTOCOL_COLORS.DNS, label: 'DNS' },
+      { color: PROTOCOL_COLORS.UDP, label: 'UDP' },
+    ]);
+  });
+
+  it('is case-insensitive on the protocol string', () => {
+    const { entries } = buildProtocolLegend(['http', 'Dns']);
+    expect(entries.map(e => e.label)).toEqual(['HTTP', 'DNS']);
+  });
+
+  it('collapses protocols sharing a colour into one entry via PROTOCOL_LABELS', () => {
+    const { entries } = buildProtocolLegend(['HTTPS', 'TLS']);
+    expect(entries).toEqual([{ color: PROTOCOL_COLORS.HTTPS, label: 'HTTPS/TLS' }]);
+  });
+
+  it('collapses STP/RSTP into a single "STP/RSTP" entry', () => {
+    const { entries } = buildProtocolLegend(['RSTP', 'STP']);
+    expect(entries).toEqual([{ color: PROTOCOL_COLORS.STP, label: 'STP/RSTP' }]);
+  });
+
+  it('labels a shared-colour entry from the first present protocol', () => {
+    // Only TLS present (no HTTPS) → the entry reflects what is actually there.
+    const { entries } = buildProtocolLegend(['TLS']);
+    expect(entries).toEqual([{ color: PROTOCOL_COLORS.TLS, label: 'TLS' }]);
+  });
+
+  it('flags unmapped protocols so the grey "Other" swatch can be shown', () => {
+    const { entries, hasUnmapped } = buildProtocolLegend(['HTTP', 'GQUIC', '']);
+    expect(hasUnmapped).toBe(true);
+    expect(entries).toEqual([{ color: PROTOCOL_COLORS.HTTP, label: 'HTTP' }]);
+    // Sanity: the fallback colour those edges render with.
+    expect(DEFAULT_EDGE_COLOR).toBeDefined();
+  });
+
+  it('does not flag unmapped when every protocol is known', () => {
+    const { hasUnmapped } = buildProtocolLegend(['TCP', 'UDP']);
+    expect(hasUnmapped).toBe(false);
+  });
+
+  it('returns an empty legend for no edges', () => {
+    expect(buildProtocolLegend([])).toEqual({ entries: [], hasUnmapped: false });
+  });
+});

--- a/frontend/src/features/network/constants.ts
+++ b/frontend/src/features/network/constants.ts
@@ -88,8 +88,13 @@ export const PROTOCOL_ALIASES: Record<string, string> = {
  *   2. explicit alias in PROTOCOL_ALIASES
  *   3. strip a trailing version suffix (V2, v1.2, " 2") and retry the base
  *   4. otherwise the uppercased name itself (an unmapped protocol)
+ *
+ * Tolerates missing/malformed values (null/undefined/non-string) by returning '',
+ * which resolves to DEFAULT_EDGE_COLOR / the "Other" legend bucket — an edge with
+ * no protocol must never crash the whole graph render.
  */
-export function normalizeProtocol(protocol: string): string {
+export function normalizeProtocol(protocol: string | null | undefined): string {
+  if (typeof protocol !== 'string' || protocol === '') return '';
   const upper = protocol.toUpperCase();
   if (upper in PROTOCOL_COLORS) return upper;
   if (upper in PROTOCOL_ALIASES) return PROTOCOL_ALIASES[upper];

--- a/frontend/src/features/network/constants.ts
+++ b/frontend/src/features/network/constants.ts
@@ -4,18 +4,58 @@ import type { NodeType } from './types';
  * Single source of truth for protocol edge colors and display labels used in
  * NetworkGraph (edge strokes) and NetworkControls (legend).
  *
- * To add a new protocol: add an entry here. The legend renders automatically.
+ * This is a *curated* palette, not a hash: well-known protocols get a hand-picked
+ * colour; everything else falls back to DEFAULT_EDGE_COLOR (grey) and collapses
+ * into one "Other" legend entry. Adding a protocol here makes it appear in the
+ * legend automatically. Each entry needs a UNIQUE colour, or the legend (which
+ * groups by colour) would hide one behind the other — the only deliberate
+ * exceptions are aliases that share a swatch on purpose (HTTPS/TLS).
+ *
+ * Version-suffixed names (TLSv1.2, SSHv2, IGMPv3, …) do NOT need their own entry:
+ * normalizeProtocol() strips the suffix and folds them into the base protocol.
+ * Only irregular/compound variant names go in PROTOCOL_ALIASES below.
+ *
+ * Distinguishing this many colours by eye has limits; the legend is the decoder.
+ * Keys are UPPERCASE (protocol names are matched case-insensitively).
  */
 export const PROTOCOL_COLORS: Record<string, string> = {
+  // Web / transport-security
   HTTP: '#2ecc71',
   HTTPS: '#3498db',
   TLS: '#3498db',
+  QUIC: '#6c5ce7',
+  // Name resolution / discovery
   DNS: '#f39c12',
+  MDNS: '#c0ca33',
+  SSDP: '#00897b',
+  // Core transport / net-layer
   TCP: '#7f8c8d',
   UDP: '#f1c40f',
   ICMP: '#e67e22',
   ICMPV6: '#e67e22',
+  IGMP: '#af7ac5',
   ARP: '#16a085',
+  // Mail (pink/magenta family)
+  SMTP: '#e84393',
+  POP: '#d81b60',
+  IMAP: '#ad1457',
+  // Remote access / file transfer
+  SSH: '#17a2b8',
+  TELNET: '#7d6608',
+  FTP: '#a04000',
+  TFTP: '#a1887f',
+  SMB: '#2471a3',
+  RDP: '#7b1fa2',
+  // Infra services
+  DHCP: '#229954',
+  NTP: '#5c6bc0',
+  SNMP: '#0e7c86',
+  LDAP: '#303f9f',
+  SYSLOG: '#546e7a',
+  // Voice
+  SIP: '#b9770e',
+  RTP: '#ff7043',
+  // L2 control
   STP: '#8e44ad',
   RSTP: '#8e44ad',
   LLDP: '#6c3483',
@@ -26,8 +66,43 @@ export const PROTOCOL_COLORS: Record<string, string> = {
 
 export const DEFAULT_EDGE_COLOR = '#95a5a6';
 
+/**
+ * Irregular variant / compound protocol names that should fold into a base
+ * protocol above but don't follow the "base + version suffix" pattern that
+ * normalizeProtocol() strips automatically. Keep this small — most variants
+ * (TLSv1.2, SSHv2, …) need no entry.
+ */
+export const PROTOCOL_ALIASES: Record<string, string> = {
+  SSL: 'TLS',
+  'HTTP/XML': 'HTTP',
+  'FTP-DATA': 'FTP',
+  'SIP/SDP': 'SIP',
+  'SMTP/IMF': 'SMTP',
+  'POP/IMF': 'POP',
+};
+
+/**
+ * Canonical protocol key for a raw tshark protocol name, used for both colour
+ * and legend grouping. Resolution order:
+ *   1. exact match in PROTOCOL_COLORS  (keeps distinct entries like ICMPv6, RSTP)
+ *   2. explicit alias in PROTOCOL_ALIASES
+ *   3. strip a trailing version suffix (V2, v1.2, " 2") and retry the base
+ *   4. otherwise the uppercased name itself (an unmapped protocol)
+ */
+export function normalizeProtocol(protocol: string): string {
+  const upper = protocol.toUpperCase();
+  if (upper in PROTOCOL_COLORS) return upper;
+  if (upper in PROTOCOL_ALIASES) return PROTOCOL_ALIASES[upper];
+  // Fold "<base><version>" (TLSV1.2, SSHV2, IGMPV3, SMB2, RDPUDP2, PCP V2, …) into
+  // <base>. Requires the base to end in a letter so pure-numeric names like
+  // "802.11" or raw ethertypes ("0X5E00") are left untouched.
+  const base = upper.replace(/\s*V?\d+(?:\.\d+)*$/, '');
+  if (base && base !== upper && base in PROTOCOL_COLORS) return base;
+  return upper;
+}
+
 export function getProtocolColor(protocol: string): string {
-  return PROTOCOL_COLORS[protocol.toUpperCase()] ?? DEFAULT_EDGE_COLOR;
+  return PROTOCOL_COLORS[normalizeProtocol(protocol)] ?? DEFAULT_EDGE_COLOR;
 }
 
 /**
@@ -60,7 +135,9 @@ export function buildProtocolLegend(
   const present = new Set<string>();
   let hasUnmapped = false;
   for (const p of protocols) {
-    const key = p.toUpperCase();
+    // Normalize first so variants (TLSv1.2, SSHv2, SSL, …) fold into their base
+    // entry instead of counting as unmapped.
+    const key = normalizeProtocol(p);
     if (key in PROTOCOL_COLORS) present.add(key);
     else hasUnmapped = true;
   }

--- a/frontend/src/features/network/constants.ts
+++ b/frontend/src/features/network/constants.ts
@@ -41,6 +41,41 @@ export const PROTOCOL_LABELS: Record<string, string> = {
 };
 
 /**
+ * Builds the edge-colour legend entries for the protocols actually present in a
+ * graph, so the NetworkGraph overlay legend explains its coloured strokes.
+ *
+ * - Ordering follows PROTOCOL_COLORS definition order (the source of truth), so
+ *   adding a protocol there makes it appear with no other change.
+ * - Protocols sharing a colour collapse into a single swatch (e.g. HTTPS + TLS
+ *   → one `#3498db` entry). The label comes from the first present protocol of
+ *   that colour, via PROTOCOL_LABELS (so HTTPS → "HTTPS/TLS").
+ * - `hasUnmapped` is true when any present protocol falls back to
+ *   DEFAULT_EDGE_COLOR, so callers can explain the grey strokes.
+ *
+ * Mirrors getProtocolColor(), so the legend stays in sync with the strokes.
+ */
+export function buildProtocolLegend(
+  protocols: Iterable<string>,
+): { entries: Array<{ color: string; label: string }>; hasUnmapped: boolean } {
+  const present = new Set<string>();
+  let hasUnmapped = false;
+  for (const p of protocols) {
+    const key = p.toUpperCase();
+    if (key in PROTOCOL_COLORS) present.add(key);
+    else hasUnmapped = true;
+  }
+
+  const entries: Array<{ color: string; label: string }> = [];
+  const seenColors = new Set<string>();
+  for (const [key, color] of Object.entries(PROTOCOL_COLORS)) {
+    if (!present.has(key) || seenColors.has(color)) continue;
+    seenColors.add(color);
+    entries.push({ color, label: PROTOCOL_LABELS[key] ?? key });
+  }
+  return { entries, hasUnmapped };
+}
+
+/**
  * Single source of truth for all per-node-type display properties.
  * Adding a new NodeType requires only one change here.
  */


### PR DESCRIPTION
Closes #497.

## Problem
The network graph colour-codes edges by protocol, but:
1. There was **no legend** explaining what the edge colours mean.
2. When two hosts talk over several protocols, each protocol is a separate edge — but all of them were drawn as **overlapping straight lines**, so only the last-painted colour was ever visible. The legend alone couldn't fix that: you'd see a swatch but couldn't find (or distinguish) its colour on the canvas.

## Changes

### 1. Protocol edge-colour legend
- New **"Edges"** section in the graph legend: a line swatch + label per protocol, under a divider below the existing node/device types.
- Driven entirely by `PROTOCOL_COLORS` / `PROTOCOL_LABELS` via a new pure `buildProtocolLegend()` helper — adding a protocol there makes it appear with no other change.
- Only protocols **present in the current graph** are listed (mirrors the node-type legend's filtering).
- Protocols that share a colour collapse into **one** entry (e.g. `HTTPS`/`TLS` → "HTTPS/TLS").
- An **"Other"** swatch (grey `DEFAULT_EDGE_COLOR`) appears only when some edge uses an unmapped protocol.
- Shown only in **protocol** colour mode (hidden in volume mode, where strokes encode bytes).

### 2. Curved parallel edges
- Added `@sigma/edge-curve` and registered `EdgeCurvedArrowProgram` alongside the straight `EdgeArrowProgram`.
- `applyParallelEdgeCurvature()` indexes parallel edges and fans out any that share a node pair (different protocol/app, or opposite directions) so **every edge — and its colour — is visible**. A pair with a single connection stays a straight arrow.
- The **PDF-capture overdraw** now mirrors the curvature with a matching quadratic Bézier (same control point Sigma uses), so exported diagrams don't collapse back to overlapping straight lines.

No API or schema changes; frontend-only.

## Verification
- New unit tests for `buildProtocolLegend` (grouping by shared colour, present-only filtering, `hasUnmapped`, case-insensitivity, empty input) — full suite green (125 passed).
- Typecheck clean; no new lint errors (the one pre-existing `edgeBytesRange` fast-refresh warning is unrelated).
- **Live app** (screenshotted on *The Ultimate PCAP*): the "Edges" legend renders with HTTP/DNS/TCP/UDP/ICMP/ARP/Other swatches, and multi-protocol pairs now fan into distinct coloured arcs instead of a single overlapping line — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added curved rendering for parallel network edges to improve readability of overlapping connections.
  * Introduced an edge protocol color legend, including an “Other” entry for unmapped protocols.
* **Bug Fixes**
  * Improved consistency between on-screen rendering and exported PDFs by matching curved edge drawing behavior.
* **Tests**
  * Added coverage for protocol legend and protocol-to-color normalization, including aliasing, version folding, and unmapped handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->