### PR TITLE
docs: Suricata cost is fixed, not proportional — and make the storage multiplier concrete

### DIFF
--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -78,9 +78,9 @@ documented in its own section below with the surrounding detail.
      - ``true``
      - Deployment-wide switch for intrusion-detection enrichment. ``false``
        skips it for **every** capture regardless of the per-upload toggle.
-       Adds a roughly fixed ~50 s per capture regardless of size, so it is the
-       single biggest throughput lever — and proportionally the most costly on
-       small captures.
+       Adds ~50 s of fixed rule-loading overhead to every capture, on top of
+       packet scanning that scales with size. The fixed floor makes it the
+       biggest throughput lever, and proportionally heaviest on small captures.
    * - ``FILE_RETENTION_ENABLED``
      - ``true``
      - Master switch for automatic deletion. ``false`` keeps captures
@@ -195,9 +195,10 @@ Analysis Queue & Reconciliation
 -------------------------------
 
 Uploaded files are analyzed asynchronously by an in-memory thread pool. Analysis
-is **Suricata-dominated**: it adds roughly **50 s to every file**, and that cost is
-largely *fixed* rather than proportional to capture size, because the full rule set
-is reloaded on each invocation. Throughput is therefore CPU-bound. When the
+is **Suricata-dominated**: it adds roughly **50 s of fixed overhead to every file**,
+because the full rule set is reloaded on each invocation. Packet scanning on top of
+that still scales with capture size, so total analysis time grows — but the 50 s
+floor is paid even by a tiny capture. Throughput is CPU-bound. When the
 pool and its queue are both full the executor applies **back-pressure**: the
 upload request runs the analysis inline and slows down, rather than dropping the
 file. A reconciliation job additionally flips any file left stuck in
@@ -244,10 +245,10 @@ and MinIO) with a queue of a few hundred is a reasonable starting point.
      - ``true``
      - Deployment-wide kill-switch for Suricata IDS enrichment. Set to
        ``false`` to skip Suricata for **every** file regardless of the per-file
-       upload toggle. It adds a roughly fixed ~50 s per capture — the rule set is
-       reloaded each time, so the cost does not scale with capture size. That
-       makes it the single biggest throughput lever, and the dominant share of
-       the work on small captures specifically.
+       upload toggle. It adds ~50 s of fixed overhead per capture — the rule set is
+       reloaded each time — plus packet scanning that does scale with size. On a
+       538 KB test capture the fixed floor alone was ~94% of total analysis time;
+       on a large capture it is a much smaller share.
 
 Nginx
 -----

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -78,8 +78,9 @@ documented in its own section below with the surrounding detail.
      - ``true``
      - Deployment-wide switch for intrusion-detection enrichment. ``false``
        skips it for **every** capture regardless of the per-upload toggle.
-       Suricata dominates analysis time, so this is the single biggest
-       throughput lever.
+       Adds a roughly fixed ~50 s per capture regardless of size, so it is the
+       single biggest throughput lever — and proportionally the most costly on
+       small captures.
    * - ``FILE_RETENTION_ENABLED``
      - ``true``
      - Master switch for automatic deletion. ``false`` keeps captures
@@ -194,7 +195,9 @@ Analysis Queue & Reconciliation
 -------------------------------
 
 Uploaded files are analyzed asynchronously by an in-memory thread pool. Analysis
-is **Suricata-dominated** (~50 s per file), so throughput is CPU-bound. When the
+is **Suricata-dominated**: it adds roughly **50 s to every file**, and that cost is
+largely *fixed* rather than proportional to capture size, because the full rule set
+is reloaded on each invocation. Throughput is therefore CPU-bound. When the
 pool and its queue are both full the executor applies **back-pressure**: the
 upload request runs the analysis inline and slows down, rather than dropping the
 file. A reconciliation job additionally flips any file left stuck in
@@ -241,8 +244,10 @@ and MinIO) with a queue of a few hundred is a reasonable starting point.
      - ``true``
      - Deployment-wide kill-switch for Suricata IDS enrichment. Set to
        ``false`` to skip Suricata for **every** file regardless of the per-file
