### PR TITLE
docs: correct credential guidance left stale by #595 and #607

### DIFF
--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -355,9 +355,9 @@ you are connecting to an external database.
    * - ``POSTGRES_USER``
      - Database user
    * - ``POSTGRES_PASSWORD``
-     - Database password — **change this in production**
-   * - ``SPRING_DATASOURCE_PASSWORD``
-     - Backend database connection password — must match ``POSTGRES_PASSWORD``
+     - Database password — **change this in production**. The backend's
+       ``DATABASE_PASSWORD`` is derived from this value in the compose files, so
+       the two cannot drift apart; there is no separate variable to set.
 
 MinIO Configuration (internal)
 -------------------------------

--- a/docs/configuration/user-management.rst
+++ b/docs/configuration/user-management.rst
@@ -35,8 +35,9 @@ The stack must be running with the production overlay:
    PUBLIC_URL=http://localhost:8888 \
      docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 
-You also need the **Keycloak admin** credentials (default ``user`` /
-``P@ssw0rd`` — override with ``KEYCLOAK_ADMIN`` / ``KEYCLOAK_ADMIN_PASSWORD``).
+You also need the **Keycloak admin** credentials. These have **no default** —
+set ``KEYCLOAK_ADMIN`` and ``KEYCLOAK_ADMIN_PASSWORD`` in ``.env`` or the
+production overlay aborts before starting anything.
 
 Create a user via the admin console
 -----------------------------------

--- a/docs/getting-started/offline-deployment.rst
+++ b/docs/getting-started/offline-deployment.rst
@@ -125,9 +125,10 @@ setting ``PUBLIC_URL`` to the exact origin you browse to (scheme + host + port):
    breaks JWT validation.
 
 Create and manage logins at ``<PUBLIC_URL>/admin`` — see
-:doc:`../configuration/user-management`. The default demo login is
-``analyst`` / ``analyst`` and the default Keycloak admin is ``user`` /
-``P@ssw0rd``; **change both for any real deployment.**
+:doc:`../configuration/user-management`. The realm seeds a demo app login of
+``analyst`` / ``analyst``; **change it for any real deployment.** The Keycloak
+admin account has no default — ``KEYCLOAK_ADMIN`` and
+``KEYCLOAK_ADMIN_PASSWORD`` must be set in ``.env`` or the overlay aborts.
 
 LLM Configuration for Offline Use
 ----------------------------------

--- a/docs/operations/production-hardening.rst
+++ b/docs/operations/production-hardening.rst
@@ -44,22 +44,37 @@ the frontend on a different origin from the API.
 Change Default Credentials
 ---------------------------
 
-**MinIO:**
+Credentials come from ``.env`` — there is no need to edit any compose file.
 
-In ``docker-compose.yml``, change:
+The base stack defaults them to well-known development values
+(``tracepcap_pass``, ``minioadmin``) so a local or CI run works with no ``.env``.
+**Those defaults are public.** The two ``*-prod.yml`` overlays therefore *require*
+every credential and abort before starting anything if one is unset, so a
+production deployment cannot silently run on them.
 
-.. code-block:: yaml
+Set all of these in ``.env`` (see ``.env.example`` for the full list):
 
-   MINIO_ROOT_USER: minioadmin
-   MINIO_ROOT_PASSWORD: minioadmin
+.. code-block:: ini
 
-to strong, unique credentials. Update any references in the backend service
-environment as well.
+   POSTGRES_DB=tracepcap
+   POSTGRES_USER=tracepcap
+   POSTGRES_PASSWORD=<strong-unique-value>
+   MINIO_ROOT_USER=tracepcap
+   MINIO_ROOT_PASSWORD=<strong-unique-value>   # MinIO requires 8+ characters
+   KEYCLOAK_ADMIN=admin                        # auth overlays only
+   KEYCLOAK_ADMIN_PASSWORD=<strong-unique-value>
 
-**PostgreSQL:**
+One value feeds every consumer that has to agree on it — the backend, the
+Postgres healthcheck, and the MinIO bucket bootstrap — so they cannot drift apart.
 
