### PR TITLE
fix: require explicit credentials in the production overlays (#595)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,8 +72,9 @@ APP_MEMORY_MB=2048
 #
 # MinIO root credentials. Also used by the backend as its S3 access/secret key and by the
 # minio-init container that creates the bucket, so all three stay in sync automatically.
+# MinIO requires the user to be at least 3 characters and the password at least 8.
 # MINIO_ROOT_USER=tracepcap
-# MINIO_ROOT_PASSWORD=change-me
+# MINIO_ROOT_PASSWORD=change-me-8-chars-min
 #
 # Keycloak admin console (auth overlays only). The console is served on the same public
 # origin as the app at /admin, so a default here is a publicly known admin password.

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,37 @@ APP_MEMORY_MB=2048
 # KEYCLOAK_MEM_LIMIT=1g        # auth overlays only
 # KEYCLOAK_CPU_LIMIT=2
 
+# =============================================================================
+# Credentials
+# =============================================================================
+# The base stack (docker-compose.yml / docker-compose.offline.yml) defaults these to the
+# well-known dev values below, so `docker compose up -d` works with no .env for local use
+# and CI. Those defaults are PUBLIC — anyone with the source knows them.
+#
+# The production overlays (docker-compose.prod.yml / docker-compose.offline-prod.yml)
+# REQUIRE every variable in this section. Compose aborts before starting anything if one
+# is unset, so a production deployment cannot silently run on shipped defaults.
+#
+# Set all of them for any shared or long-lived deployment, then treat this file as the
+# record of which values are in play (never commit the real .env — it is gitignored).
+#
+# PostgreSQL. Changing POSTGRES_USER/POSTGRES_DB after the database volume has been
+# initialised will NOT rename the existing role or database — Postgres only applies these
+# on first init. Set them before first start, or recreate the volume.
+# POSTGRES_DB=tracepcap
+# POSTGRES_USER=tracepcap_user
+# POSTGRES_PASSWORD=change-me
+#
+# MinIO root credentials. Also used by the backend as its S3 access/secret key and by the
+# minio-init container that creates the bucket, so all three stay in sync automatically.
+# MINIO_ROOT_USER=tracepcap
+# MINIO_ROOT_PASSWORD=change-me
+#
+# Keycloak admin console (auth overlays only). The console is served on the same public
+# origin as the app at /admin, so a default here is a publicly known admin password.
+# KEYCLOAK_ADMIN=admin
+# KEYCLOAK_ADMIN_PASSWORD=change-me
+
 # Nginx Port Configuration
 # Default: 80 (HTTP standard port)
 # Change if port 80 is already in use on your system

--- a/docker-compose.offline-prod.yml
+++ b/docker-compose.offline-prod.yml
@@ -38,8 +38,10 @@ services:
           cpus: ${KEYCLOAK_CPU_LIMIT:-2}
           memory: ${KEYCLOAK_MEM_LIMIT:-1g}
     environment:
-      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-user}
-      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-P@ssw0rd}
+      # REQUIRED — the admin console is reachable on the same public origin (/admin), so a
+      # shipped default would be a publicly known administrator password.
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:?set KEYCLOAK_ADMIN in .env — see .env.example}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in .env — see .env.example}
       # Public, browser-facing base URL — determines the token `iss` claim and all KC URLs.
       KC_HOSTNAME: ${PUBLIC_URL:-http://localhost:8888}
       # Trust X-Forwarded-* from the nginx proxy (same-origin reverse proxy in front of KC).
@@ -57,6 +59,19 @@ services:
     networks:
       - tracepcap-network
 
+  # Datastore credentials are REQUIRED in the production path. The base offline file defaults them
+  # so an air-gapped smoke test works without a .env; re-declaring them with `:?` here means a real
+  # offline deployment cannot silently start on the shipped defaults.
+  postgres:
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env — see .env.example}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env — see .env.example}
+
+  minio:
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env — see .env.example}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env — see .env.example}
+
   backend:
     environment:
       # Activate the prod Spring profile (overrides the base offline file's `dev`): strict CORS (no
@@ -64,6 +79,12 @@ services:
       # UI + /v3/api-docs disabled, WARN-level logging to file. See docs production-hardening.
       SPRING_PROFILES_ACTIVE: prod
       TRACEPCAP_AUTH_ENABLED: "true"
