### PR TITLE
fix: activate prod Spring profile in the auth-overlay deployments (#376)

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -25,9 +25,25 @@ chmod 664 /app/config/signatures.yml 2>/dev/null || true
 # Ensure the log directory exists and is writable by the spring user. The prod Spring profile
 # logs to a file (${LOG_DIR}/application.log, default /app/logs); the default dev profile is
 # console-only so this is a harmless no-op there. Runs as root so it can create + chown it.
-export LOG_DIR=${LOG_DIR:-/app/logs}
-mkdir -p "${LOG_DIR}"
-chown spring:spring "${LOG_DIR}" 2>/dev/null || true
+#
+# Fail fast rather than swallow errors: an immutable mount, a read-only volume, or a dir
+# pre-owned by another user would otherwise let the app boot with no file logging or crash
+# deep inside Logback init. Verify the spring user can actually create the log file before exec.
+export LOG_DIR="${LOG_DIR:-/app/logs}"
+if ! mkdir -p "${LOG_DIR}"; then
+  echo "FATAL: cannot create log directory ${LOG_DIR}" >&2
+  exit 1
+fi
+if ! chown spring:spring "${LOG_DIR}"; then
+  echo "FATAL: cannot chown log directory ${LOG_DIR} to spring:spring (immutable/read-only mount, or owned by another user?)" >&2
+  exit 1
+fi
+# Prove the spring user can actually create a file in the dir the prod profile will log into,
+# then clean up the probe. Catches read-only/immutable mounts that survive mkdir + chown.
+if ! gosu spring sh -c "touch \"${LOG_DIR}/.write-probe\" && rm -f \"${LOG_DIR}/.write-probe\""; then
+  echo "FATAL: spring user cannot write into log directory ${LOG_DIR}" >&2
+  exit 1
+fi
 
 echo "TracePcap backend starting:"
 echo "  APP_MEMORY_MB        = ${MEM} MB"

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -22,6 +22,13 @@ fi
 chown spring:spring /app/config/signatures.yml 2>/dev/null || true
 chmod 664 /app/config/signatures.yml 2>/dev/null || true
 
+# Ensure the log directory exists and is writable by the spring user. The prod Spring profile
+# logs to a file (${LOG_DIR}/application.log, default /app/logs); the default dev profile is
+# console-only so this is a harmless no-op there. Runs as root so it can create + chown it.
+export LOG_DIR=${LOG_DIR:-/app/logs}
+mkdir -p "${LOG_DIR}"
+chown spring:spring "${LOG_DIR}" 2>/dev/null || true
+
 echo "TracePcap backend starting:"
 echo "  APP_MEMORY_MB        = ${MEM} MB"
 echo "  JVM heap (-Xms/-Xmx) = ${JVM_HEAP_MB} MB"

--- a/backend/src/main/java/com/tracepcap/config/WebConfig.java
+++ b/backend/src/main/java/com/tracepcap/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.tracepcap.config;
 
+import java.util.Arrays;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.HandlerTypePredicate;
@@ -48,16 +49,24 @@ public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addCorsMappings(CorsRegistry registry) {
-    // No configured origins (the same-origin prod default) → register no CORS mapping at all.
-    // Registering with an empty/blank origin list would either allow nothing useful or, with
-    // allowCredentials=true, be an invalid configuration; skipping is the correct no-op.
-    String origins = allowedOrigins == null ? "" : allowedOrigins.trim();
-    if (origins.isEmpty()) {
+    // Trim and drop empty tokens per origin: a value like "https://a.example, https://b.example"
+    // must not register " https://b.example" (leading space) as an origin, and stray leading/
+    // trailing commas must not yield empty origins. No valid origins (the same-origin prod
+    // default) → register no CORS mapping at all; an empty/blank list with allowCredentials=true
+    // is an invalid configuration anyway, so skipping is the correct no-op.
+    String[] origins =
+        allowedOrigins == null
+            ? new String[0]
+            : Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toArray(String[]::new);
+    if (origins.length == 0) {
       return;
     }
     registry
         .addMapping("/api/**")
-        .allowedOrigins(origins.split(","))
+        .allowedOrigins(origins)
         .allowedMethods(allowedMethods.split(","))
         .allowedHeaders(allowedHeaders.split(","))
         .allowCredentials(allowCredentials)

--- a/backend/src/main/java/com/tracepcap/config/WebConfig.java
+++ b/backend/src/main/java/com/tracepcap/config/WebConfig.java
@@ -26,7 +26,12 @@ public class WebConfig implements WebMvcConfigurer {
         API_PREFIX, HandlerTypePredicate.forBasePackage("com.tracepcap"));
   }
 
-  @Value("${cors.allowed-origins}")
+  // Default to empty: the shipped deployment serves the SPA and proxies /api through the same
+  // nginx origin, so browser→API calls are same-origin and never trigger CORS. The prod profile
+  // sets this from ${CORS_ALLOWED_ORIGINS} with no default, so leaving it unset must not crash the
+  // app — an empty value simply registers no cross-origin allowance. Set it only for a genuinely
+  // cross-origin frontend (e.g. a separately-hosted SPA). The dev profile keeps localhost origins.
+  @Value("${cors.allowed-origins:}")
   private String allowedOrigins;
 
   @Value("${cors.allowed-methods}")
@@ -43,9 +48,16 @@ public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addCorsMappings(CorsRegistry registry) {
+    // No configured origins (the same-origin prod default) → register no CORS mapping at all.
+    // Registering with an empty/blank origin list would either allow nothing useful or, with
+    // allowCredentials=true, be an invalid configuration; skipping is the correct no-op.
+    String origins = allowedOrigins == null ? "" : allowedOrigins.trim();
+    if (origins.isEmpty()) {
+      return;
+    }
     registry
         .addMapping("/api/**")
-        .allowedOrigins(allowedOrigins.split(","))
+        .allowedOrigins(origins.split(","))
         .allowedMethods(allowedMethods.split(","))
         .allowedHeaders(allowedHeaders.split(","))
         .allowCredentials(allowCredentials)

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -12,7 +12,10 @@ logging:
     org.springframework: WARN
     org.hibernate: WARN
   file:
-    name: /var/log/tracepcap/application.log
+    # Env-overridable log dir. Default lives under /app (owned by the non-root `spring` user the
+    # container runs as); the entrypoint creates + chowns it. /var/log is NOT writable by `spring`,
+    # so hardcoding it there would make the app fail to start under the prod profile.
+    name: ${LOG_DIR:/app/logs}/application.log
     max-size: 100MB
     max-history: 30
     total-size-cap: 1GB
@@ -41,9 +44,12 @@ server:
     include-stacktrace: never
     include-exception: false
 
-# Strict CORS in production
+# Strict CORS in production — NO localhost defaults (unlike the dev profile's base list).
+# Empty default: the shipped stack is same-origin (nginx serves the SPA and proxies /api), so
+# browser→API calls never hit CORS and no origins need allowing. WebConfig skips the CORS mapping
+# entirely when this is blank. Set CORS_ALLOWED_ORIGINS only for a genuinely cross-origin frontend.
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:}
 
 # Disable Swagger in production
 springdoc:

--- a/backend/src/test/java/com/tracepcap/config/WebConfigTest.java
+++ b/backend/src/test/java/com/tracepcap/config/WebConfigTest.java
@@ -48,15 +48,18 @@ class WebConfigTest {
     verify(registry, never()).addMapping(org.mockito.ArgumentMatchers.anyString());
   }
 
+  private CorsRegistration fluentRegistration() {
+    return mock(CorsRegistration.class, invocation ->
+        // Fluent builder — every chained call returns the same registration.
+        invocation.getMethod().getReturnType().equals(CorsRegistration.class)
+            ? invocation.getMock()
+            : null);
+  }
+
   @Test
   void configuredOriginsRegisterCorsMapping() {
     CorsRegistry registry = mock(CorsRegistry.class);
-    CorsRegistration registration = mock(CorsRegistration.class, invocation -> {
-      // Fluent builder — every chained call returns the same registration.
-      return invocation.getMethod().getReturnType().equals(CorsRegistration.class)
-          ? invocation.getMock()
-          : null;
-    });
+    CorsRegistration registration = fluentRegistration();
     when(registry.addMapping("/api/**")).thenReturn(registration);
 
     webConfigWith("https://app.example.com,https://admin.example.com")
@@ -65,5 +68,30 @@ class WebConfigTest {
     verify(registry).addMapping("/api/**");
     verify(registration)
         .allowedOrigins("https://app.example.com", "https://admin.example.com");
+  }
+
+  @Test
+  void originsAreTrimmedAndEmptyTokensDropped() {
+    CorsRegistry registry = mock(CorsRegistry.class);
+    CorsRegistration registration = fluentRegistration();
+    when(registry.addMapping("/api/**")).thenReturn(registration);
+
+    // Whitespace around the comma + leading/trailing/duplicated commas.
+    webConfigWith(" https://app.example.com , https://admin.example.com ,, ")
+        .addCorsMappings(registry);
+
+    // Each origin registered without surrounding whitespace, no empty tokens.
+    verify(registration)
+        .allowedOrigins("https://app.example.com", "https://admin.example.com");
+  }
+
+  @Test
+  void whitespaceAndCommaOnlyOriginsRegisterNoMapping() {
+    CorsRegistry registry = mock(CorsRegistry.class);
+
+    // Only separators/whitespace → no valid origin → no mapping.
+    webConfigWith(" , , ").addCorsMappings(registry);
+
+    verify(registry, never()).addMapping(org.mockito.ArgumentMatchers.anyString());
   }
 }

--- a/backend/src/test/java/com/tracepcap/config/WebConfigTest.java
+++ b/backend/src/test/java/com/tracepcap/config/WebConfigTest.java
@@ -1,0 +1,69 @@
+package com.tracepcap.config;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.config.annotation.CorsRegistration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+
+/**
+ * Guards the CORS behaviour that lets the prod Spring profile boot without CORS_ALLOWED_ORIGINS.
+ * The shipped stack is same-origin (nginx serves the SPA and proxies /api), so an unset/blank
+ * origins value must register NO CORS mapping rather than crash or misconfigure the registry.
+ */
+class WebConfigTest {
+
+  private WebConfig webConfigWith(String origins) {
+    WebConfig config = new WebConfig();
+    ReflectionTestUtils.setField(config, "allowedOrigins", origins);
+    ReflectionTestUtils.setField(config, "allowedMethods", "GET,POST");
+    ReflectionTestUtils.setField(config, "allowedHeaders", "*");
+    ReflectionTestUtils.setField(config, "allowCredentials", true);
+    ReflectionTestUtils.setField(config, "maxAge", 3600L);
+    return config;
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "   "})
+  void blankOriginsRegistersNoCorsMapping(String origins) {
+    CorsRegistry registry = mock(CorsRegistry.class);
+
+    webConfigWith(origins).addCorsMappings(registry);
+
+    verify(registry, never()).addMapping(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  void nullOriginsRegistersNoCorsMapping() {
+    CorsRegistry registry = mock(CorsRegistry.class);
+
+    webConfigWith(null).addCorsMappings(registry);
+
+    verify(registry, never()).addMapping(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  @Test
+  void configuredOriginsRegisterCorsMapping() {
+    CorsRegistry registry = mock(CorsRegistry.class);
+    CorsRegistration registration = mock(CorsRegistration.class, invocation -> {
+      // Fluent builder — every chained call returns the same registration.
+      return invocation.getMethod().getReturnType().equals(CorsRegistration.class)
+          ? invocation.getMock()
+          : null;
+    });
+    when(registry.addMapping("/api/**")).thenReturn(registration);
+
+    webConfigWith("https://app.example.com,https://admin.example.com")
+        .addCorsMappings(registry);
+
+    verify(registry).addMapping("/api/**");
+    verify(registration)
+        .allowedOrigins("https://app.example.com", "https://admin.example.com");
+  }
+}

--- a/docker-compose.offline-prod.yml
+++ b/docker-compose.offline-prod.yml
@@ -51,6 +51,10 @@ services:
 
   backend:
     environment:
+      # Activate the prod Spring profile (overrides the base offline file's `dev`): strict CORS (no
+      # localhost defaults), stacktraces/exception details suppressed in error responses, Swagger
+      # UI + /v3/api-docs disabled, WARN-level logging to file. See docs production-hardening.
+      SPRING_PROFILES_ACTIVE: prod
       TRACEPCAP_AUTH_ENABLED: "true"
       # Public issuer (matches the token `iss`). Must equal PUBLIC_URL + /realms/tracepcap.
       KEYCLOAK_ISSUER_URI: ${PUBLIC_URL:-http://localhost:8888}/realms/tracepcap

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,6 +50,10 @@ services:
 
   backend:
     environment:
+      # Activate the prod Spring profile (overrides the base file's `dev`): strict CORS (no
+      # localhost defaults), stacktraces/exception details suppressed in error responses, Swagger
+      # UI + /v3/api-docs disabled, WARN-level logging to file. See docs production-hardening.
+      SPRING_PROFILES_ACTIVE: prod
       TRACEPCAP_AUTH_ENABLED: "true"
       # Public issuer (matches the token `iss`). Must equal PUBLIC_URL + /realms/tracepcap.
       KEYCLOAK_ISSUER_URI: ${PUBLIC_URL:-http://localhost:8888}/realms/tracepcap

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -153,6 +153,38 @@ walkthrough. They are ignored by the base stack.
    build args are set automatically by ``docker-compose.prod.yml`` and derived
    from ``PUBLIC_URL`` — you normally do not set them by hand.
 
+Spring Profile & CORS
+---------------------
+
+The active Spring profile selects dev vs. hardened behaviour. The two
+``*-prod.yml`` overlays set ``SPRING_PROFILES_ACTIVE=prod``; the base stacks
+run ``dev``. See :doc:`../operations/production-hardening` for the full profile
+matrix.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 40
+
+   * - Variable
+     - Default
+     - Description
+   * - ``SPRING_PROFILES_ACTIVE``
+     - ``dev`` (base) / ``prod`` (``*-prod.yml`` overlays)
+     - ``prod`` enforces strict CORS, disables Swagger + ``/v3/api-docs``,
+       suppresses stacktraces/exception details in error responses, and logs at
+       WARN to a file.
+   * - ``CORS_ALLOWED_ORIGINS``
+     - dev: localhost list / prod: *(empty)*
+     - Comma-separated allowed browser origins for ``/api``. Under ``prod`` it
+       has **no localhost defaults**; leave it empty for the same-origin shipped
+       stack (nginx proxies ``/api``, so CORS is never exercised). Set it only
+       when the frontend is hosted on a different origin from the API.
+   * - ``LOG_DIR``
+     - ``/app/logs``
+     - Directory for the ``prod`` profile's ``application.log`` (created and
+       owned by the container's non-root user at startup). Ignored under ``dev``
+       (console-only logging).
+
 LLM
 ---
 

--- a/docs/operations/production-hardening.rst
+++ b/docs/operations/production-hardening.rst
@@ -4,6 +4,43 @@ Production Hardening
 The default TracePcap configuration is optimised for quick local testing.
 Before exposing the application to a wider audience, follow these steps.
 
+Spring Profile per Deployment Mode
+----------------------------------
+
+The backend selects behaviour via ``SPRING_PROFILES_ACTIVE``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 40
+
+   * - Compose invocation
+     - Profile
+     - Notes
+   * - ``docker-compose.yml`` (base)
+     - ``dev``
+     - Open quick-start / Lanturn. Swagger on, verbose errors, localhost CORS
+       defaults, DEBUG logging.
+   * - ``docker-compose.offline.yml``
+     - ``dev``
+     - Air-gapped quick-start. Same dev defaults as the base file.
+   * - ``… -f docker-compose.prod.yml``
+     - ``prod``
+     - Auth overlay. Strict CORS, Swagger + ``/v3/api-docs`` disabled,
+       stacktraces/exception details suppressed, WARN logging to file.
+   * - ``… -f docker-compose.offline-prod.yml``
+     - ``prod``
+     - Offline auth overlay. Same ``prod`` hardening as above.
+
+The two ``*-prod.yml`` overlays set ``SPRING_PROFILES_ACTIVE=prod`` on the
+backend, overriding the base file's ``dev``. This is the intended production
+path — enabling authentication (below) and the ``prod`` profile together.
+
+Under the ``prod`` profile CORS defaults to **empty** (no localhost origins).
+The shipped stack is same-origin — nginx serves the SPA and proxies ``/api`` on
+one origin — so browser→API calls never trigger CORS and no origins need
+allowing. Set ``CORS_ALLOWED_ORIGINS`` (comma-separated) **only** if you host
+the frontend on a different origin from the API.
+
 Change Default Credentials
 ---------------------------
 


### PR DESCRIPTION
Closes #376.

## Problem
Both production overlays (`docker-compose.prod.yml`, `docker-compose.offline-prod.yml`) are overlays that inherited `SPRING_PROFILES_ACTIVE: dev` from the base compose files. As a result `application-prod.yml` — strict CORS, suppressed stacktraces/exception details, disabled Swagger, prod logging — was **never applied** in the shipped deployment. The prod path ran on dev defaults.

## Changes
- **Activate the profile**: `SPRING_PROFILES_ACTIVE=prod` in `docker-compose.prod.yml` and `docker-compose.offline-prod.yml`. The base open/Lanturn stacks stay on `dev` (quick-start unaffected).
- **Fix the CORS boot-crash**: under `prod`, `cors.allowed-origins: ${CORS_ALLOWED_ORIGINS}` had no default and `WebConfig` read it with no default → the app failed to start when the var was unset. Now it defaults to empty and `WebConfig` skips the CORS mapping when origins are blank. The shipped stack is same-origin (nginx proxies `/api`), so CORS is never exercised and no localhost defaults leak into prod.
- **Fix a second prod-only crash**: the prod profile logged to `/var/log/tracepcap/`, not writable by the non-root `spring` container user. Moved to env-overridable `${LOG_DIR:/app/logs}`; the entrypoint creates + chowns it.
- **Tests**: `WebConfigTest` covers empty / blank / null / populated origins.
- **Docs**: profile matrix and `CORS_ALLOWED_ORIGINS` / `LOG_DIR` in `production-hardening.rst` and `environment-variables.rst`.

## No new setup steps
The prod command is unchanged — no new required env vars, no new mounts:
`docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build`. `CORS_ALLOWED_ORIGINS` is now optional (empty = same-origin); `LOG_DIR` is an optional log-persistence knob.

## Verified at runtime (started the actual prod overlay)
- Boots on the `prod` profile **without** `CORS_ALLOWED_ORIGINS` set
- Swagger UI + `/v3/api-docs` → **404**
- Cross-origin preflight → **403**, no `Access-Control-Allow-Origin`
- Log file written to `/app/logs/application.log` (owned by `spring`)
- Base stack still runs `dev` with Swagger enabled (200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production deployments now support configurable log directories and cross-origin access settings.
  * Production profiles are automatically enabled for standard and offline deployment configurations.
  * Same-origin deployments now work without requiring CORS configuration.

* **Bug Fixes**
  * Improved log directory creation and permissions during startup.
  * Prevented invalid or empty CORS settings from creating unnecessary mappings.

* **Documentation**
  * Added guidance for Spring profiles, CORS, log directories, and production deployment modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->