### PR TITLE
ci: make the API-seam lint rule actually block a merge

### DIFF
--- a/.github/workflows/lint-contract.yml
+++ b/.github/workflows/lint-contract.yml
@@ -1,0 +1,49 @@
+name: Lint Contract Rules
+
+# The blocking half of frontend linting.
+#
+# `lint-frontend.yml` is an auto-fixer: it runs `lint:fix || true` and opens a follow-up PR,
+# so it can never fail a check — and its `push:` trigger is commented out, so it only runs on
+# manual dispatch. That is why the `no-restricted-syntax` rule added in #630 to catch
+# hand-written /api URLs could not stop the very bug it was written for.
+#
+# This job enforces the API-seam rules only (eslint.contract.config.js). It is green today, so
+# it can block from the first run, unlike the full rule set which still carries pre-existing
+# react-hooks/TypeScript errors. See #659.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/lint-contract.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: ESLint (API contract rules)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # No `|| true`: a violation here fails the check and blocks the merge. That is the point.
+      - name: Enforce API contract lint rules
+        run: npm run lint:contract

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -4,9 +4,17 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
+import { contractRuleExemptions, noHardCodedApiUrls } from './eslint.contract.js'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores([
+    'dist',
+    // Generated build/report output. Flat config does not read .gitignore, so these must be
+    // listed or ESLint walks into the coverage HTML report's own bundled scripts (#659).
+    'coverage',
+    'playwright-report',
+    'test-results',
+  ]),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -20,35 +28,13 @@ export default defineConfig([
       globals: globals.browser,
     },
     rules: {
-      // Hand-written "/api/..." URLs drift from the backend's routes: they skip both apiClient's
-      // baseURL and the endpoints.ts map, so nothing checks them against the API contract. That is
-      // how extracted-file downloads shipped pointing at "/api/files/..." — missing the /api/v1
-      // version segment, 404ing on every click. Route direct-navigation URLs (anchor href, img/
-      // video src) through directApiUrl(); everything else goes through apiClient.
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'Literal[value=/^\\u002Fapi(\\u002F|$)/]',
-          message:
-            'Do not hard-code /api URLs. Use apiClient (adds the base URL) or directApiUrl() from @/services/api/directUrl for URLs the browser fetches directly.',
-        },
-        {
-          selector: 'TemplateElement[value.raw=/^\\u002Fapi(\\u002F|$)/]',
-          message:
-            'Do not hard-code /api URLs. Use apiClient (adds the base URL) or directApiUrl() from @/services/api/directUrl for URLs the browser fetches directly.',
-        },
-      ],
+      // Definition lives in eslint.contract.js so the blocking CI job (lint:contract)
+      // enforces exactly this rule, with no chance of the two configs drifting.
+      'no-restricted-syntax': noHardCodedApiUrls,
     },
   },
   {
-    // directUrl.ts defines the prefix; the API tests and e2e specs assert on and intercept real
-    // URLs; vite.config.ts's "/api" is a dev-proxy mount path, not a request URL.
-    files: [
-      'src/services/api/directUrl.ts',
-      'src/services/api/__tests__/**',
-      'e2e/**',
-      'vite.config.ts',
-    ],
+    files: contractRuleExemptions,
     rules: { 'no-restricted-syntax': 'off' },
   },
 ])

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -4,17 +4,14 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
-import { contractRuleExemptions, noHardCodedApiUrls } from './eslint.contract.js'
+import {
+  contractRuleExemptions,
+  generatedOutputIgnores,
+  noHardCodedApiUrls,
+} from './eslint.contract.js'
 
 export default defineConfig([
-  globalIgnores([
-    'dist',
-    // Generated build/report output. Flat config does not read .gitignore, so these must be
-    // listed or ESLint walks into the coverage HTML report's own bundled scripts (#659).
-    'coverage',
-    'playwright-report',
-    'test-results',
-  ]),
+  globalIgnores(generatedOutputIgnores),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/frontend/eslint.contract.config.js
+++ b/frontend/eslint.contract.config.js
@@ -1,0 +1,54 @@
+// Blocking lint config: the API-seam rules only.
+//
+// `npm run lint:contract`, run by lint-contract.yml on every PR. Deliberately narrower
+// than eslint.config.js: it enforces the rules that guard the frontend<->backend contract
+// and nothing else, so it is green today and can block merges from day one.
+//
+// The full rule set stays advisory until the pre-existing react-hooks/TypeScript errors
+// are cleared, at which point this file folds back into eslint.config.js (#659).
+
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import { defineConfig, globalIgnores } from 'eslint/config'
+import tseslint from 'typescript-eslint'
+import { contractRuleExemptions, noHardCodedApiUrls } from './eslint.contract.js'
+
+export default defineConfig([
+  globalIgnores([
+    'dist',
+    // Generated build/report output. Flat config does not read .gitignore, so these must be
+    // listed or ESLint walks into the coverage HTML report's own bundled scripts (#659).
+    'coverage',
+    'playwright-report',
+    'test-results',
+  ]),
+  {
+    files: ['**/*.{ts,tsx}'],
+    // Parser only — no `extends`, so none of the recommended rule sets come along and the
+    // job reports contract violations exclusively. The plugins are still registered (without
+    // enabling their rules) because source files carry inline `eslint-disable` comments for
+    // them, and an unregistered rule name is itself an error.
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+      parser: tseslint.parser,
+    },
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+      'react-hooks': reactHooks,
+    },
+    // Those plugins' rules are registered but not enabled, so every inline disable comment
+    // for them looks unused here. That is expected, not a finding — eslint.config.js is
+    // where unused directives are worth reporting.
+    linterOptions: {
+      reportUnusedDisableDirectives: 'off',
+    },
+    rules: {
+      'no-restricted-syntax': noHardCodedApiUrls,
+    },
+  },
+  {
+    files: contractRuleExemptions,
+    rules: { 'no-restricted-syntax': 'off' },
+  },
+])