+      # Re-asserted so the backend fails fast alongside the datastores rather than starting and
+      # then failing to authenticate against them.
+      DATABASE_USERNAME: ${POSTGRES_USER:?set POSTGRES_USER in .env — see .env.example}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env — see .env.example}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env — see .env.example}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env — see .env.example}
       # Public issuer (matches the token `iss`). Must equal PUBLIC_URL + /realms/tracepcap.
       KEYCLOAK_ISSUER_URI: ${PUBLIC_URL:-http://localhost:8888}/realms/tracepcap
       # Backend-reachable JWKS endpoint (internal docker network), fetched lazily so the

--- a/docker-compose.offline-prod.yml
+++ b/docker-compose.offline-prod.yml
@@ -22,8 +22,9 @@
 # docs/configuration/authentication.rst and docs/getting-started/offline-deployment.rst.
 #
 # Manage users at <PUBLIC_URL>/admin (Keycloak admin console, served same-origin by nginx).
-# Default demo login: analyst / analyst. Default Keycloak admin: user / P@ssw0rd — override
-# both for any real deployment.
+# The realm seeds a demo app login (analyst / analyst) — change it for any real deployment.
+# The Keycloak admin account has NO default here: KEYCLOAK_ADMIN / KEYCLOAK_ADMIN_PASSWORD must
+# be set in .env or this overlay aborts before starting anything.
 services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.0
@@ -64,6 +65,7 @@ services:
   # offline deployment cannot silently start on the shipped defaults.
   postgres:
     environment:
+      POSTGRES_DB: ${POSTGRES_DB:?set POSTGRES_DB in .env — see .env.example}
       POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env — see .env.example}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env — see .env.example}
 
@@ -81,6 +83,7 @@ services:
       TRACEPCAP_AUTH_ENABLED: "true"
       # Re-asserted so the backend fails fast alongside the datastores rather than starting and
       # then failing to authenticate against them.
+      DATABASE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:?set POSTGRES_DB in .env — see .env.example}
       DATABASE_USERNAME: ${POSTGRES_USER:?set POSTGRES_USER in .env — see .env.example}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env — see .env.example}
       MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env — see .env.example}

--- a/docker-compose.offline.yml
+++ b/docker-compose.offline.yml
@@ -38,7 +38,10 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tracepcap_user} -d ${POSTGRES_DB:-tracepcap}"]
+      # Reads the container's own POSTGRES_USER/POSTGRES_DB rather than interpolating them here,
+      # so a value containing a space or shell metacharacter can't break the check (which would
+      # leave postgres permanently unhealthy and block every service that depends on it).
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -85,10 +88,17 @@ services:
           memory: ${MINIO_INIT_MEM_LIMIT:-128m}
     depends_on:
       - minio
+    environment:
+      # Passed as env vars, NOT interpolated into the entrypoint string below. Compose would
+      # substitute the value textually and `sh` would then re-parse it, so a password containing
+      # a space, `;`, `$$` or `"` would split the argument, run as a second command, or expand.
+      # `$$VAR` escapes the `$` so the container's shell does the expansion, not Compose.
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
     entrypoint: >
       /bin/sh -c "
       sleep 5;
-      /usr/bin/mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin};
+      /usr/bin/mc alias set myminio http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\";
       /usr/bin/mc mb myminio/tracepcap-files --ignore-existing;
       /usr/bin/mc anonymous set public myminio/tracepcap-files;
       exit 0;

--- a/docker-compose.offline.yml
+++ b/docker-compose.offline.yml
@@ -27,16 +27,18 @@ services:
           cpus: ${POSTGRES_CPU_LIMIT:-2}
           memory: ${POSTGRES_MEM_LIMIT:-1g}
     environment:
-      POSTGRES_DB: tracepcap
-      POSTGRES_USER: tracepcap_user
-      POSTGRES_PASSWORD: tracepcap_pass
+      # Credentials default to the well-known dev values so the offline stack starts with no
+      # .env. The production overlay requires them explicitly — see docker-compose.offline-prod.yml.
+      POSTGRES_DB: ${POSTGRES_DB:-tracepcap}
+      POSTGRES_USER: ${POSTGRES_USER:-tracepcap_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-tracepcap_pass}
       TZ: Asia/Singapore
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U tracepcap_user -d tracepcap"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tracepcap_user} -d ${POSTGRES_DB:-tracepcap}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -55,8 +57,8 @@ services:
           cpus: ${MINIO_CPU_LIMIT:-2}
           memory: ${MINIO_MEM_LIMIT:-1g}
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       TZ: Asia/Singapore
     ports:
       - "9000:9000"  # API
