### PR TITLE
docs: commit the production-readiness research write-ups (#364, #365, #366)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,10 @@ Designed for air-gapped and offline deployments — GeoIP lookups use a bundled 
    operations/backup-restore
    operations/logs-monitoring
    operations/production-hardening
+   operations/production-readiness
+   operations/security-audit
+   operations/scalability
+   operations/storage-redundancy
 
 .. toctree::
    :maxdepth: 2

--- a/docs/operations/production-readiness.rst
+++ b/docs/operations/production-readiness.rst
@@ -1,0 +1,134 @@
+Production Readiness
+====================
+
+An assessment of what TracePcap needs before operational use, and where that work
+currently stands.
+
+.. note::
+
+   **Two scopes exist.** The original assessment targeted a Kubernetes/Helm deployment
+   and estimated 6.5–9 weeks across three phases. A later leadership review narrowed the
+   near-term goal to a **single server serving roughly 10–25 analysts**, staged as:
+
+   - **Stage 1 — "safely run what we have"** (~15–20 days): handle large imports, support
+     concurrent use, and protect against data loss, on one box.
+   - **Stage 2 — "build a team workspace"** (multi-month): per-user logins and RBAC,
+     high availability, scale-out, and K8s packaging.
+
+   **Stage 1 is the current target.** The Kubernetes findings below remain valid but are
+   Stage 2 work.
+
+Stage 1 Checklist
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 15 45
+
+   * - Item
+     - Status
+     - Notes
+   * - Concurrent multi-user use
+     - Done
+     - Reads are not the constraint; ingestion is. See `#453 <https://github.com/NotYuSheng/TracePcap/issues/453>`_.
+   * - Load test + tuning
+     - Done
+     - k6 sweep, 5→30 concurrent uploads. See `#453 <https://github.com/NotYuSheng/TracePcap/issues/453>`_.
+   * - Production settings active
+     - Done
+     - ``prod`` profile in the auth overlays (`#376 <https://github.com/NotYuSheng/TracePcap/issues/376>`_).
+   * - Crash / memory safety
+     - Done
+     - Resource limits on all services (`#378 <https://github.com/NotYuSheng/TracePcap/issues/378>`_).
+   * - Indexing & query tuning
+     - Done
+     - No critical index gaps found. See :doc:`scalability`.
+   * - Retention & capacity planning
+     - Partial
+     - Cleanup exists; partitioning (`#394 <https://github.com/NotYuSheng/TracePcap/issues/394>`_) and retention decoupling (`#602 <https://github.com/NotYuSheng/TracePcap/issues/602>`_) open.
+   * - Automated backups + tested restore
+     - **Open**
+     - Manual procedures only (`#379 <https://github.com/NotYuSheng/TracePcap/issues/379>`_).
+   * - Default credential rotation
+     - **Open**
+     - Shipped defaults still present (`#595 <https://github.com/NotYuSheng/TracePcap/issues/595>`_).
+   * - UAT before go-live
+     - **Open**
+     - `#596 <https://github.com/NotYuSheng/TracePcap/issues/596>`_.
+
+Backups are the critical path: they are the largest remaining item, and UAT is gated on
+having rehearsed a restore.
+
+Findings
+--------
+
+Findings from the original assessment, by priority. Several are now closed; the priority
+labels reflect the original K8s-targeted assessment.
+
+**P0 — blocking**
+
+- **P0-1 No authentication.** Addressed by the optional OIDC/Keycloak overlay
+  (`#360 <https://github.com/NotYuSheng/TracePcap/issues/360>`_). The base stack remains
+  deliberately open for local use. Multi-user data ownership is separate
+  (`#361 <https://github.com/NotYuSheng/TracePcap/issues/361>`_).
+- **P0-2 Public MinIO bucket.** See :doc:`security-audit`.
+- **P0-3 Dev profile active in the production path.** Fixed
+  (`#376 <https://github.com/NotYuSheng/TracePcap/issues/376>`_).
+- **P0-4 Default credentials.** Still open
+  (`#595 <https://github.com/NotYuSheng/TracePcap/issues/595>`_).
+
+**P1 — required for production**
+
+- **P1-1/2/6 Observability.** Prometheus metrics, health probes, and log aggregation
+  (`#377 <https://github.com/NotYuSheng/TracePcap/issues/377>`_,
+  `#483 <https://github.com/NotYuSheng/TracePcap/issues/483>`_).
+- **P1-3 No resource limits / OOM risk.** Fixed
+  (`#378 <https://github.com/NotYuSheng/TracePcap/issues/378>`_).
+- **P1-4 No TLS.** Terminate at nginx; see :doc:`production-hardening`.
+- **P1-5 No automated backups or PITR.**
+  (`#379 <https://github.com/NotYuSheng/TracePcap/issues/379>`_).
+- **P1-7 Secrets management.** Stage 1 covers credential rotation
+  (`#595 <https://github.com/NotYuSheng/TracePcap/issues/595>`_); a secrets manager is
+  Stage 2.
+
+**P2 — scale-out**
+
+- **P2-1 In-process analysis cannot scale out.** Queue-backed stateless workers
+  (`#380 <https://github.com/NotYuSheng/TracePcap/issues/380>`_).
+- **P2-2 Scheduled cleanup double-runs** across instances
+  (`#381 <https://github.com/NotYuSheng/TracePcap/issues/381>`_).
+- **P2-3 Datastore SPOFs and scaling.** See :doc:`scalability` and
+  :doc:`storage-redundancy`.
+- **P2-4 Runtime ipinfo.io egress.** Closed by the ``GEO_FORCE_OFFLINE`` flag
+  (`#382 <https://github.com/NotYuSheng/TracePcap/issues/382>`_).
+- **P2-5/6 Migration hygiene and K8s/Helm packaging**
+  (`#383 <https://github.com/NotYuSheng/TracePcap/issues/383>`_).
+
+Capacity
+--------
+
+From the k6 load testing (`#453 <https://github.com/NotYuSheng/TracePcap/issues/453>`_):
+
+- **Concurrent analysts browsing results are not the constraint.** Read endpoints are
+  sub-second and comfortably handle 10+ users on modest hardware.
+- **Ingestion throughput is the real limit.** The pipeline is CPU-bound and dominated by
+  Suricata, which accounts for roughly **94% of per-file analysis time**
+  (`#569 <https://github.com/NotYuSheng/TracePcap/issues/569>`_).
+- The breaking point measured was **~20 simultaneous analyses** before latency exceeded a
+  four-minute budget. This scales with core count rather than being a fixed ceiling.
+- Failure mode is **graceful degradation through queueing**, not errors — until the queue
+  overflows (fixed in `#451 <https://github.com/NotYuSheng/TracePcap/issues/451>`_).
+
+.. warning::
+
+   Those figures came from a shared, contended development box using a small 538 KB
+   capture. They indicate relative cost and shape, **not absolute capacity** on
+   production hardware.
+
+Offline Operation
+-----------------
+
+The offline requirement holds end to end. GeoIP falls back to a bundled DB-IP Lite MMDB
+and can be forced offline with ``GEO_FORCE_OFFLINE``; maps use bundled SVG/GeoJSON with no
+tile servers; and the LLM is configured against a local inference server. Image bundling
+for air-gapped installs is covered in :doc:`../getting-started/offline-deployment`.

--- a/docs/operations/scalability.rst
+++ b/docs/operations/scalability.rst
@@ -1,0 +1,97 @@
+Database Scalability
+====================
+
+Sizing guidance for PostgreSQL and MinIO as captured data grows. Figures come from an
+audit of the live schema, repositories, and infrastructure config.
+
+.. note::
+
+   Growth figures are estimates for typical mixed traffic. Packet density varies widely
+   between captures, so treat them as planning shape rather than precise numbers.
+
+Table Growth
+------------
+
+Every packet is stored as a row, with the payload capped at **64 bytes**
+(``PacketEntity.PAYLOAD_BYTE_LIMIT``, i.e. at most 128 hex characters).
+
+- **~1.5–2M ``packets`` rows per GB of PCAP.**
+- A row is roughly 250–400 B, plus four indexes, so **PostgreSQL grows to about
+  1–1.5× the PCAP size** — almost entirely ``packets``.
+- ``conversations`` holds hundreds to low thousands of rows per GB, but carries
+  **14 indexes (5 of them GIN)**, so it is write-amplified despite the small row count.
+- ``ip_geo_cache`` and ``host_classifications`` are bounded by the number of distinct
+  IPs and hosts. Neither is a scaling concern.
+
+The practical consequence: ``packets`` is the only table whose growth matters, and it is
+what any retention or capacity policy should target.
+
+Indexing
+--------
+
+**No critical index is missing** for the current per-file query patterns. Two
+observations:
+
+- The ``payloadContains`` filter runs ``LIKE '%hex%'`` against ``packets.payload``, which
+  is unindexable and results in a sequential scan. It stays file-scoped, so this is
+  acceptable at present.
+- Aggregation and anomaly queries filter by ``file_id`` and ``GROUP BY`` source or
+  destination IP, producing full per-file scans. Also fine at current scale.
+
+Partitioning
+------------
+
+Retention deletes whole files, and ``ON DELETE CASCADE`` then removes millions of
+``packets`` rows per file on each cleanup cycle, causing significant autovacuum churn.
+
+**List or hash partitioning ``packets`` by ``file_id`` turns cleanup into an instant
+``DROP``/``DETACH`` of a partition.** This is the recommended approach and is tracked in
+`issue #394 <https://github.com/NotYuSheng/TracePcap/issues/394>`_.
+
+TimescaleDB is a **weaker fit** here. It optimises time-range operations, whereas
+TracePcap deletes per file, not per time window.
+
+Connection Pooling
+------------------
+
+HikariCP is sized via ``DB_POOL_MAX_SIZE`` (default 20) with ``DB_POOL_MIN_IDLE``
+(default 5), set in ``docker-compose.yml`` and inherited by all profiles. This stays well
+under the PostgreSQL ``max_connections`` default of 100.
+
+.. note::
+
+   An earlier deployment bug left the pool capped at 10 because the ``dev`` profile did
+   not override the datasource and the ``prod`` profile's sizing was never active. Fixed
+   in `issue #393 <https://github.com/NotYuSheng/TracePcap/issues/393>`_; the pool is now
+   configured in the base compose file so it applies regardless of profile.
+
+Object Storage
+--------------
+
+MinIO runs single-node on a ``local`` volume, so capacity is bounded by the host disk and
+there is no redundancy. See :doc:`storage-redundancy` for the SPOF discussion and the
+SNMD/MNMD upgrade paths.
+
+Archival & Retention
+--------------------
+
+A scheduled job prunes analysis files after ``FILE_RETENTION_HOURS`` (default 12h);
+retention can be disabled entirely with ``FILE_RETENTION_ENABLED``. **Monitor-mode files
+never expire**, which is where unbounded growth actually accumulates.
+
+Pruning is currently all-or-nothing through the file cascade, with no export beforehand.
+The recommended policy is to **decouple packet retention from summary retention** — drop
+the bulky ``packets`` rows early while keeping ``analysis_results`` and ``conversations``
+summaries, since the summaries are a small fraction of the storage. Tracked in
+`issue #602 <https://github.com/NotYuSheng/TracePcap/issues/602>`_.
+
+Schema Notes
+------------
+
+Corrections against older documentation:
+
+- There is **no ``dns_query_log`` table** in the migrations.
+- The geolocation table is **``ip_geo_cache``** (keyed by IP), not ``ip_geo_info``;
+  ``IpGeoInfoEntity`` maps to ``ip_geo_cache``.
+- Migrations are V1–V15 with V7 absent. ``V1__baseline_schema.sql`` is the source of
+  truth for indexes.

--- a/docs/operations/security-audit.rst
+++ b/docs/operations/security-audit.rst
@@ -1,0 +1,95 @@
+Security Audit
+==============
+
+A readiness-oriented review of the application and deployment surface.
+
+.. warning::
+
+   This is a **lightweight readiness pass over public source**, not a certified
+   penetration test or a formal security audit. It is intended to prioritise hardening
+   work, not to certify the application as secure.
+
+Context
+-------
+
+TracePcap was originally designed for small, single-user sessions — an analyst uploading
+a capture and reviewing results locally. The open defaults and absence of authentication
+reflect that original scope. The findings below matter as the project moves toward
+persistent, multi-user deployments.
+
+Findings
+--------
+
+**1. Unauthenticated signature management**
+
+``SignaturesController`` exposes ``GET`` and ``PUT`` of raw YAML signature content and
+writes to ``tracepcap.signatures.path``. Even with SnakeYAML's ``SafeConstructor`` in
+place, these endpoints should require authentication and authorisation, and should be
+audit-logged.
+
+**2. Download filename handling**
+
+``FileController.download`` builds ``Content-Disposition`` from the stored original
+filename directly (``attachment; filename=" + fileName``). This should use RFC 6266-safe
+encoding and sanitisation to avoid malformed headers or unsafe client behaviour.
+
+**3. Deployment defaults expose sensitive services**
+
+``docker-compose.yml`` ships default PostgreSQL and MinIO credentials, exposes PostgreSQL
+on ``5432`` and MinIO on ``9000``/``9001``, and configures the bucket as anonymous public.
+These are appropriate for local development and **risky for anything else**. Credential
+rotation is tracked in `#595 <https://github.com/NotYuSheng/TracePcap/issues/595>`_; the
+intent is also to stop exposing PostgreSQL and MinIO ports externally, since nothing
+outside the Docker network needs to reach them.
+
+**4. Broad CORS with credentials**
+
+``WebConfig`` and ``application.yml`` combine environment-supplied origins with
+``allowed-headers: "*"`` and ``allow-credentials: true``. Production deployments must set
+explicit trusted origins and avoid broad CORS while credentials are enabled. The ``prod``
+profile requires ``CORS_ALLOWED_ORIGINS`` to be set.
+
+**5. Sort parameter validation**
+
+``FileController.getAllFiles`` accepts a ``sort`` parameter and passes the requested
+property into ``Sort.by``. Sortable fields should be allowlisted to avoid unexpected
+property references and backend errors.
+
+Positive Findings
+-----------------
+
+- Upload storage uses **UUID-based object names** and validates extension and size.
+- PCAP merging uses ``ProcessBuilder`` **argument lists** (not shell strings), together
+  with temp files, filename sanitisation, and a timeout.
+- ``JdbcTemplate`` queries in ``NodeRoleService`` use **parameterised placeholders** for
+  ``fileId`` and ``entityKey``.
+
+Deployment Requirements
+-----------------------
+
+Any deployment beyond local development must:
+
+- Override **all** sample credentials — PostgreSQL, MinIO, and the Keycloak admin
+  (`#595 <https://github.com/NotYuSheng/TracePcap/issues/595>`_).
+- Restrict exposed services so PostgreSQL and MinIO are not externally reachable.
+- Terminate **TLS** at nginx (see :doc:`production-hardening`).
+- Set explicit ``CORS_ALLOWED_ORIGINS``.
+- Point the LLM at a **local inference server**, so capture-derived content is never sent
+  to a third party.
+- Enable authentication via the Keycloak overlay where the deployment is shared
+  (see :doc:`../configuration/authentication`).
+
+Outstanding Work
+----------------
+
+Items 1, 2, 4, and 5 above remain open and are tracked in
+`#364 <https://github.com/NotYuSheng/TracePcap/issues/364>`_. Multi-user data isolation —
+file ownership and provenance, needed before mutually untrusted users share an instance —
+is tracked separately in
+`#361 <https://github.com/NotYuSheng/TracePcap/issues/361>`_.
+
+.. note::
+
+   The initial public-source review was contributed by `@bmtriet
+   <https://github.com/bmtriet>`_ in
+   `#364 <https://github.com/NotYuSheng/TracePcap/issues/364>`_.

--- a/docs/operations/storage-redundancy.rst
+++ b/docs/operations/storage-redundancy.rst
@@ -1,0 +1,55 @@
+Storage Redundancy & Capacity
+==============================
+
+This page documents a **known limitation**, not a configuration step. TracePcap's
+object store is currently a single point of failure. Nothing here is enabled by
+default, and closing the gap requires additional hardware.
+
+Current Deployment
+------------------
+
+TracePcap runs MinIO in **Single-Node Single-Drive (SNSD)** mode — ``server /data``
+backed by one ``local`` Docker volume in ``docker-compose.yml``:
+
+- **No erasure coding and no redundancy.** A drive failure loses every stored PCAP.
+- **Capacity is bounded by the host disk.** There is no way to grow past it without
+  adding storage to the machine.
+
+Database growth compounds this. Per the datastore sizing work, PostgreSQL grows to
+roughly **1–1.5× the size of the ingested PCAP** (see :doc:`../operations/scalability`),
+so the host disk carries both the raw objects and a database of comparable size.
+
+Redundancy Options
+------------------
+
+In increasing order of cost and resilience:
+
+**SNMD — Single-Node Multi-Drive**
+   Same machine, MinIO given **four or more drives/volumes**. Erasure coding then
+   tolerates a **drive** failure. Requires no additional machines.
+
+**MNMD — Multi-Node Multi-Drive**
+   **Four or more nodes**, giving true high availability that tolerates the loss of a
+   whole **machine**. Only necessary if a full-host outage must be survived.
+
+Recommendation
+--------------
+
+For a single-server deployment, **SNMD is the first redundancy step** — it removes the
+drive-failure SPOF without any multi-machine work, and needs no application change.
+MNMD is a Stage 2 concern and should be considered alongside the wider high-availability
+and scale-out work.
+
+In the meantime:
+
+- Document the SPOF for whoever operates the box.
+- Alert on host disk usage, since capacity is bounded by it and both MinIO and
+  PostgreSQL consume it.
+
+.. note::
+
+   **Redundancy is not backup.** Erasure coding protects against hardware failure; it
+   does not protect against accidental deletion, corruption, or operator error. Both
+   are needed. Backup and restore procedures are covered in :doc:`backup-restore`, and
+   automating them is tracked separately in `issue #379
+   <https://github.com/NotYuSheng/TracePcap/issues/379>`_.


### PR DESCRIPTION
## Problem

The production-readiness, scalability, and security-audit assessments were completed in June, but the findings only ever existed as **GitHub issue comments**. The reports they promised — `docs/production-readiness.md`, `docs/scalability.md`, `docs/security-audit.md` — were never written.

A reader of the repo had no way to find the sizing figures, the P0–P2 findings, or the measured capacity limits. It also made progress hard to assess: the work was real, just not where anyone would look for it.

## What this does

Ports all three write-ups into `docs/operations/` as reStructuredText, matching the existing Sphinx layout, plus a fourth page documenting the MinIO single-point-of-failure (#365 follow-up 4).

| Page | Content |
|---|---|
| `production-readiness.rst` | Stage 1 checklist, P0–P2 findings, measured capacity |
| `security-audit.rst` | 5 findings + positives, credited to @bmtriet |
| `scalability.rst` | Sizing figures, indexing, partitioning, retention |
| `storage-redundancy.rst` | MinIO SPOF, SNMD/MNMD upgrade paths |

## Reconciling two scopes

The assessments had drifted apart and this is the main editorial call in the PR:

- **#366** targeted Kubernetes/Helm at **6.5–9 weeks**
- The later leadership review scoped Stage 1 to a **single server at ~15–20 days**

Rather than silently pick one, `production-readiness.rst` opens with a note stating both and declaring **Stage 1 the current target**, with the K8s findings retained as Stage 2. If that's the wrong framing it's one paragraph to change.

## Status is recorded as it actually stands

Not as the original assessment left it — #376 and #378 are done, #365 found no critical index gaps, and backups (#379), credentials (#595) and UAT (#596) remain open, with backups on the critical path.

## Note on `storage-redundancy.rst`

Written as a **known limitation we are not fixing**, not a hardening step. It includes an explicit note that redundancy is not backup, pointing at #379. Worth being blunt: that page reduces no risk, it records one.

## Verification

Sphinx builds clean (`EXIT=0`). All four pages render and every `:doc:` cross-reference resolves to a real link. Remaining build warnings are pre-existing in other files and untouched here.

Refs #364, #365, #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)