-Change ``POSTGRES_PASSWORD`` to a strong password and update the backend's
-``SPRING_DATASOURCE_PASSWORD`` to match.
+.. warning::
+
+   ``POSTGRES_USER`` and ``POSTGRES_DB`` are applied **only when the database
+   volume is first initialised**. Setting them against an existing deployment
+   will not rename the role or database: Postgres keeps the old ones while the
+   backend tries to connect with the new, and startup fails. Set them before
+   first start, or recreate the volume (destroying existing data) or issue a
+   manual ``ALTER ROLE`` / ``ALTER DATABASE``.
 
 Enable Authentication
 ---------------------
@@ -74,9 +89,12 @@ overlay:
      docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 
 This gates the API behind a Keycloak JWT and adds a login flow to the frontend.
-**Change the demo credentials** (app login ``analyst`` / ``analyst`` and the
-Keycloak admin ``user`` / ``P@ssw0rd``) before exposing the app. See
-:doc:`../configuration/authentication` for the full walkthrough.
+
+The Keycloak admin account has **no default** — set ``KEYCLOAK_ADMIN`` and
+``KEYCLOAK_ADMIN_PASSWORD`` in ``.env`` (the overlay aborts otherwise). The realm
+still seeds a demo **app login** of ``analyst`` / ``analyst``; change it before
+exposing the app. See :doc:`../configuration/authentication` for the full
+walkthrough.
 
 If you prefer an external identity layer instead, you can still front nginx
 with an `oauth2-proxy <https://oauth2-proxy.github.io/oauth2-proxy/>`_,

--- a/docs/operations/production-hardening.rst
+++ b/docs/operations/production-hardening.rst
@@ -49,19 +49,28 @@ Credentials come from ``.env`` — there is no need to edit any compose file.
 The base stack defaults them to well-known development values
 (``tracepcap_pass``, ``minioadmin``) so a local or CI run works with no ``.env``.
 **Those defaults are public.** The two ``*-prod.yml`` overlays therefore *require*
-every credential and abort before starting anything if one is unset, so a
-production deployment cannot silently run on them.
+every credential and abort before starting anything if one is unset.
+
+.. important::
+
+   That check tests only that a value is **present**, not that it is a good one.
+   Nothing stops an operator writing ``tracepcap_pass`` or ``minioadmin`` into
+   ``.env`` — the overlay would start normally. Replace every value below with a
+   unique secret; the fail-fast only catches the case where you forgot.
 
 Set all of these in ``.env`` (see ``.env.example`` for the full list):
 
 .. code-block:: ini
 
+   # First start only — see the warning below before changing these on a
+   # deployment that already has a database volume.
    POSTGRES_DB=tracepcap
-   POSTGRES_USER=tracepcap
+   POSTGRES_USER=tracepcap_user
    POSTGRES_PASSWORD=<strong-unique-value>
-   MINIO_ROOT_USER=tracepcap
+
+   MINIO_ROOT_USER=<strong-unique-value>
    MINIO_ROOT_PASSWORD=<strong-unique-value>   # MinIO requires 8+ characters
-   KEYCLOAK_ADMIN=admin                        # auth overlays only
+   KEYCLOAK_ADMIN=<admin-username>             # auth overlays only
    KEYCLOAK_ADMIN_PASSWORD=<strong-unique-value>
 
 One value feeds every consumer that has to agree on it — the backend, the
@@ -69,12 +78,25 @@ Postgres healthcheck, and the MinIO bucket bootstrap — so they cannot drift ap
 
 .. warning::
 
-   ``POSTGRES_USER`` and ``POSTGRES_DB`` are applied **only when the database
-   volume is first initialised**. Setting them against an existing deployment
-   will not rename the role or database: Postgres keeps the old ones while the
-   backend tries to connect with the new, and startup fails. Set them before
-   first start, or recreate the volume (destroying existing data) or issue a
-   manual ``ALTER ROLE`` / ``ALTER DATABASE``.
+   **All three ``POSTGRES_*`` values above are applied only when the database
+   volume is first initialised**, including the password. Changing any of them
+   against an existing deployment does not update PostgreSQL:
+
+   - ``POSTGRES_USER`` / ``POSTGRES_DB`` — the old role and database remain, the
+     backend connects with the new name, and startup fails.
+   - ``POSTGRES_PASSWORD`` — the old password stays active and the new one is
+     silently ignored. This is the more dangerous case, because the deployment
+     looks like it accepted a rotated credential when it did not.
+
+   Set them before first start. To change them afterwards, either recreate the
+   volume (destroying existing data — take a backup first, see
+   :doc:`backup-restore`) or alter the running database and update ``.env`` to
+   match:
+
+   .. code-block:: bash
+
+      docker exec -it tracepcap-postgres psql -U <current-user> -d <current-db> \
+        -c "ALTER ROLE <user> WITH PASSWORD '<new-password>';"
 
 Enable Authentication
 ---------------------

