### PR TITLE
ci: delete branches when a PR closes unmerged, and when a bump strands one

### DIFF
--- a/.github/workflows/app-version.yml
+++ b/.github/workflows/app-version.yml
@@ -81,6 +81,10 @@ jobs:
           fi
 
           BRANCH="chore/sync-version-${VERSION}"
+          # Export so the cleanup step below can reach it. The branch is pushed before the
+          # PR exists, so every failure between here and the merge would otherwise strand it
+          # on the remote with no PR — and with no PR, delete-branch-on-close.yml never fires.
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -128,3 +132,22 @@ jobs:
 
           echo "::error::Could not merge $PR_URL after 5 attempts — it needs a look."
           exit 1
+
+      # Only reached when the step above failed, which means the PR did not merge and
+      # `gh pr merge --delete-branch` never ran. Without this the branch is stranded on the
+      # remote: the merge path is the only thing that deletes it, and if the PR was never
+      # created there is no pull_request event for delete-branch-on-close.yml to act on
+      # either. This is the one branch-leak route neither of those covers.
+      - name: Remove the bump branch if it never merged
+        if: failure() && env.BRANCH != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Close any open PR first so it does not linger pointing at a deleted branch.
+          gh pr close "$BRANCH" --delete-branch 2>/dev/null && exit 0
+
+          if gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${BRANCH}"; then
+            echo "Removed stranded branch $BRANCH"
+          else
+            echo "Nothing to remove for $BRANCH."
+          fi

--- a/.github/workflows/delete-branch-on-close.yml
+++ b/.github/workflows/delete-branch-on-close.yml
@@ -1,0 +1,43 @@
+name: Delete Branch On Close
+
+# The repo setting "Automatically delete head branches" only fires on **merge**. A PR
+# closed without merging keeps its branch forever, which is how the repo accumulated
+# seven stale chore/sync-version-* branches. This covers the other half.
+#
+# Deleting is safe: GitHub keeps a "Restore branch" button on the closed PR, so a branch
+# removed here can be brought back from the PR page with one click.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete:
+    name: Delete the head branch
+    runs-on: ubuntu-latest
+
+    # Merged PRs are already handled by delete_branch_on_merge — acting on them too would
+    # race that setting and log spurious failures. Fork branches live in another repo and
+    # cannot be deleted with this token.
+    if: >-
+      github.event.pull_request.merged == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Delete the head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          # A 422 here means the branch is protected, and a 404 means it is already gone
+          # (someone ticked "delete branch" in the UI first). Neither is a failure worth
+          # failing the run over, so report and move on.
+          if gh api -X DELETE "repos/${REPO}/git/refs/heads/${BRANCH}"; then
+            echo "Deleted ${BRANCH}"
+          else
+            echo "Could not delete ${BRANCH} — already removed, or protected. Leaving it."
+          fi

--- a/.github/workflows/delete-branch-on-close.yml
+++ b/.github/workflows/delete-branch-on-close.yml
@@ -1,8 +1,12 @@
 name: Delete Branch On Close
 
 # The repo setting "Automatically delete head branches" only fires on **merge**. A PR
-# closed without merging keeps its branch forever, which is how the repo accumulated
-# seven stale chore/sync-version-* branches. This covers the other half.
+# closed *without* merging keeps its branch forever, and nothing in the repo cleaned those
+# up. This covers that half.
+#
+# (The seven stale chore/sync-version-* branches removed alongside this workflow were a
+# different problem: they belonged to PRs that had merged before that setting was enabled
+# on 11 Aug. Merge-time deletion works and is untouched here.)
 #
 # Deleting is safe: GitHub keeps a "Restore branch" button on the closed PR, so a branch
 # removed here can be brought back from the PR page with one click.


### PR DESCRIPTION
Seven `chore/sync-version-*` branches were lingering on the remote, the oldest from 28 Jul — including `chore/sync-version-v0.1.1-228-gd8ca0c0`.

## What was actually wrong

All seven belonged to PRs that had **merged**. The cause was timing, not a bug: the repo's **Automatically delete head branches** setting was switched on partway through 11 Aug.

| PR | merged | branch |
|---|---|---|
| #643 | 10 Aug 16:57 | lingered |
| #651 | 11 Aug **06:41:03** | lingered |
| #654 | 11 Aug **06:46:30** | deleted |
| #655, #657, #661 | later | deleted |

Five minutes apart. Everything merged before the flip kept its branch; everything after was cleaned automatically.

**So merge-time deletion already works and needs no change.** The seven stale branches have been deleted directly — they were all merged, with their content on `main`, so nothing was lost.

## The two routes that setting does not cover

Both leak branches, and neither is fixed by the repo setting:

**1. A PR closed without merging keeps its branch forever.** GitHub's setting fires on merge only. `delete-branch-on-close.yml` handles that half. It skips merged PRs (already covered — acting on them races the setting and logs spurious failures) and fork branches (not deletable with this token). Deletion is recoverable: a closed PR keeps a **Restore branch** button, one click.

**2. `app-version.yml` pushes the bump branch before the PR exists.** Any failure between `git push` and the merge strands the branch with no PR at all — and with no PR, no `pull_request` event ever fires, so the workflow above cannot help either. `BRANCH` is now exported to `GITHUB_ENV` and a `if: failure()` step removes it. This is the one leak route neither of the other two mechanisms covers.

## Test plan

- [x] All 7 stale branches deleted; `git/matching-refs/heads/chore` now returns empty
- [x] Both workflow YAMLs parse; step lists verified
- [x] Cutover timing confirmed against the GitHub API (`merged_at` vs. ref existence per PR)
- [ ] `delete-branch-on-close.yml` fires on its first closed-unmerged PR — cannot be exercised before merge, since workflows run from the default branch for `pull_request` events

## Note

The cleanup step in `app-version.yml` is failure-only, so it will not run in the normal path. If you would rather see it exercised, closing this PR unmerged after it lands would test `delete-branch-on-close.yml` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)