--- a/frontend/eslint.contract.config.js
+++ b/frontend/eslint.contract.config.js
@@ -11,17 +11,14 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import tseslint from 'typescript-eslint'
-import { contractRuleExemptions, noHardCodedApiUrls } from './eslint.contract.js'
+import {
+  contractRuleExemptions,
+  generatedOutputIgnores,
+  noHardCodedApiUrls,
+} from './eslint.contract.js'
 
 export default defineConfig([
-  globalIgnores([
-    'dist',
-    // Generated build/report output. Flat config does not read .gitignore, so these must be
-    // listed or ESLint walks into the coverage HTML report's own bundled scripts (#659).
-    'coverage',
-    'playwright-report',
-    'test-results',
-  ]),
+  globalIgnores(generatedOutputIgnores),
   {
     files: ['**/*.{ts,tsx}'],
     // Parser only — no `extends`, so none of the recommended rule sets come along and the

--- a/frontend/eslint.contract.js
+++ b/frontend/eslint.contract.js
@@ -6,9 +6,14 @@
 // everything would be red from the first run and get switched off. These rules block
 // today; the rest become blocking as the backlog clears (#659).
 
+// Generated build/report output. Flat config does not read .gitignore, so these must be
+// listed or ESLint walks into the coverage HTML report's own bundled scripts (#659).
+// Shared for the same reason the rule is: two copies drift.
+export const generatedOutputIgnores = ['dist', 'coverage', 'playwright-report', 'test-results']
+
 const message =
   'Do not hard-code /api URLs. Use apiClient (adds the base URL) or directApiUrl() from ' +
-  '@/services/api/directUrl for URLs the browser fetches directly.';
+  '@/services/api/directUrl for URLs the browser fetches directly.'
 
 // Hand-written "/api/..." URLs drift from the backend's routes: they skip both apiClient's
 // baseURL and the endpoints.ts map, so nothing checks them against the API contract. That is
@@ -25,7 +30,7 @@ export const noHardCodedApiUrls = [
     selector: 'TemplateElement[value.raw=/^\\u002Fapi(\\u002F|$)/]',
     message,
   },
-];
+]
 
 // directUrl.ts defines the prefix; the API tests and e2e specs assert on and intercept real
 // URLs; vite.config.ts's "/api" is a dev-proxy mount path, not a request URL.
@@ -34,4 +39,4 @@ export const contractRuleExemptions = [
   'src/services/api/__tests__/**',
   'e2e/**',
   'vite.config.ts',
-];
+]

