### PR TITLE
fix: Keycloak crash-loops on a fresh volume in the online prod overlay (#612)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,9 +51,16 @@ services:
       # runtime in the admin console survive container restart/recreate. Without
       # this, start-dev keeps its data inside the container and every recreate
       # wipes all users, forcing a re-import of only the realm-export.json seed.
-      # Scoped to the h2 subdir (not all of /opt/keycloak/data) so the named
-      # volume doesn't nest over the realm-export.json bind mount above.
-      - keycloak_data:/opt/keycloak/data/h2
+      #
+      # Mounted at the PARENT (/opt/keycloak/data), not the h2 subdirectory. Docker
+      # copies image content *and ownership* into an empty named volume only when
+      # the mount point exists in the image: /opt/keycloak/data does (owned by uid
+      # 1000, the keycloak user), /opt/keycloak/data/h2 does not. Mounting the
+      # subdirectory left the volume root-owned, so Keycloak — which runs as uid
+      # 1000 — could not write its H2 file and crash-looped on any fresh volume
+      # (#612). The bind mount above is applied on top of this one, so the realm
+      # import is still visible and is not shadowed.
+      - keycloak_data:/opt/keycloak/data
     networks:
       - tracepcap-network
 


### PR DESCRIPTION
## Impact

**The online authenticated deployment cannot start from clean.** Keycloak crash-loops, so nobody can log in. Found while testing an unrelated change against a fresh `docker-compose.prod.yml` stack.

```
ERROR: IO Exception: "/opt/keycloak/data/h2/keycloakdb.mv.db" [90028-230]
ERROR: Could not open file /opt/keycloak/data/h2/keycloakdb.mv.db
```

Container sits in `Restarting (1)` indefinitely.

## Root cause

Docker copies image content **and ownership** into an empty named volume only when the mount point exists in the image:

| Mount point | Exists in image? | Volume owner | Result |
|---|---|---|---|
| `/opt/keycloak/data` (offline-prod) | yes — `drwxrwxr-x 1000 0` | uid 1000 | ✅ works |
| `/opt/keycloak/data/h2` (prod) | **no** | `root:root` | ❌ crash-loop |

Keycloak runs as uid 1000 and cannot write to a root-owned directory. Verified directly:

```
$ docker run --rm -v testvol:/opt/keycloak/data/h2 --entrypoint sh \
    quay.io/keycloak/keycloak:26.0 -c 'ls -land /opt/keycloak/data/h2'
drwxr-xr-x 2 0 0 4096 ... /opt/keycloak/data/h2
```

`docker-compose.offline-prod.yml` mounts the parent and was never affected.

## Fix

Mount the parent directory. The `realm-export.json` bind mount is applied *on top of* the named volume, so it is still visible and not shadowed — which was the concern that motivated scoping to the subdirectory in #564.

## Why it wasn't caught

#564 correctly identified that a named volume over `/opt/keycloak/data` could nest over the realm-import bind mount, and scoped the mount to `h2` to avoid it. But **only a fresh volume triggers the ownership problem** — deployments with an existing `keycloak_data` volume kept working, because that volume predated #564 and already carried uid-1000 ownership.

A new production deployment is precisely the case that fails.

## Verification — both requirements together

**Fresh volume** (`docker volume rm tracepcap_keycloak_data` first):
- ✅ Keycloak starts (`started in 10.205s`)
- ✅ Realm imports from `realm-export.json` — bind mount not shadowed
- ✅ `/realms/tracepcap` returns **200**
- ✅ Volume now uid 1000; `h2/keycloakdb.mv.db` written

**Persistence — the #564 requirement:**
- Created user `persist-test` via `kcadm.sh`
- `docker compose rm -sf keycloak` (destroyed the container)
- Recreated → **user still present**

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)