### PR TITLE
fix: bring custom private ranges under the endpoint contract guard

### DIFF
--- a/frontend/src/features/intelligence/services/customPrivateRangeService.ts
+++ b/frontend/src/features/intelligence/services/customPrivateRangeService.ts
@@ -1,9 +1,10 @@
 import { apiClient } from '@/services/api/client';
+import { API_ENDPOINTS } from '@/services/api/endpoints';
 import type { CustomPrivateRange, IpClassification } from '../types/customPrivateRange.types';
 
 export const customPrivateRangeService = {
   async list(): Promise<CustomPrivateRange[]> {
-    const res = await apiClient.get<CustomPrivateRange[]>('/custom-private-ranges');
+    const res = await apiClient.get<CustomPrivateRange[]>(API_ENDPOINTS.CUSTOM_PRIVATE_RANGES);
     return res.data;
   },
 
@@ -11,7 +12,7 @@ export const customPrivateRangeService = {
     cidr: string,
     classification: IpClassification = 'PRIVATE',
   ): Promise<CustomPrivateRange> {
-    const res = await apiClient.post<CustomPrivateRange>('/custom-private-ranges', {
+    const res = await apiClient.post<CustomPrivateRange>(API_ENDPOINTS.CUSTOM_PRIVATE_RANGES, {
       cidr,
       classification,
     });
@@ -19,6 +20,6 @@ export const customPrivateRangeService = {
   },
 
   async delete(id: number): Promise<void> {
-    await apiClient.delete(`/custom-private-ranges/${id}`);
+    await apiClient.delete(API_ENDPOINTS.CUSTOM_PRIVATE_RANGE_DELETE(id));
   },
 };

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -92,6 +92,10 @@ export const API_ENDPOINTS = {
   IP_ORG_RULES: '/ip-org-rules',
   IP_ORG_RULE_DELETE: (id: number) => `/ip-org-rules/${id}`,
 
+  // Custom private ranges
+  CUSTOM_PRIVATE_RANGES: '/custom-private-ranges',
+  CUSTOM_PRIVATE_RANGE_DELETE: (id: number) => `/custom-private-ranges/${id}`,
+
   // System
   SYSTEM_TIME: '/system/time',
   SYSTEM_LIMITS: '/system/limits',


### PR DESCRIPTION
Follow-up to #684, closing the gap those tests exposed.

## The gap

`customPrivateRangeService` hard-coded its three paths inline:

```ts
apiClient.get<CustomPrivateRange[]>('/custom-private-ranges')
```

`endpointPaths.test.ts` iterates the **endpoint maps**, so these URLs sat outside the #630 guard entirely — the one piece of machinery built specifically to stop a frontend path drifting from the backend's routes.

That is exactly the shape of gap the guard exists to close, and it was invisible because nothing enumerates hard-coded URLs.

## The fix

Moves both paths into `API_ENDPOINTS` and points the service at the map. The contract test picks them up automatically — **276 → 278 tests**, the two new cases being precisely the added endpoints.

## Proven

Renaming the collection path now produces:

```
× API_ENDPOINTS.CUSTOM_PRIVATE_RANGES resolves to a real backend route
```

That failure was **not possible before this change** — the same rename previously only broke the service's own tests, and only because #684 had just added them.

## Test plan

- [x] 278 tests (was 276); the delta is the two new contract cases
- [x] Break-test above; reverting restores green
- [x] `tsc`, `typecheck:test`, `lint:contract` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized custom private-range API endpoints for listing, creating, and deleting ranges.
  - Improved consistency and maintainability of custom private-range operations without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->