### PR TITLE
docs: backups are opt-in, and a single feature-toggle reference

### DIFF
--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -56,6 +56,61 @@ directly. Set ``APP_MEMORY_MB`` and everything else scales automatically.
      - ``1g`` / ``2``
      - Keycloak container limits (auth overlays only).
 
+Feature Toggles
+---------------
+
+Every switch that turns a capability on or off, in one place. Each is also
+documented in its own section below with the surrounding detail.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 12 54
+
+   * - Variable
+     - Default
+     - Effect
+   * - ``TRACEPCAP_AUTH_ENABLED``
+     - ``false``
+     - Gates the API behind a Keycloak JWT and adds a login flow. Set to
+       ``true`` by the production overlays; you rarely set it directly. See
+       :doc:`authentication`.
+   * - ``SURICATA_ENABLED``
+     - ``true``
+     - Deployment-wide switch for intrusion-detection enrichment. ``false``
+       skips it for **every** capture regardless of the per-upload toggle.
+       Suricata dominates analysis time, so this is the single biggest
+       throughput lever.
+   * - ``FILE_RETENTION_ENABLED``
+     - ``true``
+     - Master switch for automatic deletion. ``false`` keeps captures
+       indefinitely and the clean-up scheduler is never registered, so no other
+       retention setting has any effect. See :doc:`../operations/production-hardening`.
+   * - ``STUCK_FILE_RECONCILIATION_ENABLED``
+     - ``true``
+     - Scheduled job that flips captures stranded in ``PROCESSING`` to
+       ``FAILED`` after a timeout. Disabling it leaves crashed or
+       restart-interrupted analyses stuck indefinitely.
+   * - ``GEO_FORCE_OFFLINE``
+     - ``false`` / ``true``
+     - Suppresses the ``ipinfo.io`` connectivity probe and lookups, resolving
+       geolocation from the bundled database only. Defaults to ``false`` in the
+       base stack and ``true`` in the offline stack and both production
+       overlays. This is the one intentional outbound call at runtime.
+
+.. note::
+
+   These are **deployment-wide**. Several analysis features also have per-upload
+   toggles in the UI (nDPI, Suricata, file extraction) which apply to a single
+   capture. Where both exist the deployment-wide switch wins: turning Suricata
+   off here skips it even for an upload that requested it.
+
+.. note::
+
+   Two capabilities are switched by configuration rather than a boolean. AI
+   features are governed by ``LLM_API_BASE_URL`` — point it at a reachable local
+   inference server to enable them; the production overlays require it to be set
+   explicitly. Custom detection rules activate when a signatures file is present.
+
 File Retention
 --------------
 

--- a/docs/operations/production-hardening.rst
+++ b/docs/operations/production-hardening.rst
@@ -19,6 +19,7 @@ Any deployment beyond local development must:
 - Enable authentication via the Keycloak overlay where the deployment is shared.
 - **Choose a retention window.** The default deletes captures after 12 hours.
 - **Confirm disk headroom** against that window, with room for backups.
+- **Install the backup timer.** Nothing is backed up until you do.
 
 Each is covered in detail below.
 
@@ -468,6 +469,48 @@ Step 4 — check it, and keep checking
    expiring its snapshots destroys the drift history. On a monitor-heavy
    deployment they are therefore the component that actually accumulates — check
    them first when disk grows unexpectedly.
+
+Set Up Backups
+--------------
+
+.. danger::
+
+   **No backup runs until you install the timer.** ``scripts/backup.sh`` is a
+   standalone script — it is not wired into Docker Compose, the application, or
+   any scheduler. A fresh deployment has no backups at all, however long it has
+   been running.
+
+The scripts and unit files ship in ``scripts/``; installing them is a deliberate
+step:
+
+.. code-block:: bash
+
+   sudo cp scripts/tracepcap-backup.service scripts/tracepcap-backup.timer \
+     /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now tracepcap-backup.timer
+
+Edit ``User``, ``WorkingDirectory`` and ``BACKUP_DIR`` in the ``.service`` file
+first so they match this deployment. Then confirm it is actually scheduled —
+copying the files is not enough on its own:
+
+.. code-block:: bash
+
+   systemctl list-timers tracepcap-backup.timer
+
+Point ``BACKUP_DIR`` at storage on a **different disk** from the deployment. A
+backup on the same disk does not survive that disk failing, which is the main
+thing it exists for.
+
+.. important::
+
+   Rehearse the restore before the deployment holds data you care about. An
+   untested backup is not a backup, and the restore is the one procedure you do
+   not want to be performing for the first time during an incident. The rehearsal
+   is a documented five-step drill in :doc:`backup-restore`.
+
+Full detail — what is captured, recovery objectives, the cron alternative, and
+what is deliberately *not* covered — is in :doc:`backup-restore`.
 
 Restart Policies
 ----------------


### PR DESCRIPTION
## 1. Backups read as automatic, and are not

`scripts/backup.sh` is **standalone**. No compose file, no scheduler and no part of the application invokes it, and the systemd units ship as *files in `scripts/`* rather than installed units.

Verified on a running box: no `tracepcap` timer active, nothing in `/etc/systemd/system`, and the only archives present were ones created by hand during testing.

**A fresh deployment has no backups at all**, however long it has been running — and the hardening guide neither said so nor told anyone to install them.

Adds a **"Set Up Backups"** section leading with that fact, the three install commands, the verification step (copying the files is not enough — confirm with `systemctl list-timers`), and the reminder to point `BACKUP_DIR` at a different disk. Plus a checklist line, since the checklist is what an operator actually works through.

## 2. A single feature-toggle reference

Every on/off switch in one table — previously spread across five sections of the page:

| Variable | Default |
|---|---|
| `TRACEPCAP_AUTH_ENABLED` | `false` |
| `SURICATA_ENABLED` | `true` |
| `FILE_RETENTION_ENABLED` | `true` |
| `STUCK_FILE_RECONCILIATION_ENABLED` | `true` |
| `GEO_FORCE_OFFLINE` | `false` / `true` |

It also records two things that weren't written down: **deployment-wide switches beat the per-upload ones** (turning Suricata off here skips it even for an upload that asked for it), and AI features and custom rules are enabled by *configuration* rather than a boolean.

## What building the table surfaced

The table lists **only toggles that reach the container**. Auditing that found **14 variables the backend reads that no compose file passes** — including `GEO_ENRICHMENT_ENABLED` (fully wired in `GeoIpService`, unreachable) and `CORS_ALLOWED_ORIGINS`, **which the hardening guide tells operators to set**:

```console
$ docker compose -f docker-compose.yml -f docker-compose.prod.yml config | \
    grep -cE "CORS_ALLOWED_ORIGINS|GEO_ENRICHMENT_ENABLED"
0
```

Raised as **#641** rather than documented here — documenting a setting that silently does nothing is exactly how #628 happened.

## Verification

Sphinx builds clean; both new sections render with their anchors (`#set-up-backups`, `#feature-toggles`) and all five toggles present. Confirmed the inert variables are excluded from the table.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)