### PR TITLE
test: enforce the REST conventions across all 29 controllers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,10 +80,15 @@ full HTML report as an artifact, retained 14 days.
 
 | Suite | Metric | Coverage |
 |---|---|---|
-| Backend | Instructions | 21.00% |
-| Backend | Branches | 13.85% |
+| Backend | Instructions | 19.41% |
+| Backend | Branches | 12.24% |
 | Frontend | Statements | 3.23% |
 | Frontend | Branches | 2.28% |
+
+Backend figures are 195 tests on `main`. An earlier revision of this table read 21.00% /
+13.85%: that run was measured on a branch cut from an unmerged feature branch, so it counted
+26 tests that are not on `main`. Measure baselines from `main`, not from whatever happens to
+be checked out.
 
 ### What is excluded, and why
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,22 +73,9 @@ cd frontend && npm run test:coverage
 #   HTML: frontend/coverage/index.html
 ```
 
-CI prints a summary table on every PR (see the run's **Summary** tab) and uploads the
-full HTML report as an artifact, retained 14 days.
-
-### Baseline (Aug 2026)
-
-| Suite | Metric | Coverage |
-|---|---|---|
-| Backend | Instructions | 19.41% |
-| Backend | Branches | 12.24% |
-| Frontend | Statements | 3.23% |
-| Frontend | Branches | 2.28% |
-
-Backend figures are 195 tests on `main`. An earlier revision of this table read 21.00% /
-13.85%: that run was measured on a branch cut from an unmerged feature branch, so it counted
-26 tests that are not on `main`. Measure baselines from `main`, not from whatever happens to
-be checked out.
+CI prints a summary table on every PR (see the run's **Summary** tab) and uploads the full
+HTML report as an artifact, retained 14 days. That is deliberately the only place the numbers
+live — a figure copied into this file goes stale the moment anyone merges, and one did.
 
 ### What is excluded, and why
 

--- a/backend/src/test/java/com/tracepcap/architecture/ControllerContractTest.java
+++ b/backend/src/test/java/com/tracepcap/architecture/ControllerContractTest.java
@@ -81,7 +81,7 @@ class ControllerContractTest {
               new ArchCondition<>("not hard-code the /api or version prefix") {
                 @Override
                 public void check(JavaClass item, ConditionEvents events) {
-                  for (String path : requestMappingPaths(item)) {
+                  for (String path : allDeclaredPaths(item)) {
                     if (path.startsWith("/api") || path.matches("/v[0-9]+(/.*)?")) {
                       events.add(
                           SimpleConditionEvent.violated(
@@ -106,7 +106,10 @@ class ControllerContractTest {
               new ArchCondition<>("use kebab-case resource paths") {
                 @Override
                 public void check(JavaClass item, ConditionEvents events) {
-                  for (String path : requestMappingPaths(item)) {
+                  // Class-level @RequestMapping and every method-level mapping. Checking only
+                  // the class prefix would let @GetMapping("/dnsServers") through — the 70
+                  // method-level paths are where most of the surface actually is.
+                  for (String path : allDeclaredPaths(item)) {
                     if (!path.isEmpty() && !KEBAB_PATH.matcher(path).matches()) {
                       events.add(
                           SimpleConditionEvent.violated(
@@ -205,6 +208,43 @@ class ControllerContractTest {
     List<String> declared =
         mapping.value().length > 0 ? List.of(mapping.value()) : List.of(mapping.path());
     return declared.stream().filter(p -> !p.isEmpty()).toList();
+  }
+
+  /** Class-level {@code @RequestMapping} paths plus every method-level mapping path. */
+  private static List<String> allDeclaredPaths(JavaClass javaClass) {
+    return java.util.stream.Stream.concat(
+            requestMappingPaths(javaClass).stream(),
+            javaClass.getMethods().stream().flatMap(m -> methodMappingPaths(m).stream()))
+        .toList();
+  }
+
+  /** The paths declared on a handler's mapping annotation, or empty when it maps the root. */
+  private static List<String> methodMappingPaths(JavaMethod method) {
+    if (method.isAnnotatedWith(GetMapping.class)) {
+      GetMapping a = method.getAnnotationOfType(GetMapping.class);
+      return nonEmpty(a.value().length > 0 ? a.value() : a.path());
+    }
+    if (method.isAnnotatedWith(PostMapping.class)) {
+      PostMapping a = method.getAnnotationOfType(PostMapping.class);
+      return nonEmpty(a.value().length > 0 ? a.value() : a.path());
+    }
+    if (method.isAnnotatedWith(PutMapping.class)) {
+      PutMapping a = method.getAnnotationOfType(PutMapping.class);
+      return nonEmpty(a.value().length > 0 ? a.value() : a.path());
+    }
+    if (method.isAnnotatedWith(PatchMapping.class)) {
+      PatchMapping a = method.getAnnotationOfType(PatchMapping.class);
+      return nonEmpty(a.value().length > 0 ? a.value() : a.path());
+    }
+    if (method.isAnnotatedWith(DeleteMapping.class)) {
+      DeleteMapping a = method.getAnnotationOfType(DeleteMapping.class);
+      return nonEmpty(a.value().length > 0 ? a.value() : a.path());
+    }
+    return List.of();
+  }
+
+  private static List<String> nonEmpty(String[] paths) {
+    return java.util.Arrays.stream(paths).filter(p -> !p.isEmpty()).toList();
   }
 
   /**

--- a/backend/src/test/java/com/tracepcap/architecture/ControllerContractTest.java
+++ b/backend/src/test/java/com/tracepcap/architecture/ControllerContractTest.java
@@ -1,0 +1,229 @@
+package com.tracepcap.architecture;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaParameterizedType;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Enforces the REST conventions in {@code CLAUDE.md} across every controller at once.
+ *
+ * <p><b>These rules are green, not frozen</b> — unlike {@link LayerDependencyTest}. The codebase
+ * already satisfies them, so they block from the first run and there is no violation store to
+ * shrink. That is the whole point: 29 controllers had no test of any kind, and the conventions were
+ * enforced only by whoever happened to review the PR.
+ *
+ * <p>One file covers all 29 controllers <em>and every controller anyone adds later</em>, which is
+ * why this comes before per-controller {@code @WebMvcTest} slices (#659).
+ *
+ * <p>The version-prefix rule is the backend half of the defect in #630: the frontend built {@code
+ * /api/files/...} while every route actually lives under {@code /api/v1}. The prefix is applied
+ * centrally in {@code WebConfig.configurePathMatch}, so a controller that hard-codes it would be
+ * served at {@code /api/v1/api/v1/...} — silently unreachable.
+ */
+@AnalyzeClasses(
+    packages = "com.tracepcap",
+    importOptions = {ImportOption.DoNotIncludeTests.class})
+class ControllerContractTest {
+
+  private static final List<Class<? extends java.lang.annotation.Annotation>> MAPPINGS =
+      List.of(
+          GetMapping.class,
+          PostMapping.class,
+          PutMapping.class,
+          PatchMapping.class,
+          DeleteMapping.class);
+
+  /**
+   * Lowercase segments, hyphen-separated, plus {@code {pathVariables}}. Rejects camelCase,
+   * snake_case and stray uppercase — {@code /nodeRoles} instead of {@code /node-roles}.
+   */
+  private static final Pattern KEBAB_PATH =
+      Pattern.compile("(/(\\{[A-Za-z][A-Za-z0-9]*}|[a-z0-9]+(-[a-z0-9]+)*))+");
+
+  private static final DescribedPredicate<JavaClass> REST_CONTROLLERS =
+      new DescribedPredicate<>("REST controllers") {
+        @Override
+        public boolean test(JavaClass javaClass) {
+          return javaClass.isAnnotatedWith(RestController.class);
+        }
+      };
+
+  /**
+   * Controllers declare version-agnostic paths; {@code WebConfig.API_PREFIX} supplies {@code
+   * /api/v1} centrally. Hard-coding it here double-prefixes the route.
+   */
+  @ArchTest
+  static final ArchRule controllers_declare_version_agnostic_paths =
+      ArchRuleDefinition.classes()
+          .that(REST_CONTROLLERS)
+          .should(
+              new ArchCondition<>("not hard-code the /api or version prefix") {
+                @Override
+                public void check(JavaClass item, ConditionEvents events) {
+                  for (String path : requestMappingPaths(item)) {
+                    if (path.startsWith("/api") || path.matches("/v[0-9]+(/.*)?")) {
+                      events.add(
+                          SimpleConditionEvent.violated(
+                              item,
+                              item.getName()
+                                  + " maps \""
+                                  + path
+                                  + "\": the /api/v1 prefix is applied centrally in WebConfig,"
+                                  + " so this route would be served at /api/v1"
+                                  + path));
+                    }
+                  }
+                }
+              });
+
+  /** Resource paths are lowercase kebab-case (CLAUDE.md: plural kebab-case nouns). */
+  @ArchTest
+  static final ArchRule controller_paths_are_kebab_case =
+      ArchRuleDefinition.classes()
+          .that(REST_CONTROLLERS)
+          .should(
+              new ArchCondition<>("use kebab-case resource paths") {
+                @Override
+                public void check(JavaClass item, ConditionEvents events) {
+                  for (String path : requestMappingPaths(item)) {
+                    if (!path.isEmpty() && !KEBAB_PATH.matcher(path).matches()) {
+                      events.add(
+                          SimpleConditionEvent.violated(
+                              item,
+                              item.getName()
+                                  + " maps \""
+                                  + path
+                                  + "\": resource paths are lowercase kebab-case"
+                                  + " (/node-roles, not /nodeRoles)"));
+                    }
+                  }
+                }
+              });
+
+  /** Every controller carries an OpenAPI {@code @Tag}; Swagger UI groups by it. */
+  @ArchTest
+  static final ArchRule controllers_are_tagged_for_openapi =
+      ArchRuleDefinition.classes()
+          .that(REST_CONTROLLERS)
+          .should()
+          .beAnnotatedWith(Tag.class)
+          .because("every controller has a @Tag (CLAUDE.md API conventions)");
+
+  /** Every handler method carries an {@code @Operation}, so the generated spec documents it. */
+  @ArchTest
+  static final ArchRule handler_methods_document_an_operation =
+      ArchRuleDefinition.classes()
+          .that(REST_CONTROLLERS)
+          .should(
+              new ArchCondition<>("annotate every handler method with @Operation") {
+                @Override
+                public void check(JavaClass item, ConditionEvents events) {
+                  for (JavaMethod method : item.getMethods()) {
+                    if (isHandler(method) && !method.isAnnotatedWith(Operation.class)) {
+                      events.add(
+                          SimpleConditionEvent.violated(
+                              item,
+                              method.getFullName()
+                                  + " is a request handler without @Operation:"
+                                  + " it would be undocumented in the OpenAPI spec,"
+                                  + " which openapi/baseline.json snapshots"));
+                    }
+                  }
+                }
+              });
+
+  /**
+   * Controllers return DTOs, never JPA entities.
+   *
+   * <p>Returning an entity leaks the schema into the API: every column rename becomes a breaking
+   * contract change, and lazy associations serialise unpredictably. Checks the type arguments of
+   * {@code ResponseEntity<T>} as well as the bare return type — nested enums declared on an entity
+   * (e.g. {@code FileEntity.FileSource}) are fine as query parameters and are not flagged, because
+   * only the returned type is inspected.
+   */
+  @ArchTest
+  static final ArchRule controllers_return_dtos_not_entities =
+      ArchRuleDefinition.classes()
+          .that(REST_CONTROLLERS)
+          .should(
+              new ArchCondition<>("not return JPA entities") {
+                @Override
+                public void check(JavaClass item, ConditionEvents events) {
+                  for (JavaMethod method : item.getMethods()) {
+                    if (!isHandler(method)) {
+                      continue;
+                    }
+                    for (JavaClass returned : returnedTypes(method)) {
+                      if (returned.getPackageName().endsWith(".entity")) {
+                        events.add(
+                            SimpleConditionEvent.violated(
+                                item,
+                                method.getFullName()
+                                    + " returns "
+                                    + returned.getName()
+                                    + ": controllers return DTOs, so a column rename does not"
+                                    + " become a breaking API change"));
+                      }
+                    }
+                  }
+                }
+              });
+
+  // --- helpers ---------------------------------------------------------------
+
+  private static boolean isHandler(JavaMethod method) {
+    return MAPPINGS.stream().anyMatch(method::isAnnotatedWith);
+  }
+
+  /** The paths declared on the class-level {@code @RequestMapping}, or empty when absent. */
+  private static List<String> requestMappingPaths(JavaClass javaClass) {
+    if (!javaClass.isAnnotatedWith(RequestMapping.class)) {
+      return List.of();
+    }
+    RequestMapping mapping = javaClass.getAnnotationOfType(RequestMapping.class);
+    List<String> declared =
+        mapping.value().length > 0 ? List.of(mapping.value()) : List.of(mapping.path());
+    return declared.stream().filter(p -> !p.isEmpty()).toList();
+  }
+
+  /**
+   * The concrete types a handler can serialise: the raw return type, plus the type arguments of a
+   * generic wrapper such as {@code ResponseEntity<PagedResponse<FileMetadataDto>>} (recursively, so
+   * the DTO inside a nested wrapper is reached).
+   */
+  private static List<JavaClass> returnedTypes(JavaMethod method) {
+    return flatten(method.getReturnType());
+  }
+
+  private static List<JavaClass> flatten(JavaType type) {
+    JavaClass raw = type.toErasure();
+    if (!(type instanceof JavaParameterizedType parameterized)) {
+      return List.of(raw);
+    }
+    return java.util.stream.Stream.concat(
+            java.util.stream.Stream.of(raw),
+            parameterized.getActualTypeArguments().stream().flatMap(t -> flatten(t).stream()))
+        .toList();
+  }
+}


### PR DESCRIPTION
Phase 2 of #659. Does **not** close it.

## The gap

The audit found **29 controllers with no test of any kind**. `CLAUDE.md` states precise, testable API invariants — version-agnostic paths, plural kebab-case nouns, `PagedResponse`/`ErrorResponse` envelopes, DTOs never entities, `@Tag`/`@Operation` on everything — and nothing enforced any of them but whoever reviewed the PR.

## Why ArchUnit before `@WebMvcTest`

One file covers all 29 controllers **and every controller anyone adds later**. Twenty-nine `@WebMvcTest` classes would cover 29 controllers and nothing else. The slices are still worth writing for controllers with real validation/pagination logic — that is the next item in Phase 2 — but this is the higher-leverage half.

Unlike `LayerDependencyTest`, these rules are **green, not frozen**. The codebase already satisfies them, so they block from the first run and there is no violation store to shrink.

## The five rules

| Rule | Guards against |
|---|---|
| Version-agnostic paths | The backend half of #630. `WebConfig` applies `/api/v1` centrally, so a controller hard-coding it would be served at `/api/v1/api/v1/...` — silently unreachable |
| Kebab-case paths | `/nodeRoles` instead of `/node-roles` |
| `@Tag` per controller | Swagger UI grouping |
| `@Operation` per handler | All 118 handlers. An undocumented one corrupts the `openapi/baseline.json` snapshot, which the frontend contract tests are checked against |
| No JPA entity returned | A column rename becoming a breaking API change; lazy associations serialising unpredictably |

## Every rule proven to fail

Following the lesson from #668, where two type-level assertions shipped tautological. Each rule was violated, observed to fail, and reverted:

| Injected violation | Result |
|---|---|
| `@RequestMapping("/api/v1/node-roles")` | 1 failure — *"the /api/v1 prefix is applied centrally in WebConfig"* |
| `@RequestMapping("/nodeRoles")` | 1 failure — *"resource paths are lowercase kebab-case"* |
| `@Tag` removed | 1 failure |
| One `@Operation` removed | 1 failure — *"is a request handler without @Operation"* |
| Added `ResponseEntity<HostIdentityEntity>` handler | 1 failure — *"returns …HostIdentityEntity: controllers return DTOs"* |

The entity rule walks generic type arguments recursively, so it catches the entity *inside* `ResponseEntity<...>` rather than only a bare return type — while still allowing nested entity enums (`FileEntity.FileSource`) as query parameters, which four controllers legitimately use.

## Correction: the published coverage baseline was wrong

Running the full suite on `main` produced **195 tests, not 216**, and 19.41% rather than 21.00%. The missing 26 are `InvestigationQuerySanitizerTest` (10), `InvestigationToolsTest` (7) and `LlmClientTest` (9) — all from **#623, which is still unmerged**.

The Phase 0 baseline in #660 was measured on a branch I had cut from `feature/623-native-tool-calling` instead of `main`, so it counted tests that do not exist on `main`.

| | Published | Actual on `main` |
|---|---|---|
| Backend instructions | 21.00% | **19.41%** |
| Backend branches | 13.85% | **12.24%** |
| Backend tests | 216 | **195** |

Frontend figures are unaffected — #623 is backend-only. `CONTRIBUTING.md` is corrected here, with a note to measure baselines from `main`. #659 updated separately.

## Test plan

- [x] `mvn -B clean verify` → BUILD SUCCESS, 195 tests + 5 new, 0 failures
- [x] All five rules verified to fail when violated and pass when reverted
- [x] Working tree clean after probes — no controller left modified
- [x] Baseline recomputed from a clean `main` checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