-       upload toggle. Suricata dominates per-file analysis cost, so disabling it
-       is the single biggest throughput lever.
+       upload toggle. It adds a roughly fixed ~50 s per capture — the rule set is
+       reloaded each time, so the cost does not scale with capture size. That
+       makes it the single biggest throughput lever, and the dominant share of
+       the work on small captures specifically.
 
 Nginx
 -----

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -78,8 +78,8 @@ documented in its own section below with the surrounding detail.
      - ``true``
      - Deployment-wide switch for intrusion-detection enrichment. ``false``
        skips it for **every** capture regardless of the per-upload toggle.
-       Adds ~50 s of fixed rule-loading overhead to every capture, on top of
-       packet scanning that scales with size. The fixed floor makes it the
+       Adds ~50 s of fixed rule-loading overhead to each capture it processes,
+       on top of packet scanning that scales with size. The fixed floor makes it the
        biggest throughput lever, and proportionally heaviest on small captures.
    * - ``FILE_RETENTION_ENABLED``
      - ``true``
@@ -195,8 +195,9 @@ Analysis Queue & Reconciliation
 -------------------------------
 
 Uploaded files are analyzed asynchronously by an in-memory thread pool. Analysis
-is **Suricata-dominated**: it adds roughly **50 s of fixed overhead to every file**,
-because the full rule set is reloaded on each invocation. Packet scanning on top of
+is **Suricata-dominated**: for every capture Suricata processes it adds roughly
+**50 s of fixed overhead**, because the full rule set is reloaded on each
+invocation. Packet scanning on top of
 that still scales with capture size, so total analysis time grows — but the 50 s
 floor is paid even by a tiny capture. Throughput is CPU-bound. When the
 pool and its queue are both full the executor applies **back-pressure**: the
@@ -245,8 +246,9 @@ and MinIO) with a queue of a few hundred is a reasonable starting point.
      - ``true``
      - Deployment-wide kill-switch for Suricata IDS enrichment. Set to
        ``false`` to skip Suricata for **every** file regardless of the per-file
-       upload toggle. It adds ~50 s of fixed overhead per capture — the rule set is
-       reloaded each time — plus packet scanning that does scale with size. On a
+       upload toggle. On each capture it processes it adds ~50 s of fixed overhead —
+       the rule set is reloaded each time — plus packet scanning that does scale
+       with size. On a
        538 KB test capture the fixed floor alone was ~94% of total analysis time;
        on a large capture it is a much smaller share.
 

--- a/docs/getting-started/prerequisites.rst
+++ b/docs/getting-started/prerequisites.rst
@@ -67,9 +67,10 @@ memory-bound.
 .. note::
 
    **Sizing storage from your own workload.** The figures above are starting
-   points. Storage runs to roughly **2.5x the capture volume ingested** (the
-   objects plus a database of comparable size), and how much is held at once is
-   set by the retention window rather than by how long the tool has been running:
+   points. Storage runs to roughly **2.5x the capture volume ingested** — 100 GB
+   of captures needs about 250 GB of disk, being the files themselves plus a
+   database of comparable size. How much is held at once is set by the retention
+   window rather than by how long the tool has been running:
 
    .. code-block:: text
 

--- a/docs/getting-started/prerequisites.rst
+++ b/docs/getting-started/prerequisites.rst
@@ -68,9 +68,9 @@ memory-bound.
 
    **Sizing storage from your own workload.** The figures above are starting
    points. Storage runs to roughly **2.5x the capture volume ingested** — 100 GB
-   of captures needs about 250 GB of disk, being the files themselves plus a
-   database of comparable size. How much is held at once is set by the retention
-   window rather than by how long the tool has been running:
+   of captures needs about 250 GB of disk: the 100 GB of files themselves, plus
+   100–150 GB of database built from them. How much is held at once is set by the
+   retention window rather than by how long the tool has been running:
 
    .. code-block:: text
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Designed for air-gapped and offline deployments — GeoIP lookups use a bundled 
 
    architecture/layers
    architecture/enforcement
+   architecture/adjudication-explainability
 
 .. toctree::
    :maxdepth: 2

--- a/docs/operations/production-hardening.rst
+++ b/docs/operations/production-hardening.rst
@@ -435,9 +435,9 @@ Step 1 — choose a retention window
       never ``FILE_RETENTION_HOURS=0``.
 
 Step 2 — size the disk against that window