@@ -86,7 +88,7 @@ services:
     entrypoint: >
       /bin/sh -c "
       sleep 5;
-      /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin;
+      /usr/bin/mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin};
       /usr/bin/mc mb myminio/tracepcap-files --ignore-existing;
       /usr/bin/mc anonymous set public myminio/tracepcap-files;
       exit 0;
@@ -108,15 +110,16 @@ services:
           cpus: ${BACKEND_CPU_LIMIT:-4}
     environment:
       SPRING_PROFILES_ACTIVE: dev
-      DATABASE_URL: jdbc:postgresql://postgres:5432/tracepcap
-      DATABASE_USERNAME: tracepcap_user
-      DATABASE_PASSWORD: tracepcap_pass
+      # Must resolve to the same values as the postgres service above.
+      DATABASE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-tracepcap}
+      DATABASE_USERNAME: ${POSTGRES_USER:-tracepcap_user}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-tracepcap_pass}
       # HikariCP connection pool (see #393). Stays under Postgres max_connections (100).
       DB_POOL_MAX_SIZE: ${DB_POOL_MAX_SIZE:-20}
       DB_POOL_MIN_IDLE: ${DB_POOL_MIN_IDLE:-5}
       MINIO_ENDPOINT: http://minio:9000
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
       MINIO_BUCKET: tracepcap-files
       APP_MEMORY_MB: ${APP_MEMORY_MB:-2048}
       # Air-gapped by default: suppress the one intentional runtime egress (ipinfo.io) and

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,10 +33,11 @@ services:
           cpus: ${KEYCLOAK_CPU_LIMIT:-2}
           memory: ${KEYCLOAK_MEM_LIMIT:-1g}
     environment:
-      # Demo admin credentials. The Keycloak admin console is reachable on the same public origin
-      # (/admin) — override KEYCLOAK_ADMIN / KEYCLOAK_ADMIN_PASSWORD for any real deployment.
-      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-user}
-      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-P@ssw0rd}
+      # Admin credentials are REQUIRED here — the console is reachable on the same public origin
+      # (/admin), so a shipped default would be a publicly known administrator password.
+      # Compose aborts with the message below if these are unset.
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:?set KEYCLOAK_ADMIN in .env — see .env.example}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in .env — see .env.example}
       # Public, browser-facing base URL — determines the token `iss` claim and all KC-generated URLs.
       KC_HOSTNAME: ${PUBLIC_URL:-http://localhost:8888}
       # Trust X-Forwarded-* from the nginx proxy (same-origin reverse proxy in front of Keycloak).
@@ -56,6 +57,19 @@ services:
     networks:
       - tracepcap-network
 
+  # Datastore credentials are REQUIRED in the production path. The base file defaults them to
+  # well-known dev values so local/CI runs work without a .env; re-declaring them with `:?` here
+  # means a production deployment cannot silently start on the shipped defaults.
+  postgres:
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env — see .env.example}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env — see .env.example}
+
+  minio:
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env — see .env.example}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env — see .env.example}
+
   backend:
     environment:
       # Activate the prod Spring profile (overrides the base file's `dev`): strict CORS (no
@@ -63,6 +77,12 @@ services:
       # UI + /v3/api-docs disabled, WARN-level logging to file. See docs production-hardening.
       SPRING_PROFILES_ACTIVE: prod
       TRACEPCAP_AUTH_ENABLED: "true"
+      # Re-asserted so the backend fails fast alongside the datastores rather than starting and
+      # then failing to authenticate against them.
+      DATABASE_USERNAME: ${POSTGRES_USER:?set POSTGRES_USER in .env — see .env.example}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env — see .env.example}
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env — see .env.example}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env — see .env.example}
       # Public issuer (matches the token `iss`). Must equal PUBLIC_URL + /realms/tracepcap.
       KEYCLOAK_ISSUER_URI: ${PUBLIC_URL:-http://localhost:8888}/realms/tracepcap
       # Backend-reachable JWKS endpoint (internal docker network). Decouples key fetch from the

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,6 +62,7 @@ services:
   # means a production deployment cannot silently start on the shipped defaults.
   postgres:
     environment:
+      POSTGRES_DB: ${POSTGRES_DB:?set POSTGRES_DB in .env — see .env.example}
       POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in .env — see .env.example}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env — see .env.example}
 