--- a/frontend/eslint.contract.js
+++ b/frontend/eslint.contract.js
@@ -1,0 +1,37 @@
+// Contract rules: the lint rules that guard the frontend<->backend API seam.
+//
+// Split out of eslint.config.js so CI can enforce *these* without also enforcing the
+// full rule set. `lint-frontend.yml` is an auto-fixer that cannot fail a build, and the
+// repo carries pre-existing react-hooks/TypeScript errors, so a blocking job over
+// everything would be red from the first run and get switched off. These rules block
+// today; the rest become blocking as the backlog clears (#659).
+
+const message =
+  'Do not hard-code /api URLs. Use apiClient (adds the base URL) or directApiUrl() from ' +
+  '@/services/api/directUrl for URLs the browser fetches directly.';
+
+// Hand-written "/api/..." URLs drift from the backend's routes: they skip both apiClient's
+// baseURL and the endpoints.ts map, so nothing checks them against the API contract. That is
+// how extracted-file downloads shipped pointing at "/api/files/..." — missing the /api/v1
+// version segment, 404ing on every click. Route direct-navigation URLs (anchor href, img/
+// video src) through directApiUrl(); everything else goes through apiClient.
+export const noHardCodedApiUrls = [
+  'error',
+  {
+    selector: 'Literal[value=/^\\u002Fapi(\\u002F|$)/]',
+    message,
+  },
+  {
+    selector: 'TemplateElement[value.raw=/^\\u002Fapi(\\u002F|$)/]',
+    message,
+  },
+];
+
+// directUrl.ts defines the prefix; the API tests and e2e specs assert on and intercept real
+// URLs; vite.config.ts's "/api" is a dev-proxy mount path, not a request URL.
+export const contractRuleExemptions = [
+  'src/services/api/directUrl.ts',
+  'src/services/api/__tests__/**',
+  'e2e/**',
+  'vite.config.ts',
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:contract": "eslint . -c eslint.contract.config.js",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,scss,md}\"",
     "lint:css": "stylelint \"src/**/*.css\"",
     "lint:css:fix": "stylelint \"src/**/*.css\" --fix",


### PR DESCRIPTION
Part of #659 (phase 1). Does **not** close it.

## Summary

[#630](https://github.com/NotYuSheng/TracePcap/pull/630) added a `no-restricted-syntax` rule banning hand-written `"/api"` URLs — the exact shape the broken download URL was written in — and noted it was advisory. It is more inert than that: **it has never run automatically on a pull request.**

`lint-frontend.yml` runs `lint:fix || true` and opens a follow-up PR, so it cannot fail a check. Its `push:` trigger is also commented out, leaving `workflow_dispatch` as the only trigger. The rule written to catch that bug class could not have caught it.

## Why only the contract rules block

The repo carries **61 pre-existing ESLint errors** (30 `react-hooks/set-state-in-effect`, 10 `react-hooks/static-components`, 8 `no-explicit-any`, …). A blocking job over the full rule set would be red on its first run and get switched off — which is how the current advisory setup came about.

So the API-seam rules split out and block on their own. They are green today. The rest become blocking as that backlog clears.

## Changes

- **`eslint.contract.js`** — the rule definition and its exemption list, imported by *both* configs so the blocking job and the everyday one cannot drift apart.
- **`eslint.contract.config.js`** — enables only that rule. It registers the `typescript-eslint` and `react-hooks` plugins *without* enabling their rules, because source files carry inline `eslint-disable` comments for them and an unregistered rule name is itself an error.
- **`lint-contract.yml`** — runs `npm run lint:contract` on every frontend PR. No `|| true`.
- **`globalIgnores`** — ESLint flat config does not read `.gitignore`, so it was walking into `frontend/coverage/` (the report directory #660 introduced) and linting the HTML report's own bundled scripts. Added `coverage/`, `playwright-report/`, `test-results/`.

## Two planned items dropped after checking the code

Detail in [this comment](https://github.com/NotYuSheng/TracePcap/issues/659#issuecomment-5268527972).

- **Deleting five dead endpoints — already done.** I had written that from #630's PR description, which described an intermediate state. As merged, `FIVE_WS`/`KILL_CHAIN`/`SNAPSHOT_BASELINE` are gone and both `TIMELINE_*` endpoints resolve to real routes in the baseline. `KNOWN_MISSING_ROUTES` is `{}`.
- **Method + path assertions — folded into codegen.** Only ~15 of 57 `apiClient.*` calls match a scannable pattern, so a regex checker would cover a quarter of call sites while looking comprehensive. It is also the lower-value half: a wrong method 405s in dev, a wrong path 404s silently for months. Typed call sites solve both properly.

## Test plan

- [x] Probe file confirms the rule fires on both forms: `'/api/files/x/download'` (Literal) and `` `/api/v1/files/${x}/download` `` (TemplateElement) — 2 errors
- [x] `npm run lint:contract` → exit 0 on the current tree, so it can block from the first run
- [x] Full `npm run lint` unchanged at 61 errors; warnings 9 → 3 (the coverage-dir noise)
- [x] 246 tests pass, `npx tsc --noEmit` and `npm run typecheck:test` clean
- [x] `docker compose up -d --build` succeeded; stack serves HTTP 200 on `:8888`
- [x] `lint-contract.yml` parses; triggers on `pull_request` + `workflow_dispatch`
- [x] Reverted an unrelated `js-yaml` 4.1.1→4.3.1 lockfile bump that leaked in while probing `openapi-typescript`; `npm ci` confirms the restored lockfile matches

## Follow-ups

- The 61 pre-existing errors, tracked so `eslint.contract.config.js` can fold back into `eslint.config.js`
- `lint-frontend.yml`'s commented-out `push:` trigger — left alone here rather than changed blind, since re-enabling an auto-commit-and-push job deserves its own decision
- Codegen from `openapi/baseline.json`, as its own PR: committing generated types with no consumer would repeat the "harness built but never used" pattern the audit flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)