--- a/docs/operations/production-hardening.rst
+++ b/docs/operations/production-hardening.rst
@@ -91,12 +91,23 @@ Postgres healthcheck, and the MinIO bucket bootstrap — so they cannot drift ap
    Set them before first start. To change them afterwards, either recreate the
    volume (destroying existing data — take a backup first, see
    :doc:`backup-restore`) or alter the running database and update ``.env`` to
-   match:
+   match.
+
+   To rotate the password, use ``psql``'s ``\password`` meta-command. It prompts
+   for the value and sends it pre-hashed, so the plaintext never reaches your
+   shell history, the process list, or the server log:
 
    .. code-block:: bash
 
-      docker exec -it tracepcap-postgres psql -U <current-user> -d <current-db> \
-        -c "ALTER ROLE <user> WITH PASSWORD '<new-password>';"
+      docker exec -it tracepcap-postgres psql -U <current-user> -d <current-db>
+
+   .. code-block:: text
+
+      \password <user>
+      \q
+
+   Then set the same value as ``POSTGRES_PASSWORD`` in ``.env`` and restart the
+   backend so it reconnects with the new credential.
 
 Enable Authentication
 ---------------------


### PR DESCRIPTION
## Problem

`docs/operations/production-hardening.rst` was not updated alongside the two credential PRs, so following it now produces a broken or insecure deployment:

| Doc says | Reality after #595 / #607 |
|---|---|
| Edit `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` in `docker-compose.yml` | Credentials come from `.env`; editing compose is no longer the mechanism |
| Set `SPRING_DATASOURCE_PASSWORD` to match | **This variable exists nowhere in the codebase** — the real one is `DATABASE_PASSWORD`, and it is already wired from `POSTGRES_PASSWORD` |
| Keycloak admin default is `user` / `P@ssw0rd` | Removed — the prod overlays now abort if `KEYCLOAK_ADMIN*` is unset |

An operator following the page would either leave credentials unchanged in a file that no longer drives them, or set a variable nothing reads.

## Changes

- Rewrites **Change Default Credentials** around `.env`, listing every required variable with the MinIO 8-character minimum.
- Explains the base-vs-overlay split: base defaults are public and exist for local/CI; the `*-prod.yml` overlays require every credential and abort otherwise.
- Notes that one value feeds every consumer (backend, Postgres healthcheck, MinIO bucket bootstrap), so they cannot drift.
- Corrects the **Enable Authentication** section: no Keycloak admin default; the `analyst` / `analyst` *app* login does still exist and still needs changing.

## Added: the caveat that only shows up as a startup failure

`POSTGRES_USER` and `POSTGRES_DB` apply **only on first volume init**. Setting them against an existing deployment does not rename the role or database — Postgres keeps the old ones while the backend connects with the new, and startup fails.

This was documented in `.env.example` but not on the page an operator reads when hardening a **running** box, which is exactly where it bites.

## Verification

No stale references remain (`P@ssw0rd`, `SPRING_DATASOURCE_PASSWORD`, the compose-editing instruction). Sphinx builds clean.

Docs-only — no code or compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated production deployment guidance to require providing all credentials via `.env` and to fail fast if any required values are missing.
  * Clarified that Keycloak has no default admin credentials and documented `KEYCLOAK_ADMIN`/`KEYCLOAK_ADMIN_PASSWORD` requirements; added instructions to change the seeded demo login.
  * Refined Postgres guidance: documented that backend password derivation prevents drift, removed the now-unneeded separate datasource password entry, and added a Postgres role password rotation example.
  * Clarified that `POSTGRES_USER`/`POSTGRES_DB` only apply during first-time volume initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->