### PR TITLE
test: cover the entity note hook

### DIFF
--- a/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityNote.test.ts
+++ b/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityNote.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The note hook backs the one control that writes an operator's own words into the tool.
+ *
+ * Two behaviours matter more than the CRUD: the modal is reused across entities, so a previous
+ * entity's note must not leak into the next one; and every failure path here is swallowed to a
+ * console.error, which is pinned below rather than endorsed.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { HttpResponse, http } from 'msw'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { server } from '@/test/msw'
+import { useEntityNote } from '../useEntityNote'
+
+function note(entityKey: string, text: string) {
+  return {
+    entityType: 'IP',
+    entityKey,
+    note: text,
+    createdAt: '2026-08-12T00:00:00Z',
+    updatedAt: '2026-08-12T00:00:00Z',
+  }
+}
+
+beforeEach(() => {
+  // The hook reports every failure this way, so silence it and assert on behaviour instead.
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('useEntityNote', () => {
+  it('loads the existing note into the draft', async () => {
+    server.use(
+      http.get('*/api/v1/entity-notes', () => HttpResponse.json(note('10.0.0.1', 'Jump box')))
+    )
+
+    const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+
+    await waitFor(() => expect(result.current.noteText).toBe('Jump box'))
+    expect(result.current.savedNote?.note).toBe('Jump box')
+    // Draft equals saved, so the Save button has nothing to do yet.
+    expect(result.current.noteChanged).toBe(false)
+  })
+
+  it('clears the previous entity note when the key changes', async () => {
+    server.use(
+      http.get('*/api/v1/entity-notes', ({ request }) => {
+        const key = new URL(request.url).searchParams.get('entityKey')
+        return key === '10.0.0.1'
+          ? HttpResponse.json(note('10.0.0.1', 'Jump box'))
+          : HttpResponse.json(null)
+      })
+    )
+
+    const { result, rerender } = renderHook(({ key }) => useEntityNote('IP', key), {
+      initialProps: { key: '10.0.0.1' },
+    })
+    await waitFor(() => expect(result.current.noteText).toBe('Jump box'))
+
+    rerender({ key: '10.0.0.2' })
+
+    // The modal is reused across entities. Without the reset, the second host would display —
+    // and could be saved — with the first host's note.
+    await waitFor(() => expect(result.current.noteText).toBe(''))
+    expect(result.current.savedNote).toBeNull()
+  })
+
+  it('marks the draft changed once it diverges from the saved note', async () => {
+    server.use(http.get('*/api/v1/entity-notes', () => HttpResponse.json(null)))
+
+    const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+    await waitFor(() => expect(result.current.noteChanged).toBe(false))
+
+    act(() => result.current.setNoteText('new finding'))
+
+    expect(result.current.noteChanged).toBe(true)
+  })
+
+  it('stores the saved note returned by the server', async () => {
+    server.use(
+      http.get('*/api/v1/entity-notes', () => HttpResponse.json(null)),
+      http.put('*/api/v1/entity-notes', () => HttpResponse.json(note('10.0.0.1', 'persisted')))
+    )
+
+    const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+    act(() => result.current.setNoteText('persisted'))
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    expect(result.current.savedNote?.note).toBe('persisted')
+    expect(result.current.noteSaving).toBe(false)
+  })
+
+  describe('swallowed failures — pinned, not endorsed', () => {
+    it('keeps the draft and reports nothing when a save fails', async () => {
+      server.use(
+        http.get('*/api/v1/entity-notes', () => HttpResponse.json(null)),
+        http.put('*/api/v1/entity-notes', () =>
+          HttpResponse.json({ message: 'boom' }, { status: 500 })
+        )
+      )
+
+      const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+      act(() => result.current.setNoteText('unsaved finding'))
+
+      await act(async () => {
+        await result.current.save()
+      })
+
+      // The catch only console.errors, so the hook exposes no error state. The draft still
+      // reads as unsaved (noteChanged stays true), which is the single thing standing between
+      // an operator and losing what they typed — but nothing tells them the save failed.
+      expect(result.current.savedNote).toBeNull()
+      expect(result.current.noteChanged).toBe(true)
+      expect(result.current.noteSaving).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Phase 3 of #659 — **2 of 14 hooks**.

## Why this hook

`useEntityNote` backs the one control that writes an **operator's own words** into the tool. Its failure modes cost information, not a re-render.

## The leak guard

```ts
// Reset so a previous entity's note can't leak when the modal is reused.
setSavedNote(null);
setNoteText('');
```

The modal is reused across entities. Without this, the second host would **display — and could be saved with — the first host's note**. The source comments the guard; nothing tested it. Deleting those two lines now fails.

## The swallowed failure, pinned not endorsed

Every failure path in the hook is a `console.error`, so it exposes **no error state at all**. On a failed save:

- `savedNote` stays null and `noteChanged` stays true — the draft still reads as unsaved, which is the single thing standing between an operator and losing what they typed
- but **nothing tells them the save failed**

This is the UI-side half of the `getNote` finding in #702, where the catch returns null for every error including a 500. **Both ends of this feature turn failures into silence.** Recorded on both sides rather than fixed, so a correction is a deliberate change with a visible diff.

## Proven by mutation

Removing the reset fails `× clears the previous entity note when the key changes`. Reverting returns **343/343**.

## Test plan

- [x] 343 tests across 23 files (was 338 / 22)
- [x] Mutation above; reverting restores green
- [x] `tsc`, `typecheck:test`, `lint:contract` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
