### PR TITLE
test(e2e): skip Suricata in smoke fixture to fix processing-timeout flake

### DIFF
--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -19,6 +19,10 @@ export async function uploadAndProcessFixture(request: APIRequestContext): Promi
         buffer: fs.readFileSync(FIXTURE_PCAP),
       },
       enableNdpi: 'true',
+      // Suricata defaults to on at the API, but loading the Emerging Threats ruleset adds ~60s
+      // per analysis — enough to blow this smoke test's processing deadline and make it flaky.
+      // These tests only need a *completed* file to reach the Story/Filter tabs, so skip the IDS.
+      enableSuricata: 'false',
       enableFileExtraction: 'true',
       source: 'ANALYSIS',
     },


### PR DESCRIPTION
## Problem

The `llm-error.spec.ts` smoke test (`E2E Smoke Tests / Playwright smoke tests`) has been flaky, failing in fixture setup with:

```
Error: file processing did not complete (status: processing)
Expected: "completed"
```

It first surfaced on the version-sync PR #568 (`v0.1.1-182-g75ce6ee`) — the only recent sync PR that touched an E2E-trigger path (`docker-compose.yml`), so it was the first sync to re-run the suite. It is **not** a #567 regression; #567 only nudged a test that was already sitting on the edge.

## Root cause

`uploadAndProcessFixture` uploads a pcap and polls up to **60s** for `completed`. `enableSuricata` defaults to `true` at the API, and Suricata reloads the full Emerging Threats ruleset on every analysis (~60s regardless of size), so processing lands right at the deadline and tips over when CI is slightly slow.

Measured against the running stack (`ftp.pcap`, 9 KB / 38 packets):

| Config | Analysis time |
|---|---|
| Suricata on (default) | **~62s** (Extract stage alone = 58s) |
| Suricata off | **~2s** |

## Fix

The LLM-error tests only need a *completed* file to reach the Story/Filter tabs — they don't exercise IDS output. Upload the fixture with `enableSuricata: 'false'`. Fixture setup drops from a flaky ~60s to ~2s.

Local run: `2 passed (3.4s)`.

## Follow-up

The underlying "Suricata adds ~60s to every upload" performance problem is tracked separately in #569.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved fixture upload smoke-test reliability by disabling Suricata processing during test uploads.
  * Reduced unnecessary processing time and flakiness around test deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->