### PR TITLE
fix(classifier): gate server/IoT app votes on measured serving direction (#539)

### DIFF
--- a/backend/src/main/java/com/tracepcap/hostclassification/service/DeviceClassifierService.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/DeviceClassifierService.java
@@ -278,6 +278,8 @@ public class DeviceClassifierService implements HostClassifier {
         p.measuredResponses++;
         Integer myPort = isSrc ? conv.getSrcPort() : conv.getDstPort();
         if (myPort != null) p.respondedOnPorts.add(myPort);
+        // The app is one this host SERVED, not merely spoke — gate server/IoT app votes on it (#539).
+        if (app != null && !app.isBlank()) p.servedApps.add(app);
       }
     }
   }

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/HostProfile.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/HostProfile.java
@@ -28,6 +28,14 @@ public class HostProfile {
   public final Set<Integer> respondedOnPorts = new LinkedHashSet<>();
 
   public final Set<String> apps = new LinkedHashSet<>();
+
+  /**
+   * Apps this host was observed <b>serving</b> — the app of a flow on which this host was the
+   * MEASURED responder. A subset of {@link #apps}: an endpoint-agnostic protocol name (DNS, SMB,
+   * MDNS, …) lands here only for the side that answered, never for the side that queried. Server/IoT
+   * app signals must key off this set, not {@link #apps}, or a DNS client scores as a DNS server (#539).
+   */
+  public final Set<String> servedApps = new LinkedHashSet<>();
   public final Set<String> categories = new LinkedHashSet<>();
   public final Set<String> peers = new LinkedHashSet<>();
 }

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/AppProfileSignal.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/classifier/signals/AppProfileSignal.java
@@ -13,6 +13,11 @@ import org.springframework.stereotype.Component;
  * nDPI application/category profile: streaming/social apps → mobile, productivity apps →
  * laptop/desktop, server-side apps → server, IoT categories → IoT. App/category lists are
  * configurable via {@link DeviceClassificationProperties}.
