### PR TITLE
test: characterise the change-detection locality predicate

### DIFF
--- a/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionLocalityCharacterisationTest.java
+++ b/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionLocalityCharacterisationTest.java
@@ -115,6 +115,20 @@ class ChangeDetectionLocalityCharacterisationTest {
   }
 
   @Test
+  void isPrivate_missesMostOfTheFe80Slash10LinkLocalRange() {
+    // fe80::/10 spans fe80:: through febf::, but the prefix set holds the literal string
+    // "fe80", so only the first sixteenth of the range matches. febf::1 is link-local and is
+    // classified as PUBLIC — a real gap, and the one place the string-prefix approach visibly
+    // breaks rather than merely being imprecise.
+    //
+    // Pinned, not fixed: correcting it here would change which hosts monitor mode reports as
+    // external, inside a PR whose whole purpose is to prove behaviour unchanged. Recorded on
+    // #694 with the other locality divergences.
+    assertThat(isPrivate("fe80::1")).isTrue();
+    assertThat(isPrivate("febf::1")).isFalse();
+  }
+
+  @Test
   void isPrivate_matchesFePrefixOnlyForFe80NotAllFeAddresses() {
     // The prefix set contains "fe80" rather than "fe", so fec0:: (deprecated site-local) is not
     // matched. Worth pinning: the neighbouring fc/fd entries are two characters, and it would be

--- a/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionLocalityCharacterisationTest.java
+++ b/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionLocalityCharacterisationTest.java
@@ -1,0 +1,124 @@
+package com.tracepcap.monitor.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.tracepcap.intelligence.service.CustomPrivateRangeService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Characterisation tests for {@code ChangeDetectionService}'s locality predicate (#659, phase 4).
+ * Fourth slice, after {@code subnets.service} (#688), {@code report} (#690) and {@code
+ * intelligence.service} (#692).
+ *
+ * <p><b>This is the third definition of "private" in the codebase</b>, and the widest. Tracked as
+ * #694, which the first two slices opened. The divergences pinned here are the sharpest yet:
+ *
+ * <ul>
+ *   <li>It accepts {@code 169.254/16} link-local, which the other two reject.
+ *   <li>It returns <b>true</b> for a null address. The other two return false. So a missing address
+ *       counts as internal on this path and external on both others.
+ * </ul>
+ *
+ * <p>Neither is corrected here. Pinning all three is what makes unifying them a change with a
+ * visible diff rather than a silent reclassification of existing captures.
+ *
+ * <p>Unlike the earlier slices this method has a collaborator, so the range service is stubbed to
+ * "no override, no custom CIDR" — isolating the built-in heuristic, which is the part that diverges.
+ */
+class ChangeDetectionLocalityCharacterisationTest {
+
+  private static final ChangeDetectionService SERVICE = serviceWithNeutralRangeService();
+
+  private static ChangeDetectionService serviceWithNeutralRangeService() {
+    try {
+      Constructor<?> ctor = ChangeDetectionService.class.getDeclaredConstructors()[0];
+      ctor.setAccessible(true);
+      ChangeDetectionService service =
+          (ChangeDetectionService) ctor.newInstance(new Object[ctor.getParameterCount()]);
+
+      CustomPrivateRangeService ranges = mock(CustomPrivateRangeService.class);
+      when(ranges.overrideFor(any(), any()))
+          .thenReturn(CustomPrivateRangeService.Override.NONE);
+      when(ranges.isInCidrs(any(), any())).thenReturn(false);
+
+      Field field = ChangeDetectionService.class.getDeclaredField("customPrivateRangeService");
+      field.setAccessible(true);
+      field.set(service, ranges);
+      return service;
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(
+          "ChangeDetectionService's shape changed — update this characterisation test", e);
+    }
+  }
+
+  private static boolean isPrivate(String ip) {
+    try {
+      // LocalityRules is a private record nested in ChangeDetectionService.
+      Class<?> rulesType =
+          Class.forName("com.tracepcap.monitor.service.ChangeDetectionService$LocalityRules");
+      Method m = ChangeDetectionService.class.getDeclaredMethod("isPrivate", String.class, rulesType);
+      m.setAccessible(true);
+      Constructor<?> rulesCtor = rulesType.getDeclaredConstructors()[0];
+      rulesCtor.setAccessible(true);
+      Object rules = rulesCtor.newInstance(new Object[rulesCtor.getParameterCount()]);
+      return (boolean) m.invoke(SERVICE, ip, rules);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("isPrivate/LocalityRules changed — update this test", e);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"10.0.0.1", "192.168.1.1", "172.16.0.1", "172.31.0.1", "127.0.0.1", "::1"})
+  void isPrivate_acceptsRfc1918AndLoopback(String ip) {
+    assertThat(isPrivate(ip)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"fc00::1", "fd00::1", "fe80::1"})
+  void isPrivate_acceptsIpv6UniqueLocalAndLinkLocal(String ip) {
+    // fe80::/10 is IPv6 link-local. Note the IPv4 equivalent (169.254) is accepted here too but
+    // rejected by both other implementations — see below.
+    assertThat(isPrivate(ip)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"169.254.1.1", "169.254.255.255"})
+  void isPrivate_acceptsIpv4LinkLocal_unlikeTheOtherTwoImplementations(String ip) {
+    // SubnetService.isPrivate and NetworkIntelligenceService.isPrivateIp both return false for
+    // these. Pinned on all three sides so #694 can reconcile them deliberately.
+    assertThat(isPrivate(ip)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"8.8.8.8", "172.15.0.1", "172.32.0.1", "100.64.0.1", "2001:db8::1"})
+  void isPrivate_rejectsPublicAndNearMissRanges(String ip) {
+    assertThat(isPrivate(ip)).isFalse();
+  }
+
+  @ParameterizedTest
+  @NullSource
+  void isPrivate_treatsNullAsPrivate_unlikeTheOtherTwoImplementations(String ip) {
+    // The sharpest divergence in #694: null is private here and public in both other
+    // implementations. A host with no recorded address is therefore internal on this path and
+    // external everywhere else.
+    assertThat(isPrivate(ip)).isTrue();
+  }
+
+  @Test
+  void isPrivate_matchesFePrefixOnlyForFe80NotAllFeAddresses() {
+    // The prefix set contains "fe80" rather than "fe", so fec0:: (deprecated site-local) is not
+    // matched. Worth pinning: the neighbouring fc/fd entries are two characters, and it would be
+    // easy to "tidy" this one to match.
+    assertThat(isPrivate("fec0::1")).isFalse();
+  }
+}


### PR DESCRIPTION
Phase 4 of #659, **fourth slice** — after #688, #690 and #692.

## A third definition of "private", and the sharpest divergences yet

`ChangeDetectionService.isPrivate` is the widest of the three, and two of its behaviours contradict the others outright:

| | RFC1918 | `127/8` | `169.254/16` | `fe80::/10` | **null** |
|---|---|---|---|---|---|
| `SubnetService` | ✅ | ❌ | ❌ | ❌ | **false** |
| `NetworkIntelligenceService` | ✅ | ✅ | ❌ | ❌ | **false** |
| `ChangeDetectionService` | ✅ | ✅ | **✅** | **✅** | **true** |

The null case is the one to look at twice: **a host with no recorded address counts as internal on this path and external on both others.**

All three are now pinned, which is the point — #694 can reconcile them with a diff showing exactly which classifications move, instead of a refactor quietly changing how existing captures are summarised. Nothing is corrected here.

## Also pinned

The prefix set contains `fe80` rather than `fe`, so `fec0::` (deprecated site-local) is **not** matched. Worth pinning because the neighbouring `fc`/`fd` entries are two characters, and "tidying" this one to match would change behaviour.

## Note on setup

Unlike the earlier slices this method has a collaborator, so `CustomPrivateRangeService` is stubbed to *no override, no custom CIDR* — isolating the built-in heuristic, which is the part that diverges. `LocalityRules` is a private nested record, reached by its binary name (`ChangeDetectionService$LocalityRules`); the first attempt used the dotted name and errored 18 tests, which is how the helper earned its explicit failure message.

## Proven by mutation

Flipping the null case and dropping the link-local prefix produces **3 failures**. Reverting returns **18/18**.

## Coverage

| | Before | After |
|---|---|---|
| `monitor.service` | 6.3% | **8.84%** |
| Backend total | 20.56% | **20.67%** |

## Test plan

- [x] `mvn -B clean verify` → BUILD SUCCESS, 324 tests, 0 failures
- [x] Mutation test above; reverting restores 18/18
- [x] No production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for address locality detection, including private, loopback, link-local, unique-local, public, null, and boundary IPv4/IPv6 addresses.
  * Documented expected behavior for identifying local versus non-local addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->