-   Storage runs to roughly **2.5x the capture volume ingested** — the objects
-   themselves plus a database of comparable size. With retention on, the working
-   set stops growing:
+   Storage runs to roughly **2.5x the capture volume ingested** — 100 GB of
+   captures needs about 250 GB of disk, being the files themselves plus a database
+   of comparable size. With retention on, the working set stops growing:
 
    .. code-block:: text
 

--- a/docs/operations/production-hardening.rst
+++ b/docs/operations/production-hardening.rst
@@ -437,8 +437,9 @@ Step 1 — choose a retention window
 Step 2 — size the disk against that window
    Storage runs to roughly **2.5x the capture volume ingested** — 100 GB of
    captures needs about 250 GB of disk: the 100 GB of files themselves, plus
-   100–150 GB of database built from them. With retention on, the working set
-   stops growing:
+   100–150 GB of database built from them. With file retention on, the
+   capture-derived working set stops growing (monitor snapshots are exempt — see
+   the note at the end of this section):
 
    .. code-block:: text
 

--- a/docs/operations/production-hardening.rst
+++ b/docs/operations/production-hardening.rst
@@ -436,8 +436,9 @@ Step 1 — choose a retention window
 
 Step 2 — size the disk against that window
    Storage runs to roughly **2.5x the capture volume ingested** — 100 GB of
-   captures needs about 250 GB of disk, being the files themselves plus a database
-   of comparable size. With retention on, the working set stops growing:
+   captures needs about 250 GB of disk: the 100 GB of files themselves, plus
+   100–150 GB of database built from them. With retention on, the working set
+   stops growing:
 
    .. code-block:: text
 

--- a/docs/operations/scalability.rst
+++ b/docs/operations/scalability.rst
@@ -92,9 +92,24 @@ under the PostgreSQL ``max_connections`` default of 100.
 Capacity Planning
 -----------------
 
-Storage consumed is roughly **2.5× the PCAP volume ingested** — the objects
-themselves (1×) plus a database that grows to about 1–1.5× the captures. Use that
-multiplier in both directions.
+Storage consumed is roughly **2.5× the PCAP volume ingested**. Concretely, for
+every 100 GB of captures you put in:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - What it is
+     - Disk needed
+   * - The capture files themselves
+     - 100 GB
+   * - The database they build
+     - 100 – 150 GB
+   * - **Total**
+     - **~250 GB**
+
+Use that multiplier in both directions — to size a disk for a given workload, or
+to work out the retention window a given disk can sustain.
 
 Checking where you stand
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Two figures were stated in a way that reads as more general, or less intelligible, than they are.

## 1. Suricata's 94% is a property of a *small* capture

The source measurement in #453 says it plainly, and I'd flattened it:

> Suricata alone is **~94%** of per-file analysis time, because it reloads the full Emerging Threats ruleset on every `suricata -r` invocation — **a fixed cost independent of pcap size**.

So the ~50 s is **fixed**, not proportional. On the 538 KB test capture that made it 94% of the job. On a large capture the same 50 s is a much smaller share.

The docs said *"Suricata dominates analysis time"* — true for small and medium captures, and **misleading for anyone sizing a large-capture workload**, who would over-estimate what disabling it buys them. #569's own title (*"adds ~60s to every analysis"*) already framed it correctly.

Now stated as a fixed per-capture cost, noting it is proportionally heaviest on small files. Corrected in three places in `environment-variables.rst`.

## 2. The storage figures were accurate but abstract

`2.5×`, `1–1.5×`, `1.5–2M rows per GB` are ratios the reader has to assemble into an actual number. Adds the worked breakdown:

| What it is | Disk needed |
|---|---|
| The capture files themselves | 100 GB |
| The database they build | 100 – 150 GB |
| **Total** | **~250 GB** |

As a table in `scalability.rst`, and inline where the multiplier appears in `prerequisites.rst` and `production-hardening.rst`. The ratios stay for anyone computing their own.

## Verification

Sphinx builds clean; the new table renders with all four rows and both figures.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Suricata’s fixed rule-loading overhead and how scanning time scales with capture size.
  * Added storage-sizing guidance, including a 100 GB capture example requiring approximately 250 GB of disk.
  * Expanded capacity-planning guidance with a breakdown of capture, database, and total storage requirements.
  * Added the adjudication explainability documentation to the Architecture section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->