@@ -79,6 +80,7 @@ services:
       TRACEPCAP_AUTH_ENABLED: "true"
       # Re-asserted so the backend fails fast alongside the datastores rather than starting and
       # then failing to authenticate against them.
+      DATABASE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:?set POSTGRES_DB in .env — see .env.example}
       DATABASE_USERNAME: ${POSTGRES_USER:?set POSTGRES_USER in .env — see .env.example}
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env — see .env.example}
       MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env — see .env.example}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,16 +23,19 @@ services:
           cpus: ${POSTGRES_CPU_LIMIT:-2}
           memory: ${POSTGRES_MEM_LIMIT:-1g}
     environment:
-      POSTGRES_DB: tracepcap
-      POSTGRES_USER: tracepcap_user
-      POSTGRES_PASSWORD: tracepcap_pass
+      # Credentials default to the well-known dev values so `docker compose up` works with
+      # no .env (local dev, CI). The production overlays require them to be set explicitly —
+      # see docker-compose.prod.yml. Override in .env for any shared deployment.
+      POSTGRES_DB: ${POSTGRES_DB:-tracepcap}
+      POSTGRES_USER: ${POSTGRES_USER:-tracepcap_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-tracepcap_pass}
       TZ: Asia/Singapore
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U tracepcap_user -d tracepcap"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tracepcap_user} -d ${POSTGRES_DB:-tracepcap}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -51,8 +54,8 @@ services:
           cpus: ${MINIO_CPU_LIMIT:-2}
           memory: ${MINIO_MEM_LIMIT:-1g}
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       TZ: Asia/Singapore
     ports:
       - "9000:9000"  # API
@@ -83,7 +86,7 @@ services:
     entrypoint: >
       /bin/sh -c "
       sleep 5;
-      /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin;
+      /usr/bin/mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin};
       /usr/bin/mc mb myminio/tracepcap-files --ignore-existing;
       /usr/bin/mc anonymous set public myminio/tracepcap-files;
       exit 0;
@@ -114,16 +117,17 @@ services:
       # Authentication off by default — the app runs fully open (e.g. Lanturn). To enable OIDC,
       # use docker-compose.prod.yml (bundles Keycloak) or set TRACEPCAP_AUTH_ENABLED + KEYCLOAK_* envs.
       TRACEPCAP_AUTH_ENABLED: ${TRACEPCAP_AUTH_ENABLED:-false}
-      DATABASE_URL: jdbc:postgresql://postgres:5432/tracepcap
-      DATABASE_USERNAME: tracepcap_user
-      DATABASE_PASSWORD: tracepcap_pass
+      # Must resolve to the same values as the postgres service above.
+      DATABASE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-tracepcap}
+      DATABASE_USERNAME: ${POSTGRES_USER:-tracepcap_user}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-tracepcap_pass}
       # HikariCP connection pool. Sized above the base default so concurrent analysis inserts +
       # request traffic don't starve the pool. Stays well under Postgres max_connections (100). See #393.
       DB_POOL_MAX_SIZE: ${DB_POOL_MAX_SIZE:-20}
       DB_POOL_MIN_IDLE: ${DB_POOL_MIN_IDLE:-5}
       MINIO_ENDPOINT: http://minio:9000
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
+      MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
       MINIO_BUCKET: tracepcap-files
       # Memory allocation — all limits (JVM heap, max upload, timeouts) are derived
       # from this single value in the container entrypoint script

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,10 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-tracepcap_user} -d ${POSTGRES_DB:-tracepcap}"]
+      # Reads the container's own POSTGRES_USER/POSTGRES_DB rather than interpolating them here,
+      # so a value containing a space or shell metacharacter can't break the check (which would
+      # leave postgres permanently unhealthy and block every service that depends on it).
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -83,10 +86,17 @@ services:
           memory: ${MINIO_INIT_MEM_LIMIT:-128m}
     depends_on:
       - minio
+    environment:
+      # Passed as env vars, NOT interpolated into the entrypoint string below. Compose would
+      # substitute the value textually and `sh` would then re-parse it, so a password containing
+      # a space, `;`, `$` or `"` would split the argument, run as a second command, or expand.
+      # `$$VAR` escapes the `$` so the container's shell does the expansion, not Compose.
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
     entrypoint: >
       /bin/sh -c "
       sleep 5;
