### PR TITLE
feat(analysis): live stage progress + packet-based time estimate

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/controller/AnalysisController.java
+++ b/backend/src/main/java/com/tracepcap/analysis/controller/AnalysisController.java
@@ -1,8 +1,10 @@
 package com.tracepcap.analysis.controller;
 
+import com.tracepcap.analysis.dto.AnalysisProgressResponse;
 import com.tracepcap.analysis.dto.AnalysisSummaryResponse;
 import com.tracepcap.analysis.dto.ProtocolStatsResponse;
 import com.tracepcap.analysis.entity.AnalysisResultEntity;
+import com.tracepcap.analysis.service.AnalysisProgressService;
 import com.tracepcap.analysis.service.AnalysisService;
 import com.tracepcap.file.entity.FileEntity;
 import com.tracepcap.file.service.FileService;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class AnalysisController {
 
   private final AnalysisService analysisService;
+  private final AnalysisProgressService analysisProgressService;
   private final FileService fileService;
 
   /**
@@ -80,6 +83,20 @@ public class AnalysisController {
         log.error("Unknown analysis status for file {}: {}", fileId, analysis.getStatus());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
+  }
+
+  /**
+   * Live analysis progress for a file still being analysed. Returns 200 with the current stage while
+   * a run is in flight, or 204 No Content when nothing is being tracked (not started, already
+   * finished, or dropped on a restart) — in which case the client falls back to its size estimate.
+   */
+  @GetMapping("/{fileId}/progress")
+  @Operation(summary = "Live analysis progress (204 when no run is being tracked)")
+  public ResponseEntity<AnalysisProgressResponse> getAnalysisProgress(@PathVariable UUID fileId) {
+    return analysisProgressService
+        .get(fileId)
+        .map(ResponseEntity::ok)
+        .orElseGet(() -> ResponseEntity.noContent().build());
   }
 
   /**

--- a/backend/src/main/java/com/tracepcap/analysis/dto/AnalysisProgressResponse.java
+++ b/backend/src/main/java/com/tracepcap/analysis/dto/AnalysisProgressResponse.java
@@ -1,0 +1,19 @@
+package com.tracepcap.analysis.dto;
+
+/**
+ * Live analysis progress for a file being analysed. Reported at each stage boundary of the pipeline
+ * (see {@code AnalysisService.analyzeFile}) so the loading view can show real milestones instead of
+ * a time-interpolated guess.
+ *
+ * <p>{@code percent} is the weighted fraction of work completed <em>before</em> the current stage
+ * started — it holds steady while an opaque external stage (Suricata, nDPI, file extraction) runs,
+ * because those subprocesses expose no interior progress. The frontend animates the bar to convey
+ * "still working" without fabricating movement.
+ *
+ * @param stageIndex 1-based index of the stage currently running
+ * @param totalStages number of stages that will run for this file (skipped stages are excluded)
+ * @param stage human-readable label of the current stage
+ * @param percent weighted completion 0-100 at the start of the current stage
+ */
+public record AnalysisProgressResponse(
+    int stageIndex, int totalStages, String stage, int percent) {}

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisProgressService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisProgressService.java
@@ -1,0 +1,39 @@
+package com.tracepcap.analysis.service;
+
+import com.tracepcap.analysis.dto.AnalysisProgressResponse;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+/**
+ * In-memory, per-file live analysis progress. The analysis pipeline runs inside one long
+ * transaction, so nothing it writes is visible to pollers until it commits at the very end — this
+ * bean is the out-of-band channel that publishes progress <em>during</em> the run.
+ *
+ * <p>Intentionally not persisted: progress is ephemeral and only meaningful while the (single)
+ * backend is running the job. Entries are cleared when the job finishes or fails, so the map stays
+ * bounded by the number of concurrently-analysing files. A process restart simply drops progress
+ * and the loading view falls back to its size-based estimate.
+ */
+@Service
+public class AnalysisProgressService {
+
+  private final ConcurrentHashMap<UUID, AnalysisProgressResponse> progressByFile =
+      new ConcurrentHashMap<>();
+
+  /** Publishes the latest progress for a file, overwriting any previous value. */
+  public void update(UUID fileId, AnalysisProgressResponse progress) {
+    progressByFile.put(fileId, progress);
+  }
+
+  /** Current progress for a file, or empty if none is being tracked. */
+  public Optional<AnalysisProgressResponse> get(UUID fileId) {
+    return Optional.ofNullable(progressByFile.get(fileId));
+  }
+
+  /** Drops tracking for a file once its analysis has finished (success or failure). */
+  public void clear(UUID fileId) {
+    progressByFile.remove(fileId);
+  }
+}

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -1,5 +1,6 @@
 package com.tracepcap.analysis.service;
 
+import com.tracepcap.analysis.dto.AnalysisProgressResponse;
 import com.tracepcap.analysis.dto.AnalysisSummaryResponse;
 import com.tracepcap.analysis.dto.ConversationResponse;
 import com.tracepcap.analysis.dto.ProtocolStatsResponse;
@@ -59,6 +60,48 @@ public class AnalysisService {
   // Keeps the Hibernate first-level cache from accumulating unbounded saved entities.
   private static final int JPA_FLUSH_INTERVAL = 50;
 
+  // ---- Live progress stage plan -------------------------------------------------------------
+  // One step per pipeline stage that will actually run for a file. The weights are relative shares
+  // of total wall-clock time (roughly the same reasoning as FileMapper's ETA coefficients) so the
+  // progress bar advances in realistic proportions rather than in equal jumps. Suricata dominates,
+  // so the Extract stage's weight scales with the enabled analysers. Skipped stages are omitted
+  // entirely, which also drives totalStages ("Stage 6 of 6").
+  private record StageStep(String label, int weight) {}
+
+  /** Builds the ordered list of stages that will run for {@code file}, given its enabled options. */
+  private static List<StageStep> buildStagePlan(FileEntity file) {
+    boolean ndpi = file.isEnableNdpi();
+    // Weight only: the effective Suricata state (incl. the global kill-switch) is decided inside the
+    // extractor; using the per-file flag here is a close-enough heuristic for bar proportions.
+    boolean suricata = file.isEnableSuricata();
+    List<StageStep> plan = new ArrayList<>();
+    plan.add(new StageStep("Downloading capture", 3));
+    plan.add(new StageStep("Parsing packets", 20));
+    plan.add(new StageStep("Detecting applications & threats", 5 + (ndpi ? 10 : 0) + (suricata ? 20 : 0)));
+    plan.add(new StageStep("Classifying hosts & geo-locating", 12));
+    plan.add(new StageStep("Saving analysis summary", 2));
+    plan.add(new StageStep("Writing conversations & packets", 20));
+    if (file.isEnableFileExtraction()) {
+      plan.add(new StageStep("Extracting transferred files", 8));
+    }
+    return plan;
+  }
+
+  /**
+   * Publishes progress for the stage at {@code index} (0-based). {@code percent} is the weighted
+   * fraction of work completed <em>before</em> this stage begins, so the bar reflects finished work
+   * only — it never claims interior progress on an opaque external stage.
+   */
+  private void reportStage(UUID fileId, List<StageStep> plan, int index) {
+    int totalWeight = plan.stream().mapToInt(StageStep::weight).sum();
+    int doneWeight = 0;
+    for (int i = 0; i < index; i++) doneWeight += plan.get(i).weight();
+    int percent = totalWeight > 0 ? (int) Math.round(doneWeight * 100.0 / totalWeight) : 0;
+    analysisProgressService.update(
+        fileId,
+        new AnalysisProgressResponse(index + 1, plan.size(), plan.get(index).label(), percent));
+  }
+
   @PersistenceContext private EntityManager entityManager;
 
   private final AnalysisResultRepository analysisResultRepository;
@@ -78,6 +121,7 @@ public class AnalysisService {
   private final GeoIpService geoIpService;
   private final FileExtractionStage fileExtractionStage;
   private final AnalysisRecordService analysisRecordService;
+  private final AnalysisProgressService analysisProgressService;
   private final ExtractionRunService extractionRunService;
   private final HostnameAdjudicator hostnameAdjudicator;
   private final org.springframework.context.ApplicationEventPublisher eventPublisher;
@@ -102,10 +146,14 @@ public class AnalysisService {
     // frontend can see that analysis has started rather than waiting for the entire job to finish.
     AnalysisResultEntity analysis = analysisRecordService.createInProgress(file);
 
+    // Live progress plan: which stages will run for this file, and their relative weights.
+    List<StageStep> plan = buildStagePlan(file);
+
     try {
       long analysisStart = System.currentTimeMillis();
 
       // Stage 1: Download
+      reportStage(fileId, plan, 0);
       long t = System.currentTimeMillis();
       File tempFile = File.createTempFile("pcap-", ".pcap");
       try {
@@ -113,6 +161,7 @@ public class AnalysisService {
         log.info("[{}] [1/7] Download: {}ms", fileId, System.currentTimeMillis() - t);
 
         // Stage 2: PCAP parse
+        reportStage(fileId, plan, 1);
         t = System.currentTimeMillis();
         PcapParserService.PcapAnalysisResult parseResult =
             pcapParserService.analyzePcapFile(tempFile);
@@ -129,11 +178,13 @@ public class AnalysisService {
         // by hand; adding one meant editing this method. It now names none of them: the runner
         // discovers every Extractor, each decides for itself whether it applies to this capture,
         // and the manifest row is automatic (#512).
+        reportStage(fileId, plan, 2);
         t = System.currentTimeMillis();
         extractorRunner.runAll(file, tempFile, parseResult.getConversations());
         log.info("[{}] [3/7] Extract: {}ms", fileId, System.currentTimeMillis() - t);
 
         // Stage 4: Signatures, device classification, geo-IP
+        reportStage(fileId, plan, 3);
         t = System.currentTimeMillis();
         Map<String, String> deviceOverrides =
             signatureApplier.applySignatures(parseResult.getConversations());
@@ -191,6 +242,7 @@ public class AnalysisService {
             System.currentTimeMillis() - t);
 
         // Stage 5: Persist analysis result
+        reportStage(fileId, plan, 4);
         t = System.currentTimeMillis();
         analysis.setPacketCount(parseResult.getPacketCount());
         analysis.setTotalBytes(parseResult.getTotalBytes());
@@ -219,6 +271,7 @@ public class AnalysisService {
         log.info("[{}] [5/7] Analysis result saved: {}ms", fileId, System.currentTimeMillis() - t);
 
         // Stage 6: DB inserts (conversations + packets)
+        reportStage(fileId, plan, 5);
         t = System.currentTimeMillis();
         int convIndex = 0;
         long packetsInserted = 0;
@@ -304,9 +357,10 @@ public class AnalysisService {
             parseResult.getConversations().size(),
             packetsInserted);
 
-        // Stage 7: File extraction
+        // Stage 7: File extraction (only in the plan when enabled — index 6)
         t = System.currentTimeMillis();
         if (file.isEnableFileExtraction()) {
+          reportStage(fileId, plan, 6);
           try {
             fileExtractionStage.extractFiles(file, tempFile, savedConversationIds);
             log.info("[{}] [7/7] File extraction: {}ms", fileId, System.currentTimeMillis() - t);
@@ -342,6 +396,9 @@ public class AnalysisService {
 
       } finally {
         tempFile.delete();
+        // Stop tracking live progress: on success the poller flips to the 200 summary; on failure
+        // it flips to 500. Either way the in-memory entry is no longer needed.
+        analysisProgressService.clear(fileId);
       }
 
     } catch (Exception e) {

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -93,6 +93,12 @@ public class AnalysisService {
    * only — it never claims interior progress on an opaque external stage.
    */
   private void reportStage(UUID fileId, List<StageStep> plan, int index) {
+    // Defensive: indices are hardcoded at the call sites against buildStagePlan. A mismatch (e.g. a
+    // stage added/removed without updating both) should degrade to no progress, not crash analysis.
+    if (index < 0 || index >= plan.size()) {
+      log.warn("reportStage: index {} out of range for plan of size {}", index, plan.size());
+      return;
+    }
     int totalWeight = plan.stream().mapToInt(StageStep::weight).sum();
     int doneWeight = 0;
     for (int i = 0; i < index; i++) doneWeight += plan.get(i).weight();
@@ -403,6 +409,10 @@ public class AnalysisService {
 
     } catch (Exception e) {
       log.error("Error analyzing file {}: {}", fileId, e.getMessage(), e);
+
+      // Clear progress on every failure path, including ones that never reached the inner finally
+      // (e.g. createTempFile throwing after the first reportStage). Idempotent — safe if already done.
+      analysisProgressService.clear(fileId);
 
       // Mark analysis and file as FAILED in a separate committed transaction so the status persists
       // even though the outer transaction is being rolled back.

--- a/backend/src/main/java/com/tracepcap/file/dto/FileMetadataDto.java
+++ b/backend/src/main/java/com/tracepcap/file/dto/FileMetadataDto.java
@@ -35,6 +35,11 @@ public class FileMetadataDto {
 
   private boolean enableFileExtraction;
 
+  // Rough pre-analysis time estimate (seconds), derived from file size and which analysis stages
+  // are effectively enabled for this file (nDPI / Suricata / file extraction). Lets the loading
+  // view show an estimate that reflects the user's upload choices instead of a size-only guess.
+  private Integer estimatedAnalysisSeconds;
+
   private Integer packetCount;
 
   private Long duration;

--- a/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
+++ b/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
@@ -16,6 +16,59 @@ public class FileMapper {
   @Value("${tracepcap.suricata.enabled:true}")
   private boolean suricataEnabled;
 
+  private static final int MIN_ESTIMATE_SECONDS = 10;
+
+  // ---- Packet-based coefficients (preferred) ----------------------------------------------------
+  // Analysis cost is driven by packet COUNT, not bytes: Suricata/nDPI/parse all scale per-packet, so
+  // a small but packet-dense capture can take far longer than its size suggests. Seconds per 1000
+  // packets, calibrated against a clean OFFLINE run (21.4k packets, GEO_FORCE_OFFLINE): parse+
+  // classify+persist+DB ≈ 0.38, extract(nDPI+Suricata) ≈ 2.6, file-extract ≈ 0.04 s/kpkt. Values
+  // below keep a small conservative margin (better to slightly over-estimate). Suricata dominates.
+  // Only stages that will run contribute. See analysis-eta-calibration notes for recalibration.
+  private static final double BASE_SECONDS_PER_KPKT = 0.45; // parse + classify + persist + DB insert
+  private static final double NDPI_SECONDS_PER_KPKT = 0.6;
+  private static final double SURICATA_SECONDS_PER_KPKT = 2.1;
+  private static final double EXTRACTION_SECONDS_PER_KPKT = 0.08;
+  private static final double DOWNLOAD_SECONDS_PER_MB = 0.01; // MinIO fetch, size-scaled
+
+  // ---- Size-based fallback (used only when packet count is unknown) ------------------------------
+  // e.g. capinfos failed at upload, or a legacy file predating packet-count capture. ~0.5 s/MB
+  // all-stages-on, matching the older end-to-end measurement on large captures.
+  private static final double BASE_SECONDS_PER_MB = 0.15;
+  private static final double NDPI_SECONDS_PER_MB = 0.10;
+  private static final double SURICATA_SECONDS_PER_MB = 0.20;
+  private static final double EXTRACTION_SECONDS_PER_MB = 0.05;
+
+  /**
+   * Estimates analysis wall-clock seconds from the effectively-enabled stages. Prefers a
+   * packet-count-based estimate (much more accurate — cost tracks packets, not bytes) and falls back
+   * to a size-based one when the packet count is not yet known. Only stages that will actually run
+   * contribute. Returns at least {@link #MIN_ESTIMATE_SECONDS}; {@code null} when neither packet
+   * count nor size is known.
+   */
+  private Integer estimateAnalysisSeconds(
+      Long fileSize, Integer packetCount, boolean ndpi, boolean suricata, boolean fileExtraction) {
+    if (packetCount != null && packetCount > 0) {
+      double kPkt = packetCount / 1000.0;
+      double perKPkt =
+          BASE_SECONDS_PER_KPKT
+              + (ndpi ? NDPI_SECONDS_PER_KPKT : 0)
+              + (suricata ? SURICATA_SECONDS_PER_KPKT : 0)
+              + (fileExtraction ? EXTRACTION_SECONDS_PER_KPKT : 0);
+      double downloadTerm =
+          fileSize != null ? fileSize / 1024.0 / 1024.0 * DOWNLOAD_SECONDS_PER_MB : 0;
+      return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(kPkt * perKPkt + downloadTerm));
+    }
+    if (fileSize == null || fileSize <= 0) return null;
+    double sizeMb = fileSize / 1024.0 / 1024.0;
+    double perMb =
+        BASE_SECONDS_PER_MB
+            + (ndpi ? NDPI_SECONDS_PER_MB : 0)
+            + (suricata ? SURICATA_SECONDS_PER_MB : 0)
+            + (fileExtraction ? EXTRACTION_SECONDS_PER_MB : 0);
+    return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(sizeMb * perMb));
+  }
+
   public FileUploadResponse toUploadResponse(FileEntity entity) {
     return FileUploadResponse.builder()
         .fileId(entity.getId().toString())
@@ -28,6 +81,8 @@ public class FileMapper {
   }
 
   public FileMetadataDto toMetadataDto(FileEntity entity) {
+    // Effective Suricata state honours the global kill-switch, matching the DTO's enableSuricata.
+    boolean effectiveSuricata = suricataEnabled && entity.isEnableSuricata();
     return FileMetadataDto.builder()
         .fileId(entity.getId().toString())
         .fileName(entity.getFileName())
@@ -40,8 +95,15 @@ public class FileMapper {
         .endTime(entity.getEndTime())
         .source(entity.getSource() != null ? entity.getSource().name() : null)
         .enableNdpi(entity.isEnableNdpi())
-        .enableSuricata(suricataEnabled && entity.isEnableSuricata())
+        .enableSuricata(effectiveSuricata)
         .enableFileExtraction(entity.isEnableFileExtraction())
+        .estimatedAnalysisSeconds(
+            estimateAnalysisSeconds(
+                entity.getFileSize(),
+                entity.getPacketCount(),
+                entity.isEnableNdpi(),
+                effectiveSuricata,
+                entity.isEnableFileExtraction()))
         .build();
   }
 }

--- a/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
+++ b/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
@@ -26,6 +27,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -85,12 +88,17 @@ public class FileServiceImpl implements FileService {
       String minioPath = storageService.uploadFile(file, fileName);
       log.info("DEBUG: Returned minioPath: {}", minioPath);
 
+      // Count packets up front (best-effort) so the loading view can show a packet-based time
+      // estimate immediately, before analysis has run. Overwritten with the exact count on completion.
+      Integer packetCount = countPackets(file);
+
       // Save metadata to database
       FileEntity fileEntity =
           FileEntity.builder()
               .id(fileId)
               .fileName(originalFilename)
               .fileSize(file.getSize())
+              .packetCount(packetCount)
               .minioPath(minioPath)
               .uploadedAt(LocalDateTime.now())
               .status(FileEntity.FileStatus.PROCESSING)
@@ -319,6 +327,7 @@ public class FileServiceImpl implements FileService {
               .id(newFileId)
               .fileName(mergedName)
               .fileSize(tempOutput.length())
+              .packetCount(countPackets(tempOutput))
               .minioPath(storedName)
               .uploadedAt(LocalDateTime.now())
               .status(FileEntity.FileStatus.PROCESSING)
@@ -402,6 +411,77 @@ public class FileServiceImpl implements FileService {
       return HexFormat.of().formatHex(digest.digest());
     } catch (Exception e) {
       throw new InvalidFileException("Could not compute hash of merged file", e);
+    }
+  }
+
+  // capinfos machine-readable output line: "Number of packets:   21364"
+  private static final Pattern PACKET_COUNT_PATTERN =
+      Pattern.compile("Number of packets:\\s*(\\d+)");
+
+  /**
+   * Counts packets in an uploaded capture by streaming it through {@code capinfos -M -c -} (reads
+   * stdin, ~ms even for large files). Used to compute a packet-count-based analysis time estimate up
+   * front — cost tracks packets, not bytes. Best-effort: any failure returns {@code null} and the
+   * estimate falls back to a size-based one. Never throws.
+   */
+  private Integer countPackets(MultipartFile file) {
+    Process process = null;
+    try {
+      process =
+          new ProcessBuilder("capinfos", "-M", "-c", "-").redirectErrorStream(false).start();
+      final Process p = process;
+      // Feed the capture into capinfos stdin on a daemon thread so we can read stdout concurrently
+      // (avoids a pipe-buffer deadlock). A broken pipe (capinfos closing stdin early) is expected.
+      Thread feeder =
+          new Thread(
+              () -> {
+                try (InputStream in = file.getInputStream();
+                    OutputStream out = p.getOutputStream()) {
+                  in.transferTo(out);
+                } catch (IOException ignored) {
+                  // capinfos may close stdin before consuming everything — not an error for -c
+                }
+              });
+      feeder.setDaemon(true);
+      feeder.start();
+
+      String output = new String(process.getInputStream().readAllBytes());
+      boolean finished = process.waitFor(60, TimeUnit.SECONDS);
+      if (!finished) {
+        process.destroyForcibly();
+        return null;
+      }
+      feeder.join(2000);
+      if (process.exitValue() != 0) return null;
+      Matcher m = PACKET_COUNT_PATTERN.matcher(output);
+      return m.find() ? Integer.parseInt(m.group(1)) : null;
+    } catch (Exception e) {
+      log.warn("capinfos packet count failed for {}: {}", file.getOriginalFilename(), e.getMessage());
+      if (process != null) process.destroyForcibly();
+      return null;
+    }
+  }
+
+  /** Packet count for a local capture file via {@code capinfos -M -c <path>}. Best-effort. */
+  private Integer countPackets(File file) {
+    Process process = null;
+    try {
+      process =
+          new ProcessBuilder("capinfos", "-M", "-c", file.getAbsolutePath())
+              .redirectErrorStream(false)
+              .start();
+      String output = new String(process.getInputStream().readAllBytes());
+      if (!process.waitFor(60, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        return null;
+      }
+      if (process.exitValue() != 0) return null;
+      Matcher m = PACKET_COUNT_PATTERN.matcher(output);
+      return m.find() ? Integer.parseInt(m.group(1)) : null;
+    } catch (Exception e) {
+      log.warn("capinfos packet count failed for {}: {}", file.getName(), e.getMessage());
+      if (process != null) process.destroyForcibly();
+      return null;
     }
   }
 

--- a/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
+++ b/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
@@ -16,6 +16,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
@@ -430,6 +431,10 @@ public class FileServiceImpl implements FileService {
       process =
           new ProcessBuilder("capinfos", "-M", "-c", "-").redirectErrorStream(false).start();
       final Process p = process;
+      // Drain stdout on a daemon thread so waitFor's timeout is honoured even if capinfos hangs
+      // without closing stdout (a blocking readAllBytes here would bypass the timeout entirely).
+      StringBuilder output = new StringBuilder();
+      Thread reader = drainStdout(p, output);
       // Feed the capture into capinfos stdin on a daemon thread so we can read stdout concurrently
       // (avoids a pipe-buffer deadlock). A broken pipe (capinfos closing stdin early) is expected.
       Thread feeder =
@@ -445,15 +450,14 @@ public class FileServiceImpl implements FileService {
       feeder.setDaemon(true);
       feeder.start();
 
-      String output = new String(process.getInputStream().readAllBytes());
-      boolean finished = process.waitFor(60, TimeUnit.SECONDS);
-      if (!finished) {
+      if (!process.waitFor(60, TimeUnit.SECONDS)) {
         process.destroyForcibly();
         return null;
       }
       feeder.join(2000);
+      reader.join(2000);
       if (process.exitValue() != 0) return null;
-      Matcher m = PACKET_COUNT_PATTERN.matcher(output);
+      Matcher m = PACKET_COUNT_PATTERN.matcher(output.toString());
       return m.find() ? Integer.parseInt(m.group(1)) : null;
     } catch (Exception e) {
       log.warn("capinfos packet count failed for {}: {}", file.getOriginalFilename(), e.getMessage());
@@ -470,19 +474,38 @@ public class FileServiceImpl implements FileService {
           new ProcessBuilder("capinfos", "-M", "-c", file.getAbsolutePath())
               .redirectErrorStream(false)
               .start();
-      String output = new String(process.getInputStream().readAllBytes());
+      // Drain stdout on a daemon thread so a hung capinfos can't block past waitFor's timeout.
+      StringBuilder output = new StringBuilder();
+      Thread reader = drainStdout(process, output);
       if (!process.waitFor(60, TimeUnit.SECONDS)) {
         process.destroyForcibly();
         return null;
       }
+      reader.join(2000);
       if (process.exitValue() != 0) return null;
-      Matcher m = PACKET_COUNT_PATTERN.matcher(output);
+      Matcher m = PACKET_COUNT_PATTERN.matcher(output.toString());
       return m.find() ? Integer.parseInt(m.group(1)) : null;
     } catch (Exception e) {
       log.warn("capinfos packet count failed for {}: {}", file.getName(), e.getMessage());
       if (process != null) process.destroyForcibly();
       return null;
     }
+  }
+
+  /** Reads a process's stdout into {@code sink} on a started daemon thread (UTF-8). */
+  private Thread drainStdout(Process process, StringBuilder sink) {
+    Thread reader =
+        new Thread(
+            () -> {
+              try (InputStream in = process.getInputStream()) {
+                sink.append(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+              } catch (IOException ignored) {
+                // best-effort: caller treats missing output as an unparseable count → null
+              }
+            });
+    reader.setDaemon(true);
+    reader.start();
+    return reader;
   }
 
   /** Compute SHA-256 hex digest of the uploaded file using a streaming approach */

--- a/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
+++ b/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
@@ -419,6 +419,11 @@ public class FileServiceImpl implements FileService {
   private static final Pattern PACKET_COUNT_PATTERN =
       Pattern.compile("Number of packets:\\s*(\\d+)");
 
+  // Short bound for the best-effort packet count: capinfos -c only scans record headers and is fast
+  // even on large files, and this runs on the request thread inside the upload/merge transaction, so
+  // it must never hold resources long. On timeout we give up and fall back to the size-based estimate.
+  private static final int CAPINFOS_TIMEOUT_SECONDS = 15;
+
   /**
    * Counts packets in an uploaded capture by streaming it through {@code capinfos -M -c -} (reads
    * stdin, ~ms even for large files). Used to compute a packet-count-based analysis time estimate up
@@ -450,7 +455,7 @@ public class FileServiceImpl implements FileService {
       feeder.setDaemon(true);
       feeder.start();
 
-      if (!process.waitFor(60, TimeUnit.SECONDS)) {
+      if (!process.waitFor(CAPINFOS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
         process.destroyForcibly();
         return null;
       }
@@ -477,7 +482,7 @@ public class FileServiceImpl implements FileService {
       // Drain stdout on a daemon thread so a hung capinfos can't block past waitFor's timeout.
       StringBuilder output = new StringBuilder();
       Thread reader = drainStdout(process, output);
-      if (!process.waitFor(60, TimeUnit.SECONDS)) {
+      if (!process.waitFor(CAPINFOS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
         process.destroyForcibly();
         return null;
       }

--- a/frontend/src/pages/Analysis/AnalysisLoadingView.tsx
+++ b/frontend/src/pages/Analysis/AnalysisLoadingView.tsx
@@ -5,13 +5,30 @@ import { API_ENDPOINTS } from '@/services/api/endpoints';
 interface FileMetadata {
   fileName: string;
   fileSize: number;
+  // Backend stage-weighted estimate: accounts for which analysis stages this file will run
+  // (nDPI / Suricata / file extraction), not just its size. Null when size is unknown.
+  estimatedAnalysisSeconds: number | null;
+  enableNdpi: boolean;
+  enableSuricata: boolean;
+  enableFileExtraction: boolean;
+}
+
+// Live, backend-reported stage progress (GET /analysis/{id}/progress). `percent` is the weighted
+// fraction of work completed before the current stage — it holds steady while an opaque external
+// stage (Suricata, nDPI, file extraction) runs, so we animate the bar rather than fake movement.
+interface AnalysisProgress {
+  stageIndex: number;
+  totalStages: number;
+  stage: string;
+  percent: number;
 }
 
 interface Props {
   fileId: string;
 }
 
-// Rough estimate: ~0.5 seconds per MB (measured ~0.4 s/MB on 125 MB captures post AC optimisation)
+// Fallback only, used before the first progress report arrives / if progress isn't tracked:
+// ~0.5 s/MB (all stages on).
 const SECONDS_PER_MB = 0.5;
 const MIN_ESTIMATE_S = 10;
 
@@ -32,6 +49,7 @@ function formatDuration(seconds: number): string {
 export const AnalysisLoadingView = ({ fileId }: Props) => {
   const [fileMeta, setFileMeta] = useState<FileMetadata | null>(null);
   const [elapsed, setElapsed] = useState(0);
+  const [progress, setProgress] = useState<AnalysisProgress | null>(null);
 
   // Fetch file metadata
   useEffect(() => {
@@ -39,7 +57,14 @@ export const AnalysisLoadingView = ({ fileId }: Props) => {
       .get(API_ENDPOINTS.FILE_METADATA(fileId))
       .then(res => {
         const d = res.data;
-        setFileMeta({ fileName: d.fileName, fileSize: d.fileSize });
+        setFileMeta({
+          fileName: d.fileName,
+          fileSize: d.fileSize,
+          estimatedAnalysisSeconds: d.estimatedAnalysisSeconds ?? null,
+          enableNdpi: d.enableNdpi,
+          enableSuricata: d.enableSuricata,
+          enableFileExtraction: d.enableFileExtraction,
+        });
       })
       .catch(() => {
         // ignore — we'll render without file details
@@ -55,12 +80,53 @@ export const AnalysisLoadingView = ({ fileId }: Props) => {
     return () => clearInterval(id);
   }, []);
 
+  // Poll live backend progress. 204 = nothing tracked (not started / already finishing / dropped on
+  // a restart); we keep the last known value on 204 so the bar doesn't flash back to the fallback in
+  // the brief window between the pipeline clearing progress and the summary poll flipping to 200.
+  useEffect(() => {
+    let cancelled = false;
+    const poll = () => {
+      apiClient
+        .get(API_ENDPOINTS.ANALYSIS_PROGRESS(fileId), {
+          validateStatus: s => s === 200 || s === 204,
+        })
+        .then(res => {
+          if (cancelled) return;
+          if (res.status === 200 && res.data && typeof res.data.percent === 'number') {
+            setProgress(res.data);
+          }
+        })
+        .catch(() => {
+          // transient error — keep last known progress
+        });
+    };
+    poll();
+    const id = setInterval(poll, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [fileId]);
+
+  // Prefer the backend's stage-weighted estimate; fall back to the size-only heuristic.
   const estimatedSeconds = fileMeta
-    ? Math.max(MIN_ESTIMATE_S, (fileMeta.fileSize / 1024 / 1024) * SECONDS_PER_MB)
+    ? (fileMeta.estimatedAnalysisSeconds ??
+        Math.max(MIN_ESTIMATE_S, (fileMeta.fileSize / 1024 / 1024) * SECONDS_PER_MB))
     : null;
 
-  // Progress: clamp to 95% so the bar never reaches 100% while still loading
-  const progressPct = estimatedSeconds ? Math.min(95, (elapsed / estimatedSeconds) * 100) : null;
+  const enabledStages: string[] = [];
+  if (fileMeta?.enableNdpi) enabledStages.push('nDPI');
+  if (fileMeta?.enableSuricata) enabledStages.push('Suricata');
+  if (fileMeta?.enableFileExtraction) enabledStages.push('file extraction');
+
+  // Bar position: prefer real backend stage progress. It advances on true milestones and holds
+  // between them (the striped animation conveys ongoing work). Before the first report arrives, fall
+  // back to a time-interpolated bar so it isn't empty. A small floor keeps the bar visible at 0%.
+  const barPct = progress
+    ? Math.max(3, progress.percent)
+    : estimatedSeconds
+      ? Math.min(95, (elapsed / estimatedSeconds) * 100)
+      : null;
 
   return (
     <div className="d-flex justify-content-center align-items-center" style={{ minHeight: '60vh' }}>
@@ -87,13 +153,26 @@ export const AnalysisLoadingView = ({ fileId }: Props) => {
           </p>
         )}
 
+        {/* Current stage (real backend milestone) */}
+        {progress && (
+          <p className="mb-2 text-body" style={{ fontSize: '0.85rem' }}>
+            <span className="text-secondary">
+              Stage {progress.stageIndex} of {progress.totalStages}:
+            </span>{' '}
+            <strong>{progress.stage}…</strong>
+          </p>
+        )}
+
         {/* Progress bar */}
-        {progressPct != null && (
+        {barPct != null && (
           <div className="progress mb-3" style={{ height: 8 }}>
             <div
               className="progress-bar progress-bar-striped progress-bar-animated"
               role="progressbar"
-              style={{ width: `${progressPct}%` }}
+              aria-valuenow={Math.round(barPct)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              style={{ width: `${barPct}%`, transition: 'width 0.4s ease' }}
             />
           </div>
         )}
@@ -111,8 +190,21 @@ export const AnalysisLoadingView = ({ fileId }: Props) => {
           )}
         </div>
 
+        {/* Stages included in the estimate */}
+        {fileMeta && (
+          <p className="text-muted mt-2 mb-0" style={{ fontSize: '0.78rem' }}>
+            Estimate includes{' '}
+            {enabledStages.length > 0 ? (
+              <strong className="text-body">{enabledStages.join(', ')}</strong>
+            ) : (
+              'core parsing only'
+            )}
+            .
+          </p>
+        )}
+
         {/* Hint */}
-        <p className="text-muted mt-4 mb-0" style={{ fontSize: '0.78rem' }}>
+        <p className="text-muted mt-2 mb-0" style={{ fontSize: '0.78rem' }}>
           Larger files take longer. You can leave this page and come back — analysis continues in
           the background.
         </p>

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -9,6 +9,7 @@ export const API_ENDPOINTS = {
 
   // Analysis (Not yet implemented in backend)
   ANALYSIS_SUMMARY: (fileId: string) => `/analysis/${fileId}/summary`,
+  ANALYSIS_PROGRESS: (fileId: string) => `/analysis/${fileId}/progress`,
   PROTOCOL_STATS: (fileId: string) => `/analysis/${fileId}/protocols`,
   FIVE_WS: (fileId: string) => `/analysis/${fileId}/five-ws`,
   KILL_CHAIN: (fileId: string) => `/analysis/${fileId}/kill-chain`,

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -7,7 +7,7 @@ export const API_ENDPOINTS = {
   FILE_DOWNLOAD: (fileId: string) => `/files/${fileId}/download`,
   FILES_MERGE: '/files/merge',
 
-  // Analysis (Not yet implemented in backend)
+  // Analysis
   ANALYSIS_SUMMARY: (fileId: string) => `/analysis/${fileId}/summary`,
   ANALYSIS_PROGRESS: (fileId: string) => `/analysis/${fileId}/progress`,
   PROTOCOL_STATS: (fileId: string) => `/analysis/${fileId}/protocols`,

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -19,6 +19,26 @@
         ],
         "type": "object"
       },
+      "AnalysisProgressResponse": {
+        "properties": {
+          "percent": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "stage": {
+            "type": "string"
+          },
+          "stageIndex": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "totalStages": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "AnalysisSummaryResponse": {
         "properties": {
           "analysisId": {
@@ -1324,6 +1344,10 @@
           "endTime": {
             "format": "date-time",
             "type": "string"
+          },
+          "estimatedAnalysisSeconds": {
+            "format": "int32",
+            "type": "integer"
           },
           "fileId": {
             "type": "string"
@@ -3419,6 +3443,38 @@
   },
   "openapi": "3.0.1",
   "paths": {
+    "/api/v1/analysis/{fileId}/progress": {
+      "get": {
+        "operationId": "getAnalysisProgress",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "fileId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalysisProgressResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Live analysis progress (204 when no run is being tracked)",
+        "tags": [
+          "Analysis"
+        ]
+      }
+    },
     "/api/v1/analysis/{fileId}/protocols": {
       "get": {
         "operationId": "getProtocolStats",


### PR DESCRIPTION
## Problem

While a capture is analysing, the loading view showed:
- a **time estimate** derived only from file size (`~0.5 s/MB`) that **ignored the nDPI / Suricata / file-extraction choices** made at upload, and
- a **progress bar** driven by a local timer — it *implied* measured progress it didn't have.

## What changed

### Real stage progress
- New in-memory `AnalysisProgressService` publishes per-stage progress from the pipeline. It's out-of-band because `analyzeFile` runs in one long transaction, so nothing it writes is visible to pollers until commit.
- Exposed at `GET /analysis/{id}/progress` (200 with `{stageIndex, totalStages, stage, percent}`, 204 when nothing is tracked).
- The bar now advances on **true milestones** (weighted by stage) and **holds** during opaque external stages (Suricata/nDPI/file-extraction expose no interior progress) — the striped animation conveys ongoing work without faking movement. Skipped stages are excluded, so "Stage 6 of 6" reflects the actual plan.

### Packet-based time estimate
- Analysis cost tracks **packet count, not bytes** (a small dense capture can take far longer than its size implies). Packet count is captured at upload via `capinfos -M -c -` (best-effort stdin stream, ~ms; `null` → size-based fallback) and stored on `FileEntity.packetCount`.
- `FileMapper` computes the estimate from packet count, weighted per **enabled** stage, and it's surfaced on the file metadata the loading view already fetches.

### Frontend
- `AnalysisLoadingView` polls progress, shows "Stage X of Y: …", drives the bar off real percent, and notes which stages the estimate includes.

## Testing

Verified end-to-end on the running stack with `editcap.427fbe9e.pcap` (13 MB, **21,364 packets**):

- Progress endpoint reported the real sequence 1/7 → 7/7, holding at 23% during Suricata and clearing to 204 on completion.
- Old size-based estimate: **10s**. New estimate: **82s** all-stages, **32s** with Suricata off (same file) — responds to the toggle.
- `capinfos` count matched tshark's post-analysis count exactly (both 21364).
- **Calibrated against a clean offline run** (`GEO_FORCE_OFFLINE=true`, so geo uses the bundled MMDB): per-stage logs showed Extract 55s dominant, geo just 1.5s; tuned estimate **69s vs 65s actual (~6% conservative)**.

## Notes / follow-ups
- Coefficients are fit to one clean offline run; recalibrate from the `[1/7]…[7/7]` logs across more captures over time.
- On an internet-connected box, the geo stage hits ipinfo.io and adds latency the estimate can't predict — not the offline/air-gapped production target. The stage-progress bar stays accurate regardless.
- No DB migration (reuses the existing `packetCount` column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live analysis progress updates, including the current stage and completion percentage.
  * Enhanced the analysis loading view with stage details and more accurate progress estimates.
  * Added estimated analysis time and enabled-stage information to file metadata.
  * Improved estimates using packet counts and analysis options when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->