### PR TITLE
test: sweep every standalone route for failed API calls

### DIFF
--- a/frontend/e2e/route-sweep.spec.ts
+++ b/frontend/e2e/route-sweep.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Visits every standalone route and fails on a broken API call or a console error.
+ *
+ * This is the test that would have caught #630 directly. The extracted-file download had
+ * pointed at `/api/files/...` since #158 while every route is served under `/api/v1`; the
+ * existing e2e walkthrough is thorough down one happy path but never touched that control,
+ * so the 404 shipped and stayed. A sweep asserts something weaker about each page than a
+ * scripted journey does, but it asserts it about *every* page — and a request 404ing is
+ * exactly the shape of failure that hides from a journey test.
+ *
+ * Routes taking a `:fileId` are excluded: they need an uploaded, analysed capture, which
+ * `demo.spec.ts` sets up properly. This covers what can stand alone.
+ */
+const ROUTES = ['/', '/compare', '/monitor'] as const;
+
+/** Requests the app makes to itself. A failure here is a broken contract, not a flaky CDN. */
+const API_CALL = /\/api\//;
+
+for (const route of ROUTES) {
+  test(`${route} loads without failed API calls or console errors`, async ({ page }) => {
+    const consoleErrors: string[] = [];
+    const failedRequests: string[] = [];
+
+    page.on('console', message => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text());
+      }
+    });
+
+    // Response-level, not requestfailed: a 404 is a *successful* HTTP exchange as far as the
+    // network layer is concerned, so requestfailed never fires for it. That is precisely how
+    // #630 stayed invisible.
+    page.on('response', response => {
+      const url = response.url();
+      if (API_CALL.test(url) && response.status() >= 400) {
+        failedRequests.push(`${response.status()} ${url}`);
+      }
+    });
+
+    await page.goto(route, { waitUntil: 'domcontentloaded' });
+
+    // Not networkidle: the app polls (analysis progress, monitor snapshots), so the network
+    // never goes idle and every route times out at 90s. Wait for the shell to prove the SPA
+    // mounted, then allow a bounded window for the route's initial calls to land.
+    await expect(page.getByText('TracePcap').first()).toBeVisible({ timeout: 30_000 });
+    await page.waitForTimeout(3_000);
+
+    expect(failedRequests, `failed API calls on ${route}`).toEqual([]);
+    expect(consoleErrors, `console errors on ${route}`).toEqual([]);
+  });
+}

--- a/frontend/e2e/route-sweep.spec.ts
+++ b/frontend/e2e/route-sweep.spec.ts
@@ -16,7 +16,7 @@ import { expect, test } from '@playwright/test';
 const ROUTES = ['/', '/compare', '/monitor'] as const;
 
 /** Requests the app makes to itself. A failure here is a broken contract, not a flaky CDN. */
-const API_CALL = /\/api\//;
+const API_PATH = /^\/api\//;
 
 for (const route of ROUTES) {
   test(`${route} loads without failed API calls or console errors`, async ({ page }) => {
@@ -33,9 +33,14 @@ for (const route of ROUTES) {
     // network layer is concerned, so requestfailed never fires for it. That is precisely how
     // #630 stayed invisible.
     page.on('response', response => {
-      const url = response.url();
-      if (API_CALL.test(url) && response.status() >= 400) {
-        failedRequests.push(`${response.status()} ${url}`);
+      // Same-origin only. Matching "/api/" anywhere in the URL would also catch a third
+      // party that happens to use that path, failing the sweep for something outside the
+      // app's contract. (The app is required to work fully offline, so an external call
+      // should not occur at all — but that is a separate assertion, not this one.)
+      const url = new URL(response.url());
+      const isOwnApi = url.origin === new URL(page.url()).origin && API_PATH.test(url.pathname);
+      if (isOwnApi && response.status() >= 400) {
+        failedRequests.push(`${response.status()} ${url.pathname}`);
       }
     });
 


### PR DESCRIPTION
Phase 5 of #659. Does **not** close it.

## The test that would have caught #630

The extracted-file download pointed at `/api/files/...` from #158 onward while every route is served under `/api/v1`. `demo.spec.ts` is genuinely thorough down one happy path — but it never touched that control, so the 404 shipped and stayed for months.

A sweep asserts something **weaker** about each page than a scripted journey does, but it asserts it about **every** page. A silently-404ing request is exactly the shape of failure that hides from a journey test.

## Two design points, both learned by the test failing first

**Listens on `response`, not `requestfailed`.** A 404 is a *successful* HTTP exchange as far as the network layer is concerned, so `requestfailed` never fires for one. Verified against a live stack — the listener records:

```
RECORDED: [ '404 http://127.0.0.1:8888/api/files/nope/extractions' ]
```

That is #630's URL shape exactly.

**Does not use `networkidle`.** The first version did, and **all three routes timed out at 90s**. The app polls (analysis progress, monitor snapshots), so the network never goes idle. Waiting for the shell to mount plus a bounded settle window runs the same three routes in **11s**.

## Scope

`/`, `/compare`, `/monitor`. Routes taking a `:fileId` are excluded — they need an uploaded, analysed capture, which `demo.spec.ts` already sets up properly.

## Test plan

- [x] 3 passed in 11.0s against the live stack
- [x] Probe confirms the listener records a 404 on an `/api/` call; probe removed before commit
- [x] First revision (`networkidle`) reproduced the 90s timeout, which is why it is not used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for key application routes.
  * Detects console errors and failed API responses during initial page loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->