-      /usr/bin/mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin};
+      /usr/bin/mc alias set myminio http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\";
       /usr/bin/mc mb myminio/tracepcap-files --ignore-existing;
       /usr/bin/mc anonymous set public myminio/tracepcap-files;
       exit 0;

--- a/docs/configuration/authentication.rst
+++ b/docs/configuration/authentication.rst
@@ -51,8 +51,9 @@ demo user. **Change these for any real deployment.**
      - ``analyst`` / ``analyst``
      - Keycloak admin console → Users, or edit the realm export
    * - Keycloak admin
-     - ``user`` / ``P@ssw0rd``
-     - ``KEYCLOAK_ADMIN`` / ``KEYCLOAK_ADMIN_PASSWORD`` env vars
+     - *no default — must be set*
+     - ``KEYCLOAK_ADMIN`` / ``KEYCLOAK_ADMIN_PASSWORD`` in ``.env``; the
+       production overlays abort if either is unset
 
 The Keycloak admin console is served same-origin at ``/admin``. To add or manage
 application logins, see :doc:`user-management`.

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -172,12 +172,13 @@ walkthrough. They are ignored by the base stack.
        permit-all. The prod overlay sets this to ``true`` to gate ``/api``
        behind a Keycloak JWT.
    * - ``KEYCLOAK_ADMIN``
-     - ``user``
+     - *(none)*
      - Keycloak bootstrap admin username (admin console is served same-origin
-       at ``/admin``). **Change for any real deployment.**
+       at ``/admin``). **Required** — the production overlays abort if unset.
    * - ``KEYCLOAK_ADMIN_PASSWORD``
-     - ``P@ssw0rd``
-     - Keycloak bootstrap admin password. **Change for any real deployment.**
+     - *(none)*
+     - Keycloak bootstrap admin password. **Required** — the production overlays
+       abort if unset. See :doc:`../operations/production-hardening`.
 
 .. note::
    ``KEYCLOAK_ISSUER_URI``, ``KEYCLOAK_JWK_SET_URI``, and the ``VITE_AUTH_*``


### PR DESCRIPTION
## Problem

Every deployment path shipped the same well-known credentials — `tracepcap_pass`, `minioadmin`, `P@ssw0rd` — hard-coded as **literals** rather than `${VAR:-default}`. There was no way to override them from `.env` without editing the compose file itself.

## Why not just make them required

CI runs `docker compose up -d --build` with **no `.env`** (it's gitignored and absent in CI). A blanket `${VAR:?}` would have broken `e2e.yml` and `system-tests.yml` immediately. So this splits by audience instead of picking one:

**Base** (`docker-compose.yml`, `docker-compose.offline.yml`) → `${VAR:-<dev default>}`
Local dev and CI work exactly as before, now overridable from `.env`.

**Prod overlays** (`docker-compose.prod.yml`, `docker-compose.offline-prod.yml`) → `${VAR:?message}`
Compose aborts *before starting anything* if a credential is unset, so a production deployment cannot silently come up on shipped defaults.

## The subtle part

Credentials are threaded through **every consumer that has to agree on them**:

- the postgres healthcheck's `pg_isready -U`
- minio-init's `mc alias set`
- the database name inside `DATABASE_URL`
- the backend's S3 access/secret key

Missing any one would leave a service unable to authenticate against a datastore whose password had moved — a failure that only surfaces at runtime.

## Verification

| Case | Result |
|---|---|
| Base, no `.env` (the CI case) | ✅ Resolves to unchanged dev values |
| Prod overlay, no `.env` | ✅ Aborts: *"required variable KEYCLOAK_ADMIN is missing a value"* |
| Offline-prod, no `.env` | ✅ Aborts on `POSTGRES_USER` |
| Prod, with `.env` | ✅ Custom values propagate everywhere; **no shipped default remains** |
| `docker compose up -d --build` | ✅ Flyway migrated, bucket created, API `HTTP 200` |

## Caveat worth knowing before the box goes live

`POSTGRES_USER` / `POSTGRES_DB` only take effect on **first volume init** — Postgres will not rename an existing role or database. Setting them on an already-initialised deployment silently leaves the old role in place while the backend tries the new one.

Documented in `.env.example`, but it means rotating credentials on the running deploy box needs a volume recreate or a manual `ALTER ROLE`.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)