+ *
+ * <p>Client-leaning app votes (mobile/desktop) score off every app the host spoke; server/IoT app
+ * votes score only off apps the host was the measured responder on ({@link
+ * com.tracepcap.hostclassification.service.classifier.HostProfile#servedApps}), so a host that
+ * merely <em>queried</em> DNS/SMB/mDNS is not miscounted as serving them (#539).
  */
 @Component
 @RequiredArgsConstructor
@@ -34,16 +39,27 @@ public class AppProfileSignal implements DeviceClassificationSignal {
     Set<String> iotApps = classificationProps.getIotApps();
     Set<String> iotCategories = classificationProps.getIotCategories();
 
+    // Client-leaning app names (mobile/desktop) are direction-agnostic: a host that speaks Instagram
+    // is a phone whether it opened the flow or not, so score them off every observed app.
     for (String app : ctx.profile().apps) {
       if (mobileApps.contains(app)) board.add(DeviceTypes.MOBILE, 20, "Mobile app \"" + app + "\" → +20");
       if (desktopApps.contains(app))
         board.add(DeviceTypes.LAPTOP_DESKTOP, 20, "Desktop app \"" + app + "\" → +20");
+    }
+
+    // Server/IoT app names imply a SERVING host, so score them only for apps this host was the
+    // measured responder on (#539). Endpoint-agnostic protocol names (DNS, SMB, MDNS, …) otherwise
+    // credited the querying CLIENT too: a workstation resolving DNS collected a bogus "Server app
+    // DNS" vote, an mDNS-chatty laptop collected IoT votes. A genuine server keeps its vote because
+    // it answered on that app; UDP-only servers with no measured responder are still caught by their
+    // detected service role (DnsServerSignal, etc.).
+    for (String app : ctx.profile().servedApps) {
       if (serverApps.contains(app))
-        board.add(DeviceTypes.SERVER, 20, "Server app \"" + app + "\" → +20");
-      // Weak server apps (HTTP/TLS) nudge but don't decide — clients speak them too.
+        board.add(DeviceTypes.SERVER, 20, "Served app \"" + app + "\" → +20");
+      // Weak server apps (HTTP/TLS) nudge but don't decide — even when served they are ambiguous.
       if (weakServerApps.contains(app))
-        board.add(DeviceTypes.SERVER, 5, "App \"" + app + "\" (weak server hint) → +5");
-      if (iotApps.contains(app)) board.add(DeviceTypes.IOT, 20, "IoT app \"" + app + "\" → +20");
+        board.add(DeviceTypes.SERVER, 5, "Served app \"" + app + "\" (weak server hint) → +5");
+      if (iotApps.contains(app)) board.add(DeviceTypes.IOT, 20, "Served IoT app \"" + app + "\" → +20");
     }
     for (String cat : ctx.profile().categories) {
       if (iotCategories.contains(cat)) board.add(DeviceTypes.IOT, 15, "IoT category \"" + cat + "\" → +15");

--- a/backend/src/test/java/com/tracepcap/hostclassification/service/DeviceClassifierServiceTest.java
+++ b/backend/src/test/java/com/tracepcap/hostclassification/service/DeviceClassifierServiceTest.java
@@ -1,0 +1,79 @@
+package com.tracepcap.hostclassification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tracepcap.analysis.entity.HostClassificationEntity;
+import com.tracepcap.analysis.service.PcapParserService.ConversationInfo;
+import com.tracepcap.config.DeviceClassificationProperties;
+import com.tracepcap.file.entity.FileEntity;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.signals.AppProfileSignal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end guard for the measured-serving direction wiring (#539): a reversed or omitted
+ * {@code servedApps.add()} in {@link DeviceClassifierService#classify} would sail past the
+ * signal-level {@link com.tracepcap.hostclassification.service.classifier.signals.AppProfileSignalTest}
+ * (which builds profiles by hand), so exercise a real flow through {@code classify} and assert only
+ * the measured responder is credited with serving the app.
+ */
+class DeviceClassifierServiceTest {
+
+  private static final String CLIENT_IP = "10.0.0.10";
+  private static final String SERVER_IP = "10.0.0.53";
+
+  private DeviceClassifierService service() {
+    DeviceClassificationProperties props = new DeviceClassificationProperties();
+    props.setServerApps(Set.of("DNS"));
+    return new DeviceClassifierService(List.of(new AppProfileSignal(props)));
+  }
+
+  /** One TCP DNS flow the client opened toward the server (measured initiator = client). */
+  private ConversationInfo dnsFlow() {
+    ConversationInfo conv = new ConversationInfo();
+    conv.setSrcIp(CLIENT_IP); // sorts first; NOT a direction claim
+    conv.setSrcPort(54321);
+    conv.setDstIp(SERVER_IP);
+    conv.setDstPort(53);
+    conv.setInitiatorIp(CLIENT_IP); // client sent SYN → server is the responder
+    conv.setAppName("DNS");
+    conv.setPacketCount(10L);
+    conv.setTotalBytes(2000L);
+    return conv;
+  }
+
+  private HostClassificationEntity classifyAndGet(String ip) {
+    List<HostClassificationEntity> results =
+        service()
+            .classify(
+                FileEntity.builder().build(),
+                List.of(dnsFlow()),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                Map.of(),
+                Map.of());
+    return results.stream().filter(h -> ip.equals(h.getIp())).findFirst().orElseThrow();
+  }
+
+  @Test
+  void responder_isCreditedWithServingTheApp() {
+    HostClassificationEntity server = classifyAndGet(SERVER_IP);
+
+    assertThat(server.getDeviceType()).isEqualTo(DeviceTypes.SERVER);
+    assertThat(server.getWinnerReasons()).contains("Served app \"DNS\"");
+  }
+
+  @Test
+  void initiator_isNotCreditedWithServingTheApp() {
+    // The client spoke DNS but never answered it: the server-app vote must not reach it (#539).
+    HostClassificationEntity client = classifyAndGet(CLIENT_IP);
+
+    assertThat(client.getDeviceType()).isNotEqualTo(DeviceTypes.SERVER);
+    // winnerReasons is null when a host gathered no votes at all — guard the null before asserting.
+    assertThat(String.valueOf(client.getWinnerReasons())).doesNotContain("Served app");
+  }
+}

--- a/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/AppProfileSignalTest.java
+++ b/backend/src/test/java/com/tracepcap/hostclassification/service/classifier/signals/AppProfileSignalTest.java
@@ -1,0 +1,85 @@
+package com.tracepcap.hostclassification.service.classifier.signals;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tracepcap.config.DeviceClassificationProperties;
+import com.tracepcap.hostclassification.service.classifier.DeviceTypes;
+import com.tracepcap.hostclassification.service.classifier.HostContext;
+import com.tracepcap.hostclassification.service.classifier.HostProfile;
+import com.tracepcap.hostclassification.service.classifier.ScoreBoard;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Server/IoT app votes must follow the MEASURED serving direction (#539): an endpoint-agnostic
+ * protocol name (DNS, SMB, MDNS, …) credits only the side that answered, never the side that
+ * queried. Client-leaning app names (mobile/desktop) stay direction-agnostic.
+ */
+class AppProfileSignalTest {
+
+  private final DeviceClassificationProperties props = props();
+  private final AppProfileSignal signal = new AppProfileSignal(props);
+
+  private static DeviceClassificationProperties props() {
+    DeviceClassificationProperties p = new DeviceClassificationProperties();
+    p.setMobileApps(Set.of("Instagram"));
+    p.setDesktopApps(Set.of("Zoom"));
+    p.setServerApps(Set.of("DNS", "SMB"));
+    p.setWeakServerApps(Set.of("HTTP"));
+    p.setIotApps(Set.of("MDNS"));
+    p.setIotCategories(Set.of());
+    return p;
+  }
+
+  private HostContext ctx(HostProfile p) {
+    return new HostContext("10.0.0.1", p, null, null, null, null, null, Set.of());
+  }
+
+  @Test
+  void clientThatOnlyQueriedDns_getsNoServerVote() {
+    // Workstation resolving DNS: the app is in `apps` (it spoke it) but not `servedApps` (it never
+    // answered). Before #539 this collected a bogus "Server app DNS" vote.
+    HostProfile p = new HostProfile();
+    p.apps.add("DNS");
+
+    ScoreBoard board = new ScoreBoard();
+    signal.contribute(ctx(p), board);
+
+    assertThat(board.scores()).doesNotContainKey(DeviceTypes.SERVER);
+  }
+
+  @Test
+  void hostThatAnsweredDns_getsServerVote() {
+    HostProfile p = new HostProfile();
+    p.apps.add("DNS");
+    p.servedApps.add("DNS"); // measured responder on the DNS flow
+
+    ScoreBoard board = new ScoreBoard();
+    signal.contribute(ctx(p), board);
+
+    assertThat(board.scores()).containsKey(DeviceTypes.SERVER);
+  }
+
+  @Test
+  void mdnsChatterAlone_getsNoIotVote() {
+    HostProfile p = new HostProfile();
+    p.apps.add("MDNS"); // multicast chatter, no measured responder
+
+    ScoreBoard board = new ScoreBoard();
+    signal.contribute(ctx(p), board);
+
+    assertThat(board.scores()).doesNotContainKey(DeviceTypes.IOT);
+  }
+
+  @Test
+  void mobileAppVote_isDirectionAgnostic() {
+    // Client-leaning apps score whether or not the host served anything.
+    HostProfile p = new HostProfile();
+    p.apps.add("Instagram");
+
+    ScoreBoard board = new ScoreBoard();
+    signal.contribute(ctx(p), board);
+
+    assertThat(board.scores()).containsKey(DeviceTypes.MOBILE);
+  }
+}


### PR DESCRIPTION
Closes #539.

## Problem
`AppProfileSignal` scored server/IoT app votes off `HostProfile.apps`, which `addToProfile` populates for **both** endpoints of every conversation. Endpoint-agnostic protocol names (`DNS`, `SMB`, `MDNS`, …) therefore credited the querying **client**:
- a workstation resolving DNS collected a bogus `Server app "DNS" → +20`
- an mDNS-chatty laptop collected IoT votes

## Fix
Gate server/IoT app votes on **measured serving direction** — the same #496 philosophy the rest of the classifier already uses (`TrafficPatternSignal`, the role-based signals):

- **`HostProfile`** — new `servedApps` set: the app of a flow where this host was the *measured responder* (a subset of `apps`).
- **`DeviceClassifierService.addToProfile`** — populate `servedApps` in the existing measured-responder branch.
- **`AppProfileSignal`** — mobile/desktop apps still score off `apps` (client-leaning, direction-agnostic, as the issue notes); server / weak-server / IoT apps now score off `servedApps` only.

Real UDP-only servers (no measured responder, e.g. a pure-UDP DNS resolver) keep their verdict via the independent role-based signals (`DnsServerSignal` / `WebServerSignal` / `ApiServerSignal` on `hasServiceRole`), which this PR does not touch.

## Tests
New `AppProfileSignalTest`: DNS client → no SERVER vote; DNS responder → SERVER vote; lone mDNS → no IoT vote; mobile app stays direction-agnostic. Signal suite passes 16/16 (incl. `TrafficPatternSignalTest`/`DnsServerSignalTest`/`WebApiServerSignalTest` regressions). No DTO/endpoint/migration changes, so no OpenAPI baseline regen.

## Follow-up (out of scope)
`iotCategories` (`Cloud`, `IoT-Scada`) has the same endpoint-agnostic flaw for `profile.categories` — a client reaching a cloud service gets an IoT vote. It's a separate list and #539 scoped itself to "app names," so it's left for a follow-up with its own before/after check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device classification by distinguishing applications a host uses from applications it serves.
  * Reduced incorrect server and IoT classifications for hosts that only query services, such as DNS.
  * Improved handling of responder-based signals while preserving client and mobile app detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->