### PR TITLE
ci: run the test workflows on merge, not only per-PR

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -2,6 +2,12 @@ name: System Tests
 
 on:
   workflow_dispatch:
+  # Also on merge, not only per-PR. A PR run proves the branch was sound at the time; nothing
+  # re-checked main after it landed, so a semantic conflict between two independently-green
+  # PRs would go unnoticed until someone opened the next one (#659).
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - 'backend/**'

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -2,6 +2,11 @@ name: Backend Tests
 
 on:
   workflow_dispatch:
+  # Also on merge, so main has a continuous coverage history rather than only per-PR
+  # readings. The ratchet in #659 needs a trustworthy floor measured from main.
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - 'backend/**'

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -2,6 +2,11 @@ name: Frontend Unit Tests
 
 on:
   workflow_dispatch:
+  # Also on merge, so main has a continuous coverage history rather than only per-PR
+  # readings. The ratchet in #659 needs a trustworthy floor measured from main.
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - 'frontend/**'


### PR DESCRIPTION
Two items from #659, one root cause: every test workflow triggers on `pull_request` only.

## What that costs

A PR run proves the branch was sound **at the time it ran**. Nothing re-checks `main` afterwards, so two independently-green PRs that conflict semantically stay green until somebody happens to open the next one.

`system-tests` is the sharpest case — the only end-to-end proof that a pcap uploads, analyses and reports — and it has **never run against `main`**.

It also leaves `main` with no coverage history. Readings exist per-PR and nowhere else, so the **coverage ratchet still open in #659 has no trustworthy floor to ratchet from**. This is the last blocker on that item.

## Changes

`push: branches: [main]` added to `system-tests.yml`, `test-backend.yml` and `test-frontend.yml`.

Worth correcting one thing from the original issue text: it framed the system-tests item as "run on merge rather than behind `RUN_SYSTEM_TESTS`". But `RUN_SYSTEM_TESTS: 'true'` is already set at job level in that workflow, so the env gate was never the obstacle in CI — the missing `push` trigger was. The gate still does its job locally, where the stack usually is not running.

## Test plan

- [x] All three workflows parse; triggers now `workflow_dispatch`, `push`, `pull_request`
- [ ] Proves itself on merge — this PR landing fires all three against `main` for the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)