### PR TITLE
test: characterise the LLM response salvaging in snapshot insights

### DIFF
--- a/backend/src/test/java/com/tracepcap/insights/service/SnapshotInsightJsonCharacterisationTest.java
+++ b/backend/src/test/java/com/tracepcap/insights/service/SnapshotInsightJsonCharacterisationTest.java
@@ -1,0 +1,150 @@
+package com.tracepcap.insights.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Characterisation tests for {@code SnapshotInsightService}'s LLM-response salvaging (#659, phase
+ * 4). Fifth and final service slice, after {@code subnets.service} (#688), {@code report} (#690),
+ * {@code intelligence.service} (#692) and {@code monitor.service} (#695).
+ *
+ * <p>{@code extractJson} exists because models do not reliably return bare JSON — they wrap it in
+ * fences, add prose, and emit comments that JSON does not allow. It is therefore a pile of regex
+ * heuristics operating on untrusted text, and every one of them is a silent-failure risk: a bad
+ * salvage does not throw, it produces JSON that parses into the wrong insight.
+ *
+ * <p>Pins current behaviour, including where the heuristics are lossy. Nothing is corrected.
+ */
+class SnapshotInsightJsonCharacterisationTest {
+
+  private static final SnapshotInsightService SERVICE = newServiceWithoutCollaborators();
+
+  private static SnapshotInsightService newServiceWithoutCollaborators() {
+    try {
+      Constructor<?> ctor = SnapshotInsightService.class.getDeclaredConstructors()[0];
+      ctor.setAccessible(true);
+      return (SnapshotInsightService) ctor.newInstance(new Object[ctor.getParameterCount()]);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(
+          "SnapshotInsightService's constructor changed — update this test", e);
+    }
+  }
+
+  private static String extractJson(String content) {
+    try {
+      Method m = SnapshotInsightService.class.getDeclaredMethod("extractJson", String.class);
+      m.setAccessible(true);
+      return (String) m.invoke(SERVICE, content);
+    } catch (InvocationTargetException e) {
+      throw (RuntimeException) e.getCause();
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("extractJson changed — update this test", e);
+    }
+  }
+
+  // --- rejection -------------------------------------------------------------
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", "   ", "\n\t"})
+  void extractJson_throwsOnAnEmptyResponse(String content) {
+    // A RuntimeException rather than a checked one or a null return, so the caller records the
+    // insight as failed rather than storing an empty body.
+    assertThatThrownBy(() -> extractJson(content))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Empty LLM response");
+  }
+
+  // --- fence stripping -------------------------------------------------------
+
+  @Test
+  void extractJson_stripsFencedCodeBlocks() {
+    assertThat(extractJson("```json\n{\"a\":1}\n```")).isEqualTo("{\"a\":1}");
+  }
+
+  @Test
+  void extractJson_stripsBareFencesToo() {
+    assertThat(extractJson("```\n{\"a\":1}\n```")).isEqualTo("{\"a\":1}");
+  }
+
+  // --- brace slicing ---------------------------------------------------------
+
+  @Test
+  void extractJson_discardsProseAroundTheObject() {
+    // Models routinely prepend "Here is the JSON:" and append a summary.
+    assertThat(extractJson("Sure! Here you go:\n{\"a\":1}\nHope that helps."))
+        .isEqualTo("{\"a\":1}");
+  }
+
+  @Test
+  void extractJson_slicesToTheLastBraceSoNestedObjectsSurvive() {
+    String json = "{\"a\":{\"b\":2}}";
+    assertThat(extractJson("noise " + json + " noise")).isEqualTo(json);
+  }
+
+  @Test
+  void extractJson_returnsContentUnchangedWhenThereIsNoObject() {
+    // No braces: nothing to salvage, so the raw text is handed on and fails at the parse step
+    // with the model's actual words, which is more debuggable than an empty string.
+    assertThat(extractJson("I cannot help with that.")).isEqualTo("I cannot help with that.");
+  }
+
+  @Test
+  void extractJson_returnsContentUnchangedWhenBracesAreInverted() {
+    // "}" before "{" fails the `end > start` guard.
+    assertThat(extractJson("} not json {")).isEqualTo("} not json {");
+  }
+
+  // --- comment stripping -----------------------------------------------------
+
+  @Test
+  void extractJson_removesWholeLineComments() {
+    assertThat(extractJson("{\n  // explanation\n  \"a\":1\n}"))
+        .isEqualTo("{\n  \n  \"a\":1\n}");
+  }
+
+  @Test
+  void extractJson_removesTrailingCommentsAfterACommaButKeepsTheComma() {
+    assertThat(extractJson("{\"a\":1, // note\n\"b\":2}")).isEqualTo("{\"a\":1,\n\"b\":2}");
+  }
+
+  @Test
+  void extractJson_preservesUrlsThatContainDoubleSlashes() {
+    // The comment patterns are anchored at line start or immediately after a comma, so a "//"
+    // inside a string value survives. Worth pinning: a naive "strip everything after //" would
+    // corrupt every URL the model reports, silently and unrecoverably.
+    String json = "{\"url\":\"https://example.com/a\"}";
+    assertThat(extractJson(json)).isEqualTo(json);
+  }
+
+  @Test
+  void extractJson_stripsAnIndentedCommentLineButLeavesItsIndentation() {
+    // The replacement keeps group 1, so the line becomes blank-but-indented rather than being
+    // removed. Harmless for a JSON parser; pinned because "tidying" it changes the output.
+    assertThat(extractJson("{\n    // c\n\"a\":1}")).isEqualTo("{\n    \n\"a\":1}");
+  }
+
+  // --- formatValue -----------------------------------------------------------
+
+  @Test
+  void formatValue_joinsEntriesAndRendersNullAsAnEmDash() throws Exception {
+    Method m = SnapshotInsightService.class.getDeclaredMethod("formatValue", Map.class);
+    m.setAccessible(true);
+    Map<String, Object> value = new LinkedHashMap<>();
+    value.put("hosts", 3);
+    value.put("subnet", "10.0.0.0/8");
+
+    assertThat(m.invoke(SERVICE, value)).isEqualTo("hosts=3, subnet=10.0.0.0/8");
+    assertThat(m.invoke(SERVICE, (Map<String, Object>) null)).isEqualTo("—");
+  }
+}

--- a/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionLocalityCharacterisationTest.java
+++ b/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionLocalityCharacterisationTest.java
@@ -115,6 +115,20 @@ class ChangeDetectionLocalityCharacterisationTest {
   }
 
   @Test
+  void isPrivate_missesMostOfTheFe80Slash10LinkLocalRange() {
+    // fe80::/10 spans fe80:: through febf::, but the prefix set holds the literal string
+    // "fe80", so only the first sixteenth of the range matches. febf::1 is link-local and is
+    // classified as PUBLIC — a real gap, and the one place the string-prefix approach visibly
+    // breaks rather than merely being imprecise.
+    //
+    // Pinned, not fixed: correcting it here would change which hosts monitor mode reports as
+    // external, inside a PR whose whole purpose is to prove behaviour unchanged. Recorded on
+    // #694 with the other locality divergences.
+    assertThat(isPrivate("fe80::1")).isTrue();
+    assertThat(isPrivate("febf::1")).isFalse();
+  }
+
+  @Test
   void isPrivate_matchesFePrefixOnlyForFe80NotAllFeAddresses() {
     // The prefix set contains "fe80" rather than "fe", so fec0:: (deprecated site-local) is not
     // matched. Worth pinning: the neighbouring fc/fd entries are two characters, and it would be

--- a/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionLocalityCharacterisationTest.java
+++ b/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionLocalityCharacterisationTest.java
@@ -1,0 +1,124 @@
+package com.tracepcap.monitor.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.tracepcap.intelligence.service.CustomPrivateRangeService;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Characterisation tests for {@code ChangeDetectionService}'s locality predicate (#659, phase 4).
+ * Fourth slice, after {@code subnets.service} (#688), {@code report} (#690) and {@code
+ * intelligence.service} (#692).
+ *
+ * <p><b>This is the third definition of "private" in the codebase</b>, and the widest. Tracked as
+ * #694, which the first two slices opened. The divergences pinned here are the sharpest yet:
+ *
+ * <ul>
+ *   <li>It accepts {@code 169.254/16} link-local, which the other two reject.
+ *   <li>It returns <b>true</b> for a null address. The other two return false. So a missing address
+ *       counts as internal on this path and external on both others.
+ * </ul>
+ *
+ * <p>Neither is corrected here. Pinning all three is what makes unifying them a change with a
+ * visible diff rather than a silent reclassification of existing captures.
+ *
+ * <p>Unlike the earlier slices this method has a collaborator, so the range service is stubbed to
+ * "no override, no custom CIDR" — isolating the built-in heuristic, which is the part that diverges.
+ */
+class ChangeDetectionLocalityCharacterisationTest {
+
+  private static final ChangeDetectionService SERVICE = serviceWithNeutralRangeService();
+
+  private static ChangeDetectionService serviceWithNeutralRangeService() {
+    try {
+      Constructor<?> ctor = ChangeDetectionService.class.getDeclaredConstructors()[0];
+      ctor.setAccessible(true);
+      ChangeDetectionService service =
+          (ChangeDetectionService) ctor.newInstance(new Object[ctor.getParameterCount()]);
+
+      CustomPrivateRangeService ranges = mock(CustomPrivateRangeService.class);
+      when(ranges.overrideFor(any(), any()))
+          .thenReturn(CustomPrivateRangeService.Override.NONE);
+      when(ranges.isInCidrs(any(), any())).thenReturn(false);
+
+      Field field = ChangeDetectionService.class.getDeclaredField("customPrivateRangeService");
+      field.setAccessible(true);
+      field.set(service, ranges);
+      return service;
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(
+          "ChangeDetectionService's shape changed — update this characterisation test", e);
+    }
+  }
+
+  private static boolean isPrivate(String ip) {
+    try {
+      // LocalityRules is a private record nested in ChangeDetectionService.
+      Class<?> rulesType =
+          Class.forName("com.tracepcap.monitor.service.ChangeDetectionService$LocalityRules");
+      Method m = ChangeDetectionService.class.getDeclaredMethod("isPrivate", String.class, rulesType);
+      m.setAccessible(true);
+      Constructor<?> rulesCtor = rulesType.getDeclaredConstructors()[0];
+      rulesCtor.setAccessible(true);
+      Object rules = rulesCtor.newInstance(new Object[rulesCtor.getParameterCount()]);
+      return (boolean) m.invoke(SERVICE, ip, rules);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("isPrivate/LocalityRules changed — update this test", e);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {"10.0.0.1", "192.168.1.1", "172.16.0.1", "172.31.0.1", "127.0.0.1", "::1"})
+  void isPrivate_acceptsRfc1918AndLoopback(String ip) {
+    assertThat(isPrivate(ip)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"fc00::1", "fd00::1", "fe80::1"})
+  void isPrivate_acceptsIpv6UniqueLocalAndLinkLocal(String ip) {
+    // fe80::/10 is IPv6 link-local. Note the IPv4 equivalent (169.254) is accepted here too but
+    // rejected by both other implementations — see below.
+    assertThat(isPrivate(ip)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"169.254.1.1", "169.254.255.255"})
+  void isPrivate_acceptsIpv4LinkLocal_unlikeTheOtherTwoImplementations(String ip) {
+    // SubnetService.isPrivate and NetworkIntelligenceService.isPrivateIp both return false for
+    // these. Pinned on all three sides so #694 can reconcile them deliberately.
+    assertThat(isPrivate(ip)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"8.8.8.8", "172.15.0.1", "172.32.0.1", "100.64.0.1", "2001:db8::1"})
+  void isPrivate_rejectsPublicAndNearMissRanges(String ip) {
+    assertThat(isPrivate(ip)).isFalse();
+  }
+
+  @ParameterizedTest
+  @NullSource
+  void isPrivate_treatsNullAsPrivate_unlikeTheOtherTwoImplementations(String ip) {
+    // The sharpest divergence in #694: null is private here and public in both other
+    // implementations. A host with no recorded address is therefore internal on this path and
+    // external everywhere else.
+    assertThat(isPrivate(ip)).isTrue();
+  }
+
+  @Test
+  void isPrivate_matchesFePrefixOnlyForFe80NotAllFeAddresses() {
+    // The prefix set contains "fe80" rather than "fe", so fec0:: (deprecated site-local) is not
+    // matched. Worth pinning: the neighbouring fc/fd entries are two characters, and it would be
+    // easy to "tidy" this one to match.
+    assertThat(isPrivate("fec0::1")).isFalse();
+  }
+}


### PR DESCRIPTION
Phase 4 of #659 — **fifth and final service slice**, after #688, #690, #692 and #695.

## Why `extractJson`

It exists because models do not reliably return bare JSON: they fence it, wrap it in prose, and emit comments JSON does not allow. So it is a pile of regex heuristics operating on untrusted text — and every one is a **silent-failure** risk. A bad salvage does not throw; it yields JSON that parses into the *wrong insight*.

## The load-bearing property

**URLs survive.** The comment patterns are anchored at line start or immediately after a comma, so `//` inside a string value is untouched:

```json
{"url":"https://example.com/a"}   →   unchanged
```

A naive "strip everything after `//`" would corrupt **every URL a model reports**, silently and unrecoverably. That property was incidental; it is now tested.

## Lossy behaviour, pinned not fixed

- A stripped comment line keeps its indentation rather than vanishing (the replacement preserves group 1) — harmless to a parser, but "tidying" it changes output
- Content with no braces is returned **unchanged**, so the parse failure carries the model's actual words rather than an empty string — more debuggable
- Inverted braces (`}` before `{`) fail the `end > start` guard and fall through to the same path

## Proven by mutation

Slicing to the **first** `}` instead of the last, and dropping the `isBlank` guard, produces **4 failures**. Reverting returns **15/15**.

## Coverage

| | Before | After |
|---|---|---|
| `insights.service` | 17.5% | **18.97%** |
| Backend total | 20.67% | **20.79%** |

## Test plan

- [x] `mvn -B clean verify` → BUILD SUCCESS, 340 tests, 0 failures
- [x] Mutation test above; reverting restores 15/15
- [x] No production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)