### PR TITLE
docs: correct hardware requirements to match enforced container limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This makes it well-suited for:
 |----------|---------|---------|
 | Docker | Latest | Container runtime |
 | Docker Compose | Latest | Multi-container orchestration |
-| LLM Server | Any OpenAI-compatible API | AI features (e.g., LM Studio, Ollama, OpenAI) |
+| LLM Server | Any OpenAI-compatible API, self- or LAN-hosted | AI features (e.g., LM Studio, Ollama) |
 
 **Minimum Hardware:**
 
@@ -78,7 +78,9 @@ auth overlay), so size the host above that — see
 per-service breakdown.
 
 These tiers size the TracePcap stack **only** — AI features disabled, or
-`LLM_BASE_URL` pointed at an LLM server on another machine.
+`LLM_BASE_URL` pointed at a separate inference server on the same local network.
+TracePcap must run fully offline, so `LLM_BASE_URL` must not reference a public
+or internet-hosted API.
 
 | | Minimum | Recommended | Comfortable |
 |---|---------|-------------|-------------|
@@ -95,6 +97,7 @@ APP_MEMORY_MB=8192      # 4 GB heap, 2 GB max upload
 BACKEND_CPU_LIMIT=6
 POSTGRES_MEM_LIMIT=2g
 MINIO_MEM_LIMIT=1g
