### PR TITLE
test: cover extracted-file download end to end

### DIFF
--- a/backend/src/test/java/com/tracepcap/integration/PipelineIntegrationTest.java
+++ b/backend/src/test/java/com/tracepcap/integration/PipelineIntegrationTest.java
@@ -167,13 +167,7 @@ class PipelineIntegrationTest {
     // Re-analysis records the same (file, extractor) again. The naive delete-then-insert dies on
     // the unique constraint (IDENTITY ids flush the INSERT before the queued DELETE), and the
     // recorder's catch would swallow it — so assert the second write actually lands.
-    ResponseEntity<JsonNode> upload = uploadFixture("ftp.pcap");
-    JsonNode body = upload.getBody();
-    UUID fileId =
-        UUID.fromString(
-            upload.getStatusCode() == HttpStatus.CREATED
-                ? body.get("fileId").asText()
-                : body.get("existingFileId").asText());
+    UUID fileId = UUID.fromString(uploadedFileId());
 
     extractionRunService.record(
         fileId,
@@ -344,7 +338,12 @@ class PipelineIntegrationTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
   }
 
-  /** Uploads the shared fixture if needed and returns its id, tolerating a 409 from a prior test. */
+  /**
+   * Uploads the shared fixture and returns its id.
+   *
+   * <p>201 on a fresh container; 409 once another test in this class has already stored the same
+   * pcap, which returns the existing id instead. Tests share one container, so both are normal.
+   */
   private String uploadedFileId() {
     ResponseEntity<JsonNode> upload = uploadFixture("ftp.pcap");
     JsonNode body = upload.getBody();

--- a/backend/src/test/java/com/tracepcap/integration/PipelineIntegrationTest.java
+++ b/backend/src/test/java/com/tracepcap/integration/PipelineIntegrationTest.java
@@ -68,6 +68,8 @@ class PipelineIntegrationTest {
 
   @Autowired private TestRestTemplate rest;
   @Autowired private com.tracepcap.analysis.service.ExtractionRunService extractionRunService;
+  @Autowired private com.tracepcap.extraction.repository.ExtractedFileRepository extractedFiles;
+  @Autowired private com.tracepcap.file.repository.FileRepository files;
 
   @Test
   void filesList_returnsPagedResponseEnvelope() {
@@ -261,5 +263,94 @@ class PipelineIntegrationTest {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     return new HttpEntity<>(body, headers);
+  }
+
+  // --- extracted-file download (#630) ---------------------------------------
+  //
+  // The endpoint the frontend pointed at for months without reaching it: getDownloadUrl()
+  // built "/api/files/..." while the route lives under "/api/v1". Nothing exercised the
+  // route from either side, so the 404 was invisible until someone clicked Download.
+  //
+  // A route that does not exist and a route that exists but cannot find the row both answer
+  // 404, so status alone proves nothing. The discriminator is the body: a mapped handler
+  // throws ResourceNotFoundException and GlobalExceptionHandler renders the ErrorResponse
+  // envelope, whereas an unmapped path produces Spring's bare "no handler" 404 with none of
+  // those fields. Asserting the envelope is therefore asserting the route is reachable.
+
+  @Test
+  void extractedFileDownload_unknownExtraction_returns404ErrorEnvelope() {
+    UUID fileId = UUID.fromString(uploadedFileId());
+    UUID missing = UUID.randomUUID();
+
+    ResponseEntity<JsonNode> response =
+        rest.getForEntity(
+            "/api/v1/files/" + fileId + "/extractions/" + missing + "/download", JsonNode.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    JsonNode body = response.getBody();
+    assertThat(body).isNotNull();
+    // Envelope fields, i.e. our handler ran — not Spring's unmapped-path 404.
+    assertThat(body.has("message")).isTrue();
+    assertThat(body.get("message").asText()).contains(missing.toString());
+  }
+
+  @Test
+  void extractedFileDownload_withoutStoredObject_returns404ErrorEnvelope() {
+    // Exercises the handler body rather than only the route: a row exists, so lookup and the
+    // file-ownership check both pass, and it fails at the missing minioPath.
+    UUID fileId = UUID.fromString(uploadedFileId());
+    var extraction =
+        extractedFiles.save(
+            com.tracepcap.extraction.entity.ExtractedFileEntity.builder()
+                .id(UUID.randomUUID())
+                .file(files.findById(fileId).orElseThrow())
+                .filename("evidence.bin")
+                .mimeType("application/octet-stream")
+                .minioPath(null)
+                .createdAt(java.time.LocalDateTime.now())
+                .build());
+
+    ResponseEntity<JsonNode> response =
+        rest.getForEntity(
+            "/api/v1/files/" + fileId + "/extractions/" + extraction.getId() + "/download",
+            JsonNode.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().get("message").asText()).contains("not available");
+  }
+
+  @Test
+  void extractedFileDownload_extractionBelongingToAnotherFile_returns404() {
+    // The ownership guard: a valid extraction id must not be downloadable through a different
+    // file's path, which would otherwise leak another capture's extracted bytes.
+    UUID fileId = UUID.fromString(uploadedFileId());
+    var extraction =
+        extractedFiles.save(
+            com.tracepcap.extraction.entity.ExtractedFileEntity.builder()
+                .id(UUID.randomUUID())
+                .file(files.findById(fileId).orElseThrow())
+                .filename("evidence.bin")
+                .minioPath("some/object/path")
+                .createdAt(java.time.LocalDateTime.now())
+                .build());
+
+    ResponseEntity<JsonNode> response =
+        rest.getForEntity(
+            "/api/v1/files/" + UUID.randomUUID() + "/extractions/" + extraction.getId()
+                + "/download",
+            JsonNode.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  /** Uploads the shared fixture if needed and returns its id, tolerating a 409 from a prior test. */
+  private String uploadedFileId() {
+    ResponseEntity<JsonNode> upload = uploadFixture("ftp.pcap");
+    JsonNode body = upload.getBody();
+    assertThat(body).isNotNull();
+    return upload.getStatusCode() == HttpStatus.CREATED
+        ? body.get("fileId").asText()
+        : body.get("existingFileId").asText();
   }
 }


### PR DESCRIPTION
Phase 2 of #659, final item. Does **not** close it.

## Why this endpoint

This is the route from [#630](https://github.com/NotYuSheng/TracePcap/pull/630) — the one the frontend pointed at for months without ever reaching. `getDownloadUrl()` built `/api/files/...` while the route lives under `/api/v1`. Nothing exercised it from either side, so the 404 stayed invisible until a human clicked Download.

The audit named this the untested affordance class: **no test anywhere touched a download or export control.**

## The assertion that matters

Status alone proves nothing here — an unmapped path and a mapped path with an unknown id both answer `404`.

The discriminator is the **body**. A mapped handler throws `ResourceNotFoundException`, and `GlobalExceptionHandler` renders the shared `ErrorResponse` envelope. An unmapped path yields Spring's bare "no handler" 404 with none of those fields. So asserting the envelope *is* asserting the route is reachable.

## Three cases, each reaching further into the handler

| Case | What it proves |
|---|---|
| Unknown extraction id | The route is mapped and the envelope renders |
| Row with `minioPath == null` | Lookup and the file-ownership check both pass; it fails on the missing object — so the handler body actually ran |
| Extraction owned by another file | The ownership guard, which otherwise leaks another capture's extracted bytes through a different file's URL |

The second and third seed real rows through the repositories against the Testcontainers Postgres, so they exercise the full HTTP → controller → repository path rather than just routing.

## Proven to fail

Rewriting the first test's URL to #630's exact form (`/api/files/...`, no `/v1`):

```
Tests run: 12, Failures: 1
extractedFileDownload_unknownExtraction_returns404ErrorEnvelope (PipelineIntegrationTest.java:294)
```

Restoring it returns **12/12**. Worth noting the first attempt at this proof used a `sed` that failed on its delimiter, so it silently tested the unmodified file and "passed" — the check was redone with Python before being trusted.

## Test plan

- [x] `mvn -Dtest=PipelineIntegrationTest test` → 12 tests, 0 failures (was 9)
- [x] Injected #630's URL → the intended test fails; reverting restores 12/12
- [x] Working tree clean after probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)