+SURICATA_ENABLED=true   # the default; set explicitly if lowered for Minimum
 ```
 
 **GPU:** not used by TracePcap — packet dissection and threat detection are CPU-bound,

--- a/README.md
+++ b/README.md
@@ -71,8 +71,36 @@ This makes it well-suited for:
 | LLM Server | Any OpenAI-compatible API | AI features (e.g., LM Studio, Ollama, OpenAI) |
 
 **Minimum Hardware:**
-- RAM: 4GB (8GB+ recommended)
-- Storage: 10GB (for database, PCAP files, and object storage)
+
+The default stack's enforced container limits total ~4.4GB (~5.4GB with the Keycloak
+auth overlay), so size the host above that — see
+[Container Resource Limits](docs/operations/production-hardening.rst) for the
+per-service breakdown.
+
+These tiers size the TracePcap stack **only** — AI features disabled, or
+`LLM_BASE_URL` pointed at an LLM server on another machine.
+
+| | Minimum | Recommended | Comfortable |
+|---|---------|-------------|-------------|
+| RAM | 6GB (with `SURICATA_ENABLED=false`) | 8GB+ | 16GB |
+| CPU | 4 cores | 4+ cores for fast nDPI analysis | 8 cores |
+| Storage | 10GB (database, PCAP files, object storage) | 50GB+ for large PCAP collections | 100GB+ SSD |
+
+**Comfortable** assumes Suricata enabled and routine work on large captures. Raise the
+`.env` defaults to match — the shipped `APP_MEMORY_MB=2048` caps uploads at 512MB, since
+max upload is 25% of the backend budget:
+
+```ini
+APP_MEMORY_MB=8192      # 4 GB heap, 2 GB max upload
+BACKEND_CPU_LIMIT=6
+POSTGRES_MEM_LIMIT=2g
+MINIO_MEM_LIMIT=1g
+```
+
+**GPU:** not used by TracePcap — packet dissection and threat detection are CPU-bound,
+and no container requests a GPU device. A GPU only matters if you self-host the LLM,
+where it is that server's requirement: ~8GB VRAM for a 7B model, ~16GB for a 14B
+(quantised), plus 5–30GB of storage for weights, **on top of** the tiers above.
 
 ### Installation
 

--- a/docs/getting-started/prerequisites.rst
+++ b/docs/getting-started/prerequisites.rst
@@ -25,9 +25,11 @@ Hardware Requirements
 ---------------------
 
 All three tiers below size the TracePcap stack **only**. They assume AI features
-are either disabled or pointed at an LLM server on another machine via
-``LLM_BASE_URL``. Self-hosting an LLM on the same box adds to every figure — see
-the note at the end of this section.
+are either disabled or pointed via ``LLM_BASE_URL`` at a separate inference
+server on the same local network. TracePcap must function fully offline, so
+``LLM_BASE_URL`` must never reference a public or internet-hosted API. Running
+the LLM on the TracePcap host itself adds to every figure — see the note at the
+end of this section.
 
 **Minimum:**
 
@@ -56,6 +58,7 @@ caps uploads at 512 MB, which is usually the first limit reached:
    BACKEND_CPU_LIMIT=6
    POSTGRES_MEM_LIMIT=2g
    MINIO_MEM_LIMIT=1g
+   SURICATA_ENABLED=true   # the default; set explicitly if lowered for Minimum
 
 An SSD matters here: Postgres analysis history, MinIO object storage, and nginx
 spilling large request bodies to ``/tmp`` are all disk-bound before they are

--- a/docs/getting-started/prerequisites.rst
+++ b/docs/getting-started/prerequisites.rst
@@ -24,21 +24,76 @@ Software Requirements
 Hardware Requirements
 ---------------------
 
+All three tiers below size the TracePcap stack **only**. They assume AI features
+are either disabled or pointed at an LLM server on another machine via
+``LLM_BASE_URL``. Self-hosting an LLM on the same box adds to every figure — see
+the note at the end of this section.
+
 **Minimum:**
 
-- RAM: 4 GB
+- RAM: 6 GB, with ``SURICATA_ENABLED=false``
+- CPU: 4 cores
 - Storage: 10 GB (database, PCAP files, object storage)
 
 **Recommended:**
 
 - RAM: 8 GB or more
-- Storage: 50 GB+ for large PCAP collections
 - CPU: 4+ cores for fast nDPI analysis
+- Storage: 50 GB+ for large PCAP collections
+
+**Comfortable** — Suricata enabled, routine work on large captures:
+
+- RAM: 16 GB
+- CPU: 8 cores
+- Storage: 100 GB+ SSD
+
+At this tier, raise the defaults in ``.env`` — the shipped ``APP_MEMORY_MB=2048``
+caps uploads at 512 MB, which is usually the first limit reached:
+
+.. code-block:: ini
+
+   APP_MEMORY_MB=8192      # 4 GB heap, 2 GB max upload
+   BACKEND_CPU_LIMIT=6
+   POSTGRES_MEM_LIMIT=2g
+   MINIO_MEM_LIMIT=1g
+
+An SSD matters here: Postgres analysis history, MinIO object storage, and nginx
+spilling large request bodies to ``/tmp`` are all disk-bound before they are
+memory-bound.
 
 .. note::
 
-   If you plan to run an LLM locally for AI features, allocate additional RAM
-   (8–16 GB typical for a 7B–14B parameter model).
+   The Comfortable tier is an operational recommendation, not a measured
+   benchmark. It is derived from the backend guidance in
+   :doc:`../operations/production-hardening` (4 GB+ for the backend alone with
+   Suricata on captures over 100 MB), with headroom for the rest of the stack.
+
+.. important::
+
+   The default stack declares ~4.4 GB of enforced container memory limits
+   (~5.4 GB with an authentication overlay), before the host OS and Docker
+   itself — a 4 GB host cannot run it at default settings. See
+   :doc:`../operations/production-hardening` for the per-service breakdown and
+   the environment variables that override each limit.
+
+   ``.env.example`` ships ``SURICATA_ENABLED=true``, for which 4 GB+ for the
+   backend alone is recommended on captures over 100 MB. Budget 8 GB+ if you
+   keep Suricata enabled.
+
+.. note::
+
+   TracePcap itself never uses a GPU — packet dissection (tshark, nDPI) and
+   threat detection (Suricata) are CPU-bound, and no container in the stack
+   requests a GPU device.
+
+   A GPU is relevant only when self-hosting the LLM, and it is that server's
+   requirement rather than TracePcap's. Budget roughly 8 GB of VRAM for a 7B
+   parameter model or 16 GB for a 14B, quantised, plus 5–30 GB of storage for
+   model weights, **on top of** the tiers above. CPU-only inference works but is
+   slow enough that long generations such as Story Mode may approach the proxy
+   timeout. Pointing ``LLM_BASE_URL`` at an LLM server on another machine — which
+   still satisfies the offline requirement on a local network — leaves the tiers
+   above unchanged.
 
 Operating System
 ----------------


### PR DESCRIPTION
Closes #597

## Summary

The documented **4 GB minimum RAM** sits below the default stack's own enforced `deploy.resources.limits` (~4.4 GB, ~5.4 GB with the Keycloak auth overlay) — before host OS and Docker. A 4 GB host cannot start TracePcap at default settings.

Changes to `README.md` and `docs/getting-started/prerequisites.rst`:

- **Minimum raised to 6 GB** (with `SURICATA_ENABLED=false`), CPU promoted from *Recommended* into the minimum tier
- **New Comfortable tier** — 16 GB / 8 cores / 100 GB+ SSD, for Suricata enabled on large captures, with the `.env` overrides to match. The shipped `APP_MEMORY_MB=2048` caps uploads at 512 MB, since max upload is 25% of the backend budget (`backend/docker-entrypoint.sh:73`)
- **All tiers now say they size the stack only** — AI features disabled, or `LLM_BASE_URL` pointed at a self- or LAN-hosted inference server
- **GPU position stated**: TracePcap never uses one. Packet dissection (tshark, nDPI) and threat detection (Suricata) are CPU-bound, and no container requests a GPU device — verified by grep across compose files, Dockerfiles, Java, and shell. A GPU is the LLM server's requirement, not TracePcap's
- Cross-reference to the per-service breakdown in `production-hardening.rst`

## Review follow-ups (`8cf6289`)

Two findings from the CodeRabbit review, both addressed:

- **LLM endpoint scope** — "an LLM server on another machine" did not exclude a cloud endpoint, which conflicts with the offline requirement. Both files now say *a separate inference server on the same local network*, with an explicit statement that `LLM_BASE_URL` must not reference a public or internet-hosted API. Related and outside the flagged scope: the prerequisites table in `README.md` listed **OpenAI** as an example provider, contradicting the same requirement — removed, and the row now reads "self- or LAN-hosted".
- **Comfortable-tier Suricata** — the tier is sized for Suricata enabled, but neither override block set it, and the Minimum tier above recommends `SURICATA_ENABLED=false`. Anyone stepping up from Minimum would have carried `false` forward. Added `SURICATA_ENABLED=true` to both blocks.

## Verification

- Per-service table in `docs/operations/production-hardening.rst` checked line-by-line against `docker-compose.yml` and `docker-compose.prod.yml` — every default matches. **No changes needed there**; the drift was confined to the two getting-started pages
- The 25% upload rule and the 50% JVM heap split confirmed in `backend/docker-entrypoint.sh` and `nginx/docker-entrypoint.sh`
- `python3 -m sphinx -b html` builds with no warnings from `prerequisites.rst`

## Note on the numbers

The corrected tiers are **operational recommendations, not measured benchmarks**. The 6 GB minimum is derived from ~4.4 GB of enforced limits plus host headroom; the Comfortable tier from the ops doc's own guidance (4 GB+ for the backend alone with Suricata on captures over 100 MB), with headroom for the rest of the stack. Neither has been validated by booting the stack on a host of that size — worth doing once if a defensible figure is wanted. The RST labels the Comfortable tier as such so the doc does not overclaim. LLM VRAM figures are standard quantised-model sizing, not measured against TracePcap's prompts.

## Test plan

- [ ] Docs build clean (`cd docs && python3 -m sphinx -b html . _build`)
- [ ] Rendered prerequisites page reads correctly and the `:doc:` cross-reference to production-hardening resolves
- [ ] Optional: boot the stack on a 6 GB host with `SURICATA_ENABLED=false` to confirm the stated minimum

🤖 Generated with [Claude Code](https://claude.com/claude-code)
