### PR TITLE
test: complete the frontend test harness (#659 phase 3)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.4",
         "@types/color-hash": "^2.0.0",
         "@types/d3": "^7.4.3",
         "@types/node": "^24.10.1",
@@ -2361,6 +2362,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
+      "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,6 +64,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.4",
     "@types/color-hash": "^2.0.0",
     "@types/d3": "^7.4.3",
     "@types/node": "^24.10.1",

--- a/frontend/src/components/common/Alert/__tests__/Alert.test.tsx
+++ b/frontend/src/components/common/Alert/__tests__/Alert.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Regression cover for #384.
+ *
+ * React 19 ignores `defaultProps` on function components, but SGDS's Alert relies on them for
+ * `show` and `transition`. Without this wrapper `show` is undefined, SGDS returns null, and the
+ * page renders an empty invisible container — every error message in the app silently vanishes
+ * while the code that raised it looks correct.
+ *
+ * That failure mode is the reason this tiny component deserves tests: nothing throws, nothing
+ * logs, the alert simply is not there.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Alert } from '../Alert'
+
+describe('Alert', () => {
+  it('renders its content without being told to show', () => {
+    render(<Alert variant="danger">Analysis failed on server</Alert>)
+
+    // The whole point of the wrapper. If this fails, every error banner in the app is invisible.
+    expect(screen.getByText('Analysis failed on server')).toBeInTheDocument()
+  })
+
+  it('still honours an explicit show={false}', () => {
+    render(<Alert show={false}>Should not appear</Alert>)
+
+    // The default must not become a hard-coded true, or callers lose the ability to hide one.
+    expect(screen.queryByText('Should not appear')).not.toBeInTheDocument()
+  })
+
+  it('honours an explicit show={true}', () => {
+    render(<Alert show>Explicitly shown</Alert>)
+
+    expect(screen.getByText('Explicitly shown')).toBeInTheDocument()
+  })
+
+  it('renders immediately rather than fading in', () => {
+    render(<Alert variant="warning">Immediate</Alert>)
+
+    // transition defaults to false because react-transition-group's Fade also misbehaves under
+    // React 19. With a transition the element is present but starts hidden, which reintroduces
+    // the same "message never appeared" symptom by a different route.
+    const alert = screen.getByText('Immediate').closest('.alert')
+    expect(alert).not.toHaveClass('fade')
+  })
+
+  it('keeps the variant class so severity is still conveyed', () => {
+    render(<Alert variant="danger">Bad news</Alert>)
+
+    // An alert that renders but looks neutral is nearly as bad as one that does not render.
+    expect(screen.getByText('Bad news').closest('.alert')).toHaveClass('alert-danger')
+  })
+
+  it('exposes the Heading and Link subcomponents the wrapper re-attaches', () => {
+    render(
+      <Alert variant="info">
+        <Alert.Heading>Heads up</Alert.Heading>
+        <Alert.Link href="/docs">docs</Alert.Link>
+      </Alert>
+    )
+
+    // Object.assign re-attaches these; forgetting one is a runtime "is not a component" crash
+    // at the call site rather than a compile error.
+    expect(screen.getByText('Heads up')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'docs' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityHistory.test.tsx
+++ b/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityHistory.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Which uploaded captures an entity appeared in. Small hook, but it is the one that answers
+ * "have we seen this host before" — so an empty list must mean "never seen", not "the request
+ * failed".
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  entityNotesService,
+  type EntityHistoryEntry,
+} from '@/features/notes/services/entityNotesService'
+import { useEntityHistory } from '../useEntityHistory'
+
+vi.mock('@/features/notes/services/entityNotesService', () => ({
+  entityNotesService: { getHistory: vi.fn() },
+}))
+
+const mocked = vi.mocked(entityNotesService)
+
+const entry = (fileId: string): EntityHistoryEntry => ({
+  fileId,
+  fileName: `${fileId}.pcap`,
+  startTime: null,
+  endTime: null,
+  packetCount: null,
+  totalBytes: null,
+})
+
+afterEach(() => vi.resetAllMocks())
+
+describe('useEntityHistory', () => {
+  it('loads the capture history', async () => {
+    mocked.getHistory.mockResolvedValue([entry('f1'), entry('f2')])
+
+    const { result } = renderHook(() => useEntityHistory('IP', '10.0.0.1'))
+
+    await waitFor(() => expect(result.current.history).toHaveLength(2))
+    expect(result.current.historyError).toBeNull()
+    expect(result.current.historyLoading).toBe(false)
+  })
+
+  it('distinguishes a failure from an empty history', async () => {
+    mocked.getHistory.mockRejectedValue(new Error('backend down'))
+
+    const { result } = renderHook(() => useEntityHistory('IP', '10.0.0.1'))
+
+    // Both leave `history` empty, so the error flag is the only thing separating "this host is
+    // new" from "we could not check". Reporting the first when the second is true would let an
+    // analyst treat a known host as unseen.
+    await waitFor(() => expect(result.current.historyError).toBe('Failed to load history'))
+    expect(result.current.history).toEqual([])
+    expect(result.current.historyLoading).toBe(false)
+  })
+
+  it('clears the previous entity history immediately on switch', async () => {
+    mocked.getHistory.mockResolvedValue([entry('f1')])
+    const { result, rerender } = renderHook(({ key }) => useEntityHistory('IP', key), {
+      initialProps: { key: '10.0.0.1' },
+    })
+    await waitFor(() => expect(result.current.history).toHaveLength(1))
+
+    mocked.getHistory.mockReturnValue(new Promise(() => {}))
+    rerender({ key: '10.0.0.2' })
+
+    // The modal is reused, so one host's capture history must not sit under another's heading.
+    expect(result.current.history).toEqual([])
+  })
+
+  it('clears a stale error when a new entity loads cleanly', async () => {
+    mocked.getHistory.mockRejectedValueOnce(new Error('boom'))
+    const { result, rerender } = renderHook(({ key }) => useEntityHistory('IP', key), {
+      initialProps: { key: '10.0.0.1' },
+    })
+    await waitFor(() => expect(result.current.historyError).not.toBeNull())
+
+    mocked.getHistory.mockResolvedValue([entry('f1')])
+    rerender({ key: '10.0.0.2' })
+
+    // A left-over error would label a perfectly good history as broken.
+    //
+    // Both fields are asserted inside one waitFor rather than sequentially: the first
+    // entity's rejection can still be settling when the rerender happens, so the error is
+    // briefly non-null again. Checking them one at a time made this flake roughly one run in
+    // five — a flaky test is worse than none, because it teaches people to re-run.
+    await waitFor(() => {
+      expect(result.current.historyError).toBeNull()
+      expect(result.current.history).toHaveLength(1)
+    })
+  })
+
+  it('ignores a slow response for an entity the user has already left', async () => {
+    let resolveFirst: (v: EntityHistoryEntry[]) => void = () => {}
+    mocked.getHistory.mockImplementationOnce(
+      () => new Promise<EntityHistoryEntry[]>(res => { resolveFirst = res })
+    )
+
+    const { result, rerender } = renderHook(({ key }) => useEntityHistory('IP', key), {
+      initialProps: { key: '10.0.0.1' },
+    })
+
+    mocked.getHistory.mockResolvedValue([entry('second')])
+    rerender({ key: '10.0.0.2' })
+    await waitFor(() => expect(result.current.history[0]?.fileId).toBe('second'))
+
+    await waitFor(async () => { resolveFirst([entry('first')]) })
+
+    expect(result.current.history[0]?.fileId).toBe('second')
+  })
+})

--- a/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityNote.test.tsx
+++ b/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityNote.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * The entity detail modal is reused across hosts: clicking one node then another mounts the
+ * same component with new props. That makes the reset and the stale-response guard the two
+ * properties worth testing — both are invisible until an analyst sees one host's note attached
+ * to another.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { entityNotesService, type EntityNote } from '@/features/notes/services/entityNotesService'
+import { useEntityNote } from '../useEntityNote'
+
+vi.mock('@/features/notes/services/entityNotesService', () => ({
+  entityNotesService: {
+    getNote: vi.fn(),
+    upsertNote: vi.fn(),
+    deleteNote: vi.fn(),
+  },
+}))
+
+const mocked = vi.mocked(entityNotesService)
+
+function note(text: string, key = '10.0.0.1'): EntityNote {
+  return {
+    entityType: 'IP',
+    entityKey: key,
+    note: text,
+    createdAt: '2026-08-12T00:00:00Z',
+    updatedAt: '2026-08-12T00:00:00Z',
+  }
+}
+
+afterEach(() => vi.resetAllMocks())
+
+describe('useEntityNote', () => {
+  it('loads the existing note into the draft', async () => {
+    mocked.getNote.mockResolvedValue(note('DNS server'))
+
+    const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+
+    await waitFor(() => expect(result.current.noteText).toBe('DNS server'))
+    expect(result.current.noteChanged).toBe(false)
+  })
+
+  it('clears the previous note immediately when the entity changes', async () => {
+    mocked.getNote.mockResolvedValue(note('first host'))
+    const { result, rerender } = renderHook(({ key }) => useEntityNote('IP', key), {
+      initialProps: { key: '10.0.0.1' },
+    })
+    await waitFor(() => expect(result.current.noteText).toBe('first host'))
+
+    mocked.getNote.mockReturnValue(new Promise(() => {}))
+    rerender({ key: '10.0.0.2' })
+
+    // Synchronously blank, not "blank once the fetch returns". The modal is reused, so leaving
+    // the old text visible would attribute one host's note to another.
+    expect(result.current.noteText).toBe('')
+    expect(result.current.savedNote).toBeNull()
+  })
+
+  it('ignores a slow response for an entity the user has already left', async () => {
+    let resolveFirst: (n: EntityNote) => void = () => {}
+    mocked.getNote.mockImplementationOnce(
+      () => new Promise<EntityNote>(res => { resolveFirst = res })
+    )
+
+    const { result, rerender } = renderHook(({ key }) => useEntityNote('IP', key), {
+      initialProps: { key: '10.0.0.1' },
+    })
+
+    mocked.getNote.mockResolvedValue(note('second host', '10.0.0.2'))
+    rerender({ key: '10.0.0.2' })
+    await waitFor(() => expect(result.current.noteText).toBe('second host'))
+
+    // The first request now lands. Without the `active` flag it would overwrite the note the
+    // user is actually looking at — the classic out-of-order response bug.
+    await act(async () => {
+      resolveFirst(note('first host'))
+    })
+
+    expect(result.current.noteText).toBe('second host')
+  })
+
+  it('tracks whether the draft differs from what is saved', async () => {
+    mocked.getNote.mockResolvedValue(note('original'))
+    const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+    await waitFor(() => expect(result.current.noteText).toBe('original'))
+
+    act(() => result.current.setNoteText('edited'))
+
+    // Drives the Save button's enabled state.
+    expect(result.current.noteChanged).toBe(true)
+  })
+
+  it('treats an empty draft against no saved note as unchanged', async () => {
+    mocked.getNote.mockResolvedValue(null)
+
+    const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+
+    // `savedNote?.note ?? ''` — otherwise an untouched empty field would look edited and offer
+    // to save nothing.
+    await waitFor(() => expect(result.current.noteChanged).toBe(false))
+  })
+
+  it('adopts the saved note returned by the backend after a save', async () => {
+    mocked.getNote.mockResolvedValue(null)
+    mocked.upsertNote.mockResolvedValue(note('saved text'))
+
+    const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+    act(() => result.current.setNoteText('saved text'))
+    await act(async () => { await result.current.save() })
+
+    // Takes the server's copy, so createdAt/updatedAt come from the backend rather than being
+    // guessed locally.
+    expect(result.current.savedNote?.note).toBe('saved text')
+    expect(result.current.noteChanged).toBe(false)
+  })
+
+  it('clears the draft after a successful delete', async () => {
+    mocked.getNote.mockResolvedValue(note('to be removed'))
+    mocked.deleteNote.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+    await waitFor(() => expect(result.current.noteText).toBe('to be removed'))
+
+    await act(async () => { await result.current.remove() })
+
+    expect(result.current.savedNote).toBeNull()
+    expect(result.current.noteText).toBe('')
+  })
+
+  describe('known looseness — pinned, not endorsed', () => {
+    it('swallows a failed save, leaving no signal beyond a console error', async () => {
+      mocked.getNote.mockResolvedValue(null)
+      mocked.upsertNote.mockRejectedValue(new Error('backend down'))
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const { result } = renderHook(() => useEntityNote('IP', '10.0.0.1'))
+      act(() => result.current.setNoteText('important finding'))
+      await act(async () => { await result.current.save() })
+
+      // save() resolves either way and exposes no error state. The draft is preserved and
+      // noteChanged stays true, which is the only hint anything went wrong — an analyst who
+      // closes the modal loses the note believing it was stored. Notes already swallow read
+      // errors too (#719), so both directions fail quietly.
+      expect(result.current.savedNote).toBeNull()
+      expect(result.current.noteChanged).toBe(true)
+      expect(result.current.noteSaving).toBe(false)
+      expect(consoleError).toHaveBeenCalled()
+      consoleError.mockRestore()
+    })
+  })
+})

--- a/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityRole.test.tsx
+++ b/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityRole.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Node roles are operator-owned labels: an analyst decides a host is "branch printer" and that
+ * sticks across captures. The safety property is that an AI suggestion never silently replaces
+ * a label a human confirmed — it goes into the editor for review instead.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { insightsService } from '@/features/insights/services/insightsService'
+import type { NodeRole } from '@/features/insights/types/insights.types'
+import { useEntityRole } from '../useEntityRole'
+
+vi.mock('@/features/insights/services/insightsService', () => ({
+  insightsService: {
+    getNodeRole: vi.fn(),
+    suggestNodeRole: vi.fn(),
+    suggestNodeRolePreview: vi.fn(),
+    upsertNodeRole: vi.fn(),
+    deleteNodeRole: vi.fn(),
+  },
+}))
+
+const mocked = vi.mocked(insightsService)
+const FILE = '11111111-1111-1111-1111-111111111111'
+
+const role = (overrides: Partial<NodeRole> = {}): NodeRole =>
+  ({
+    roleLabel: 'branch printer',
+    roleDescription: 'prints things',
+    confirmedByHuman: false,
+    ...overrides,
+  }) as NodeRole
+
+afterEach(() => vi.resetAllMocks())
+
+function render(showRole = true) {
+  return renderHook(() => useEntityRole('IP', '10.0.0.1', FILE, showRole))
+}
+
+describe('useEntityRole', () => {
+  it('loads the existing role', async () => {
+    mocked.getNodeRole.mockResolvedValue(role())
+
+    const { result } = render()
+
+    await waitFor(() => expect(result.current.role?.roleLabel).toBe('branch printer'))
+  })
+
+  it('does not fetch when the role section is hidden', async () => {
+    const { result } = render(false)
+
+    await waitFor(() => expect(result.current.roleLoading).toBe(false))
+    expect(mocked.getNodeRole).not.toHaveBeenCalled()
+  })
+
+  describe('suggest', () => {
+    it('replaces an unconfirmed role outright', async () => {
+      mocked.getNodeRole.mockResolvedValue(role({ confirmedByHuman: false }))
+      mocked.suggestNodeRole.mockResolvedValue(role({ roleLabel: 'ai guess' }))
+
+      const { result } = render()
+      await waitFor(() => expect(result.current.role).not.toBeNull())
+      await act(async () => { await result.current.suggest() })
+
+      // Nothing human-authored is at stake, so the suggestion is applied directly.
+      expect(result.current.role?.roleLabel).toBe('ai guess')
+      expect(result.current.roleEditing).toBe(false)
+    })
+
+    it('never overwrites a human-confirmed label, offering the suggestion for review', async () => {
+      mocked.getNodeRole.mockResolvedValue(
+        role({ roleLabel: 'analyst label', confirmedByHuman: true })
+      )
+      mocked.suggestNodeRolePreview.mockResolvedValue({
+        roleLabel: 'ai guess',
+        roleDescription: 'ai description',
+      })
+
+      const { result } = render()
+      await waitFor(() => expect(result.current.role?.confirmedByHuman).toBe(true))
+      await act(async () => { await result.current.suggest() })
+
+      // The whole point of a confirmed label: it survives until the analyst says otherwise.
+      // The suggestion lands in the draft and the editor opens for a decision.
+      expect(result.current.role?.roleLabel).toBe('analyst label')
+      expect(result.current.roleLabelDraft).toBe('ai guess')
+      expect(result.current.roleEditing).toBe(true)
+      expect(mocked.suggestNodeRole).not.toHaveBeenCalled()
+    })
+
+    it('surfaces the suggestion error message', async () => {
+      mocked.getNodeRole.mockResolvedValue(null)
+      mocked.suggestNodeRole.mockRejectedValue(new Error('Only 2 conversations seen'))
+
+      const { result } = render()
+      await waitFor(() => expect(result.current.roleLoading).toBe(false))
+      await act(async () => { await result.current.suggest() })
+
+      // insightsService turns a 422 into this message; the hook must show it rather than
+      // discarding the reason no role could be suggested.
+      expect(result.current.roleSuggestError).toBe('Only 2 conversations seen')
+      expect(result.current.roleSuggesting).toBe(false)
+    })
+  })
+
+  it('marks a role confirmed when accepted', async () => {
+    mocked.getNodeRole.mockResolvedValue(role())
+    mocked.upsertNodeRole.mockResolvedValue(role({ confirmedByHuman: true }))
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.role).not.toBeNull())
+    await act(async () => { await result.current.accept() })
+
+    // The `true` argument is the confirmation flag — accepting an AI guess is what promotes it
+    // to a human-owned label that later suggestions must not overwrite.
+    expect(mocked.upsertNodeRole).toHaveBeenCalledWith(
+      'IP', '10.0.0.1', 'branch printer', 'prints things', true, FILE
+    )
+    expect(result.current.role?.confirmedByHuman).toBe(true)
+  })
+
+  it('clears the role on discard', async () => {
+    mocked.getNodeRole.mockResolvedValue(role())
+    mocked.deleteNodeRole.mockResolvedValue(undefined)
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.role).not.toBeNull())
+    await act(async () => { await result.current.discard() })
+
+    expect(result.current.role).toBeNull()
+    expect(result.current.roleEditing).toBe(false)
+  })
+
+  it('seeds the editor from the current role', async () => {
+    mocked.getNodeRole.mockResolvedValue(role())
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.role).not.toBeNull())
+    act(() => result.current.openEdit())
+
+    // Editing starts from what is there, so a small correction does not require retyping.
+    expect(result.current.roleLabelDraft).toBe('branch printer')
+    expect(result.current.roleDescDraft).toBe('prints things')
+    expect(result.current.roleEditing).toBe(true)
+  })
+
+  it('saves the draft as a confirmed role', async () => {
+    mocked.getNodeRole.mockResolvedValue(null)
+    mocked.upsertNodeRole.mockResolvedValue(role({ roleLabel: 'edited', confirmedByHuman: true }))
+
+    const { result } = render()
+    await waitFor(() => expect(result.current.roleLoading).toBe(false))
+    act(() => result.current.setRoleLabelDraft('edited'))
+    await act(async () => { await result.current.save() })
+
+    expect(mocked.upsertNodeRole).toHaveBeenCalledWith(
+      'IP', '10.0.0.1', 'edited', '', true, FILE
+    )
+    expect(result.current.role?.roleLabel).toBe('edited')
+  })
+})

--- a/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityStats.test.tsx
+++ b/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useEntityStats.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Aggregate stats for an application or protocol, computed server-side so the numbers stay
+ * internally consistent however many conversations match (#436). The hook's job is deciding
+ * *when* to ask and *how* to name the filter — get either wrong and the modal shows another
+ * entity's totals, or none.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { server } from '@/test/msw'
+import { useEntityStats } from '../useEntityStats'
+
+const FILE = '11111111-1111-1111-1111-111111111111'
+
+const payload = {
+  conversationCount: 3,
+  packetCount: 300,
+  totalBytes: 30000,
+  topPeers: [{ ip: '8.8.8.8', bytes: 1000 }],
+}
+
+/** Serves the stats endpoint and records the query it was asked with. */
+function serveStats(status = 200) {
+  const seen: { query?: URLSearchParams; calls: number } = { calls: 0 }
+  server.use(
+    http.get('*/entity-stats', ({ request }) => {
+      seen.calls += 1
+      seen.query = new URL(request.url).searchParams
+      return status === 200
+        ? HttpResponse.json(payload)
+        : HttpResponse.json({ message: 'boom' }, { status })
+    })
+  )
+  return seen
+}
+
+describe('useEntityStats', () => {
+  it('loads stats for an APPLICATION entity', async () => {
+    serveStats()
+
+    const { result } = renderHook(() => useEntityStats('APPLICATION', 'TLS', FILE))
+
+    await waitFor(() => expect(result.current.stats).not.toBeNull())
+    expect(result.current.stats).toEqual(payload)
+    expect(result.current.statsError).toBeNull()
+  })
+
+  it('filters by app for an APPLICATION and by l7Protocol for a PROTOCOL', async () => {
+    const app = serveStats()
+    const { unmount } = renderHook(() => useEntityStats('APPLICATION', 'TLS', FILE))
+    await waitFor(() => expect(app.query?.get('app')).toBe('TLS'))
+    unmount()
+
+    const proto = serveStats()
+    renderHook(() => useEntityStats('PROTOCOL', 'TCP', FILE))
+
+    // Two different backend filters behind one modal. Swapping them returns stats for a
+    // different entity entirely, with nothing to indicate the mix-up.
+    await waitFor(() => expect(proto.query?.get('l7Protocol')).toBe('TCP'))
+    expect(proto.query?.has('app')).toBe(false)
+  })
+
+  it('encodes an entity key containing URL-significant characters', async () => {
+    const seen = serveStats()
+
+    renderHook(() => useEntityStats('APPLICATION', 'Google/Maps', FILE))
+
+    // A raw "/" would change the path; "&" would start a second parameter.
+    await waitFor(() => expect(seen.query?.get('app')).toBe('Google/Maps'))
+  })
+
+  it.each(['IP', 'DEVICE'] as const)('does not fetch for a %s entity', async entityType => {
+    const seen = serveStats()
+
+    const { result } = renderHook(() => useEntityStats(entityType, '10.0.0.1', FILE))
+
+    // The endpoint only aggregates applications and protocols; asking it about a host would
+    // return nothing useful and cost a request per modal open.
+    await waitFor(() => expect(result.current.statsLoading).toBe(false))
+    expect(seen.calls).toBe(0)
+    expect(result.current.stats).toBeNull()
+  })
+
+  it.each([
+    ['a missing fileId', ''],
+    ['a blank entity key', '   '],
+  ])('does not fetch with %s', async (_label, key) => {
+    const seen = serveStats()
+    const fileId = key === '' ? '' : FILE
+    const entityKey = key === '' ? 'TLS' : key
+
+    renderHook(() => useEntityStats('APPLICATION', entityKey, fileId))
+
+    await waitFor(() => expect(seen.calls).toBe(0))
+  })
+
+  it('surfaces a failure as an error message rather than silence', async () => {
+    serveStats(500)
+
+    const { result } = renderHook(() => useEntityStats('APPLICATION', 'TLS', FILE))
+
+    // Contrast with useEntityNote, which swallows failures to console.error. Here the modal
+    // can tell the analyst the totals are unavailable instead of implying they are zero.
+    await waitFor(() => expect(result.current.statsError).toBe('Failed to load details'))
+    expect(result.current.stats).toBeNull()
+    expect(result.current.statsLoading).toBe(false)
+  })
+
+  it('clears previous stats when the entity changes', async () => {
+    serveStats()
+    const { result, rerender } = renderHook(({ key }) => useEntityStats('APPLICATION', key, FILE), {
+      initialProps: { key: 'TLS' },
+    })
+    await waitFor(() => expect(result.current.stats).not.toBeNull())
+
+    server.use(http.get('*/entity-stats', () => new Promise(() => {}) as never))
+    rerender({ key: 'HTTP' })
+
+    // The modal is reused across entities, so stale totals must not sit under a new heading
+    // while the next request is in flight.
+    expect(result.current.stats).toBeNull()
+  })
+})

--- a/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useIpSnapshotHistory.test.tsx
+++ b/frontend/src/components/common/EntityDetailModal/hooks/__tests__/useIpSnapshotHistory.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Per-snapshot history for an IP or a MAC across a monitor network. This is the view an analyst
+ * uses to answer "did this address change hands", so the two halves are mirror images: for an IP,
+ * which MACs claimed it; for a DEVICE, which IPs that MAC used. More than one on either side is
+ * the conflict worth seeing.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import type { NetworkSnapshot } from '@/features/monitor/types/monitor.types'
+import { server } from '@/test/msw'
+import { useIpSnapshotHistory } from '../useIpSnapshotHistory'
+
+const snapshot = (id: string, fileId: string, order: number) =>
+  ({ id, fileId, snapshotOrder: order }) as NetworkSnapshot
+
+/**
+ * Serves the three endpoints the hook fans out to, keyed by fileId so each snapshot can carry
+ * different data.
+ */
+function serve(byFile: Record<string, { classifications?: unknown[]; observations?: unknown[] }>) {
+  server.use(
+    http.get('*/files/:fileId/host-classifications', ({ params }) =>
+      HttpResponse.json(byFile[params.fileId as string]?.classifications ?? [])
+    ),
+    http.get('*/files/:fileId/ip-mac-observations', ({ params }) =>
+      HttpResponse.json(byFile[params.fileId as string]?.observations ?? [])
+    ),
+    http.get('*/node-roles', () => new HttpResponse(null, { status: 404 })),
+    http.get('*/conversations/*', () => HttpResponse.json({ data: [] }))
+  )
+}
+
+describe('useIpSnapshotHistory', () => {
+  it('keeps only the snapshots where the IP appeared', async () => {
+    serve({
+      'file-1': { classifications: [{ ip: '10.0.0.1', mac: 'aa:bb:cc:dd:ee:ff' }] },
+      'file-2': { classifications: [{ ip: '10.0.0.9', mac: '11:22:33:44:55:66' }] },
+    })
+
+    const { result } = renderHook(() =>
+      useIpSnapshotHistory('IP', '10.0.0.1', [
+        snapshot('s1', 'file-1', 1),
+        snapshot('s2', 'file-2', 2),
+      ])
+    )
+
+    // A row per snapshot the host was absent from would imply it vanished, when it was simply
+    // never captured there.
+    await waitFor(() => expect(result.current.ipSnapHistory).toHaveLength(1))
+    expect(result.current.ipSnapHistory[0].snap.id).toBe('s1')
+  })
+
+  it('orders history by snapshotOrder, not by the order snapshots were passed in', async () => {
+    serve({
+      'file-1': { classifications: [{ ip: '10.0.0.1', mac: 'aa:aa:aa:aa:aa:aa' }] },
+      'file-2': { classifications: [{ ip: '10.0.0.1', mac: 'bb:bb:bb:bb:bb:bb' }] },
+    })
+
+    const { result } = renderHook(() =>
+      useIpSnapshotHistory('IP', '10.0.0.1', [
+        snapshot('s2', 'file-2', 2),
+        snapshot('s1', 'file-1', 1),
+      ])
+    )
+
+    // The history reads as a timeline, so a reversed row order tells the opposite story about
+    // which MAC held the address first.
+    await waitFor(() => expect(result.current.ipSnapHistory).toHaveLength(2))
+    expect(result.current.ipSnapHistory.map(e => e.snap.id)).toEqual(['s1', 's2'])
+  })
+
+  it('lists every MAC that claimed the IP in a snapshot', async () => {
+    serve({
+      'file-1': {
+        classifications: [{ ip: '10.0.0.1', mac: 'aa:aa:aa:aa:aa:aa' }],
+        observations: [{ ip: '10.0.0.1', macs: ['aa:aa:aa:aa:aa:aa', 'bb:bb:bb:bb:bb:bb'] }],
+      },
+    })
+
+    const { result } = renderHook(() =>
+      useIpSnapshotHistory('IP', '10.0.0.1', [snapshot('s1', 'file-1', 1)])
+    )
+
+    // More than one MAC on an address is the overlap conflict this view exists to surface.
+    await waitFor(() => expect(result.current.ipSnapHistory).toHaveLength(1))
+    expect(result.current.ipSnapHistory[0].macs).toEqual([
+      'aa:aa:aa:aa:aa:aa',
+      'bb:bb:bb:bb:bb:bb',
+    ])
+  })
+
+  it('matches a MAC case-insensitively', async () => {
+    serve({
+      'file-1': {
+        classifications: [{ ip: '10.0.0.5', mac: 'AA:BB:CC:DD:EE:FF' }],
+        observations: [{ ip: '10.0.0.5', macs: ['AA:BB:CC:DD:EE:FF'] }],
+      },
+    })
+
+    const { result } = renderHook(() =>
+      useIpSnapshotHistory('DEVICE', 'aa:bb:cc:dd:ee:ff', [snapshot('s1', 'file-1', 1)])
+    )
+
+    // Captures and the UI disagree on MAC casing routinely. An exact match would show a device
+    // as absent from every snapshot it is actually in.
+    await waitFor(() => expect(result.current.ipSnapHistory).toHaveLength(1))
+    expect(result.current.ipSnapHistory[0].ips).toEqual(['10.0.0.5'])
+  })
+
+  it.each(['APPLICATION', 'PROTOCOL'] as const)('does not fetch for a %s entity', async type => {
+    let called = false
+    server.use(
+      http.get('*/files/:fileId/host-classifications', () => {
+        called = true
+        return HttpResponse.json([])
+      })
+    )
+
+    const { result } = renderHook(() =>
+      useIpSnapshotHistory(type, 'TLS', [snapshot('s1', 'file-1', 1)])
+    )
+
+    // Snapshot history is about addresses; an application has none.
+    await waitFor(() => expect(result.current.ipHistoryLoading).toBe(false))
+    expect(called).toBe(false)
+  })
+
+  it('does nothing without snapshots', async () => {
+    const { result } = renderHook(() => useIpSnapshotHistory('IP', '10.0.0.1', []))
+
+    await waitFor(() => expect(result.current.ipHistoryLoading).toBe(false))
+    expect(result.current.ipSnapHistory).toEqual([])
+  })
+
+  it('keeps the other snapshots when one snapshot fails to load', async () => {
+    server.use(
+      http.get('*/files/file-1/host-classifications', () =>
+        HttpResponse.json({ message: 'boom' }, { status: 500 })
+      ),
+      http.get('*/files/file-2/host-classifications', () =>
+        HttpResponse.json([{ ip: '10.0.0.1', mac: 'bb:bb:bb:bb:bb:bb' }])
+      ),
+      http.get('*/files/:fileId/ip-mac-observations', () => HttpResponse.json([])),
+      http.get('*/node-roles', () => new HttpResponse(null, { status: 404 })),
+      http.get('*/conversations/*', () => HttpResponse.json({ data: [] }))
+    )
+
+    const { result } = renderHook(() =>
+      useIpSnapshotHistory('IP', '10.0.0.1', [
+        snapshot('s1', 'file-1', 1),
+        snapshot('s2', 'file-2', 2),
+      ])
+    )
+
+    // Each snapshot is fetched independently and its failure caught, so one bad file does not
+    // blank a history spanning months.
+    await waitFor(() => expect(result.current.ipSnapHistory).toHaveLength(1))
+    expect(result.current.ipSnapHistory[0].snap.id).toBe('s2')
+  })
+})

--- a/frontend/src/components/common/HostnameSourceBadge/__tests__/HostnameSourceBadge.test.tsx
+++ b/frontend/src/components/common/HostnameSourceBadge/__tests__/HostnameSourceBadge.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * How a hostname was discovered decides how far to trust it. A DHCP option-12 name is whatever
+ * the host claimed about itself and is trivially spoofed; a reverse-DNS name came from the
+ * resolver. The badge exists so an analyst can tell those apart at a glance, which makes the
+ * label mapping the whole contract.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { HostnameSourceBadge } from '../HostnameSourceBadge'
+
+describe('HostnameSourceBadge', () => {
+  it.each([
+    ['dhcp', 'DHCP'],
+    ['mdns', 'mDNS'],
+    ['nbns', 'NBNS'],
+    ['reverse_dns', 'rDNS'],
+    ['manual', 'Manual'],
+  ])('labels %s as %s', (source, label) => {
+    render(<HostnameSourceBadge source={source} />)
+
+    // The abbreviations are not interchangeable: rDNS and mDNS differ by one character and by
+    // who asserted the name.
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+
+  it('explains the provenance on hover', () => {
+    render(<HostnameSourceBadge source="dhcp" />)
+
+    // The chip is four characters; the tooltip is where the caveat lives.
+    expect(screen.getByTitle(/DHCP request \(option 12\)/)).toBeInTheDocument()
+  })
+
+  it.each([undefined, null, ''])('renders nothing for %s', source => {
+    const { container } = render(<HostnameSourceBadge source={source} />)
+
+    // Most hosts have no discovered name. An empty chip beside every one of them would be
+    // noise on the densest screen in the app.
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing for a source it does not recognise', () => {
+    const { container } = render(<HostnameSourceBadge source="llmnr" />)
+
+    // Deliberately unlike GeoSourceBadge, which falls back to its cautious label. Here there is
+    // no safe default: inventing an abbreviation for an unknown mechanism would assert a
+    // provenance nobody established. Showing nothing says "unknown" honestly.
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/components/common/Pagination/__tests__/Pagination.test.tsx
+++ b/frontend/src/components/common/Pagination/__tests__/Pagination.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Shared by every table in the app, so its arithmetic is repeated everywhere at once. The
+ * "Showing X to Y of Z" line is the only place a user can check that a filter did what they
+ * expected, which makes an off-by-one here quietly corrosive rather than cosmetic.
+ */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Pagination } from '../Pagination'
+
+function renderPager(props: Partial<Parameters<typeof Pagination>[0]> = {}) {
+  const onPageChange = vi.fn()
+  const onPageSizeChange = vi.fn()
+  const { container } = render(
+    <Pagination
+      currentPage={1}
+      totalPages={4}
+      totalItems={100}
+      pageSize={25}
+      onPageChange={onPageChange}
+      onPageSizeChange={onPageSizeChange}
+      {...props}
+    />
+  )
+  return { onPageChange, onPageSizeChange, container }
+}
+
+describe('Pagination', () => {
+  it('renders nothing when there are no pages', () => {
+    const { container } = renderPager({ totalPages: 0 })
+
+    // An empty pager below an empty table is noise; the table already says it is empty.
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('counts from one on the first page', () => {
+    renderPager({ currentPage: 1, pageSize: 25, totalItems: 100 })
+
+    // Off by one here is the classic: "Showing 0 to 25" or "1 to 26" both look plausible.
+    expect(screen.getByText(/Showing 1 to 25 of 100 items/)).toBeInTheDocument()
+  })
+
+  it('offsets the range on a later page', () => {
+    renderPager({ currentPage: 3, pageSize: 25, totalItems: 100 })
+
+    expect(screen.getByText(/Showing 51 to 75 of 100 items/)).toBeInTheDocument()
+  })
+
+  it('clamps the last page to the item count', () => {
+    renderPager({ currentPage: 3, totalPages: 3, pageSize: 25, totalItems: 60 })
+
+    // Without the clamp this reads "Showing 51 to 75 of 60", which is visibly wrong and
+    // undermines confidence in every other number on the page.
+    expect(screen.getByText(/Showing 51 to 60 of 60 items/)).toBeInTheDocument()
+  })
+
+  it('shows a zero range rather than "1 to 0" when there is nothing to show', () => {
+    renderPager({ totalPages: 1, totalItems: 0 })
+
+    expect(screen.getByText(/Showing 0 to 0 of 0 items/)).toBeInTheDocument()
+  })
+
+  it('reports the chosen page to the caller', async () => {
+    const { onPageChange } = renderPager()
+
+    await userEvent.click(screen.getByText('3'))
+
+    expect(onPageChange).toHaveBeenCalledWith(3)
+  })
+
+  it('reports a page size change', async () => {
+    const { onPageSizeChange } = renderPager()
+
+    await userEvent.selectOptions(screen.getByLabelText(/Items per page/), '50')
+
+    expect(onPageSizeChange).toHaveBeenCalledWith(50)
+  })
+
+  it('hides the page-size selector when the caller cannot handle it', () => {
+    render(
+      <Pagination currentPage={1} totalPages={4} totalItems={100} onPageChange={vi.fn()} />
+    )
+
+    // Offering a control that does nothing is worse than not offering it.
+    expect(screen.queryByLabelText(/Items per page/)).not.toBeInTheDocument()
+  })
+
+  it('offers the page sizes it was given', () => {
+    renderPager({ pageSizeOptions: [5, 10] })
+
+    expect(screen.getByRole('option', { name: '5' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: '25' })).not.toBeInTheDocument()
+  })
+
+  it('marks itself compact for narrow containers', () => {
+    const { container } = renderPager({ compact: true })
+
+    // The drift panels put this in a ~250px column; the compact class is what stops the pager
+    // wrapping onto three rows there.
+    expect(container.querySelector('.pagination-container--compact')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/common/RoleEditModal/__tests__/RoleEditModal.test.tsx
+++ b/frontend/src/components/common/RoleEditModal/__tests__/RoleEditModal.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Per-snapshot role editing (#369). The semantics are the sharp edge: a role set here applies
+ * from this snapshot *forward* and leaves earlier ones alone. An analyst who assumes it relabels
+ * the whole timeline will silently disagree with what monitor mode reports for older snapshots.
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { insightsService } from '@/features/insights/services/insightsService'
+import { RoleEditModal } from '../RoleEditModal'
+
+vi.mock('@/features/insights/services/insightsService', () => ({
+  insightsService: {
+    getNodeRole: vi.fn(),
+    suggestNodeRolePreview: vi.fn(),
+    upsertNodeRole: vi.fn(),
+    dismissNodeRoleStaleness: vi.fn(),
+  },
+}))
+
+const mocked = vi.mocked(insightsService)
+const FILE = '11111111-1111-1111-1111-111111111111'
+
+afterEach(() => vi.resetAllMocks())
+
+function renderModal() {
+  const onClose = vi.fn()
+  const onSaved = vi.fn()
+  render(
+    <RoleEditModal
+      entityType="IP"
+      entityKey="10.0.0.1"
+      fileId={FILE}
+      snapshotName="monday.pcap"
+      onClose={onClose}
+      onSaved={onSaved}
+    />
+  )
+  return { onClose, onSaved }
+}
+
+describe('RoleEditModal', () => {
+  it('states that the edit applies forward and not backward', async () => {
+    mocked.getNodeRole.mockResolvedValue(null as never)
+    renderModal()
+
+    // The one thing a user must not get wrong. Losing this wording turns a scoped edit into an
+    // assumed retroactive one.
+    expect(screen.getByText(/carries forward/)).toBeInTheDocument()
+    expect(screen.getByText(/Earlier snapshots are\s+not changed/)).toBeInTheDocument()
+  })
+
+  it('loads the existing role into the form', async () => {
+    mocked.getNodeRole.mockResolvedValue({
+      roleLabel: 'branch printer',
+      roleDescription: 'prints things',
+    } as never)
+
+    renderModal()
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue('branch printer')).toBeInTheDocument()
+    )
+    expect(screen.getByDisplayValue('prints things')).toBeInTheDocument()
+  })
+
+  it('starts blank when the entity has no role in this snapshot', async () => {
+    mocked.getNodeRole.mockResolvedValue(null as never)
+
+    renderModal()
+
+    // A role carried forward from an earlier snapshot must not be pre-filled here as though it
+    // were set on this one.
+    await waitFor(() => expect(mocked.getNodeRole).toHaveBeenCalled())
+    const label = await screen.findByPlaceholderText(/File Server/i)
+    expect(label).toHaveValue('')
+  })
+
+  it('fills the form from an AI suggestion without saving it', async () => {
+    mocked.getNodeRole.mockResolvedValue(null as never)
+    mocked.suggestNodeRolePreview.mockResolvedValue({
+      roleLabel: 'file server',
+      roleDescription: 'serves files',
+    } as never)
+    renderModal()
+    await waitFor(() => expect(mocked.getNodeRole).toHaveBeenCalled())
+
+    await userEvent.click(screen.getByRole('button', { name: /suggest/i }))
+
+    // Preview, not persist: the analyst reviews before committing, so nothing is written until
+    // they press Save.
+    await waitFor(() => expect(screen.getByDisplayValue('file server')).toBeInTheDocument())
+    expect(mocked.upsertNodeRole).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the reason a suggestion could not be made', async () => {
+    mocked.getNodeRole.mockResolvedValue(null as never)
+    mocked.suggestNodeRolePreview.mockRejectedValue(new Error('Only 2 conversations seen'))
+    renderModal()
+    await waitFor(() => expect(mocked.getNodeRole).toHaveBeenCalled())
+
+    await userEvent.click(screen.getByRole('button', { name: /suggest/i }))
+
+    // insightsService turns a 422 into this message; swallowing it leaves the analyst pressing
+    // a button that appears to do nothing.
+    expect(await screen.findByText(/Only 2 conversations seen/)).toBeInTheDocument()
+  })
+
+  it('saves as a human-confirmed role scoped to this snapshot', async () => {
+    mocked.getNodeRole.mockResolvedValue(null as never)
+    mocked.upsertNodeRole.mockResolvedValue({} as never)
+    const { onSaved, onClose } = renderModal()
+    await waitFor(() => expect(mocked.getNodeRole).toHaveBeenCalled())
+
+    await userEvent.type(await screen.findByPlaceholderText(/File Server/i), 'printer')
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    // `true` is the confirmed flag and fileId is the snapshot scope — dropping either turns a
+    // deliberate per-snapshot label into an unconfirmed global one.
+    await waitFor(() =>
+      expect(mocked.upsertNodeRole).toHaveBeenCalledWith('IP', '10.0.0.1', 'printer', '', true, FILE)
+    )
+    expect(onSaved).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('refuses to save an empty label', async () => {
+    mocked.getNodeRole.mockResolvedValue(null as never)
+    renderModal()
+    await waitFor(() => expect(mocked.getNodeRole).toHaveBeenCalled())
+
+    // A blank role is worse than none: it occupies the label slot and carries forward, hiding
+    // the fact that the host was never identified.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled()
+    )
+  })
+
+  it('keeps the modal open and reports the failure when a save fails', async () => {
+    mocked.getNodeRole.mockResolvedValue(null as never)
+    mocked.upsertNodeRole.mockRejectedValue(new Error('offline'))
+    const { onClose } = renderModal()
+    await waitFor(() => expect(mocked.getNodeRole).toHaveBeenCalled())
+
+    // Save is disabled until the label is non-empty, so a role cannot be saved as blank.
+    await userEvent.type(await screen.findByPlaceholderText(/File Server/i), 'printer')
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    // Closing on failure would discard the analyst's typing and imply it was stored.
+    expect(await screen.findByText(/Failed to save role/)).toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/common/Spinner/__tests__/Spinner.test.tsx
+++ b/frontend/src/components/common/Spinner/__tests__/Spinner.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * The loading indicator used across the app. Small, but it carries an accessibility
+ * contradiction worth recording: it sets role="status" and aria-hidden="true" at the same time,
+ * so the role it advertises is unreachable to assistive technology — and to any test that looks
+ * for it by role.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Spinner } from '../Spinner'
+
+describe('Spinner', () => {
+  it('renders a border spinner by default', () => {
+    const { container } = render(<Spinner />)
+
+    expect(container.firstChild).toHaveClass('spinner-border')
+  })
+
+  it('renders a grow spinner when asked', () => {
+    const { container } = render(<Spinner animation="grow" />)
+
+    expect(container.firstChild).toHaveClass('spinner-grow')
+    expect(container.firstChild).not.toHaveClass('spinner-border')
+  })
+
+  it('applies the small modifier alongside the animation class', () => {
+    const { container } = render(<Spinner animation="grow" size="sm" />)
+
+    // The modifier is derived from the animation, so `spinner-border-sm` on a grow spinner
+    // would size nothing.
+    expect(container.firstChild).toHaveClass('spinner-grow', 'spinner-grow-sm')
+  })
+
+  it('keeps a caller-supplied className rather than replacing it', () => {
+    const { container } = render(<Spinner className="text-primary me-2" />)
+
+    // Callers position the spinner with utility classes; dropping them collapses layouts.
+    expect(container.firstChild).toHaveClass('spinner-border', 'text-primary', 'me-2')
+  })
+
+  it('omits the size modifier entirely at default size', () => {
+    const { container } = render(<Spinner />)
+
+    // Not an empty class token: `.filter(Boolean)` exists to stop "spinner-border  " reaching
+    // the DOM with a stray gap.
+    expect((container.firstChild as HTMLElement).className).toBe('spinner-border')
+  })
+
+  describe('accessibility — pinned, not endorsed', () => {
+    it('defaults to role="status" but hides itself from assistive technology', () => {
+      const { container } = render(<Spinner />)
+      const el = container.firstChild as HTMLElement
+
+      // Both are set together. aria-hidden removes the node from the accessibility tree, so
+      // the status role announces nothing — a screen reader gets no indication that anything
+      // is loading, and getByRole('status') cannot find it either.
+      //
+      // Pinned rather than fixed: dropping aria-hidden would start announcing every spinner in
+      // the app, which is a UX decision rather than a test fix.
+      expect(el).toHaveAttribute('role', 'status')
+      expect(el).toHaveAttribute('aria-hidden', 'true')
+      expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    })
+
+    it('lets a caller override the role', () => {
+      const { container } = render(<Spinner role="presentation" />)
+
+      expect(container.firstChild).toHaveAttribute('role', 'presentation')
+    })
+  })
+})

--- a/frontend/src/components/conversation/HexViewer/__tests__/HexViewer.test.tsx
+++ b/frontend/src/components/conversation/HexViewer/__tests__/HexViewer.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * The payload viewer. Analysts read raw bytes here to confirm what a conversation actually
+ * carried, so the rendering has to be faithful in both columns: the hex must be the bytes, and
+ * the ASCII column must not let a control byte pretend to be text.
+ */
+import { render, screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { HexViewer } from '../HexViewer'
+
+beforeAll(() => {
+  // jsdom has no ResizeObserver. The component observes its container to pick a byte width;
+  // with a no-op observer it keeps the initial 16 bytes per row, which is what these assert.
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+})
+
+/** The rendered <pre>, which holds every row. */
+function dump(): string {
+  return document.querySelector('pre')?.textContent ?? ''
+}
+
+describe('HexViewer', () => {
+  it('says so when there is no payload', () => {
+    render(<HexViewer hex="" truncated={false} />)
+
+    // An empty hex pane looks like a rendering bug; saying "no payload" distinguishes an
+    // empty conversation from a broken viewer.
+    expect(screen.getByText(/No payload data available/)).toBeInTheDocument()
+    expect(document.querySelector('pre')).toBeNull()
+  })
+
+  it('splits the hex string into byte pairs', () => {
+    render(<HexViewer hex="48656c6c6f" truncated={false} />)
+
+    expect(dump()).toContain('48 65 6c 6c 6f')
+  })
+
+  it('renders printable bytes in the ASCII column', () => {
+    render(<HexViewer hex="48656c6c6f" truncated={false} />)
+
+    expect(dump()).toContain('Hello')
+  })
+
+  it.each([
+    ['00', 'null'],
+    ['0a', 'newline'],
+    ['1f', 'unit separator'],
+    ['7f', 'delete'],
+    ['ff', 'high byte'],
+  ])('substitutes a dot for %s (%s) in the ASCII column', hex => {
+    render(<HexViewer hex={hex} truncated={false} />)
+
+    // Standard hexdump convention, and load-bearing: emitting a raw control byte would let
+    // payload content move the cursor or inject escape sequences into the rendered view.
+    const ascii = dump().trimEnd().slice(-1)
+    expect(ascii).toBe('.')
+  })
+
+  it('keeps the printable boundary bytes as characters', () => {
+    render(<HexViewer hex="207e" truncated={false} />)
+
+    // 0x20 is space and 0x7e is '~' — both printable. An off-by-one on either bound would
+    // blank a legitimate character or print a control one.
+    expect(dump()).toContain(' ~')
+  })
+
+  it('numbers each row by its byte offset in hex', () => {
+    // 20 bytes: two rows at the default 16 wide, so offsets 0000 and 0010.
+    render(<HexViewer hex={'ab'.repeat(20)} truncated={false} />)
+
+    expect(dump()).toContain('0000')
+    expect(dump()).toContain('0010')
+  })
+
+  it('pads the offset to four hex digits', () => {
+    render(<HexViewer hex="ab" truncated={false} />)
+
+    // "0" instead of "0000" would misalign every row against the ones below it.
+    expect(dump()).toMatch(/^0000/)
+  })
+
+  it('splits each row into two groups for readability', () => {
+    render(<HexViewer hex={'ab'.repeat(16)} truncated={false} />)
+
+    // A double space at the midpoint is what lets the eye count bytes without a ruler.
+    expect(dump()).toContain('ab ab ab ab ab ab ab ab  ab')
+  })
+
+  it('announces truncation so a short dump is not mistaken for a short payload', () => {
+    render(<HexViewer hex="4142" truncated />)
+
+    expect(screen.getByText(/truncated to first 1024 bytes/)).toBeInTheDocument()
+  })
+
+  it('says nothing about truncation when the payload is complete', () => {
+    render(<HexViewer hex="4142" truncated={false} />)
+
+    expect(screen.queryByText(/truncated/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/intelligence/TopHostsTable/__tests__/TopHostsTable.test.tsx
+++ b/frontend/src/components/intelligence/TopHostsTable/__tests__/TopHostsTable.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * The top-hosts table ranks who talked most in a capture. Two things make it more than a list:
+ * the rank numbers must keep counting across pages, and the geo badge must not overstate how
+ * trustworthy a location is.
+ */
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { HostSummary } from '@/features/intelligence/services/intelligenceService'
+import { TopHostsTable } from '../TopHostsTable'
+
+/**
+ * No `as HostSummary` cast: the cast is what let an earlier version of this fixture invent
+ * `totalPackets` and `roleLabel` (the real fields are `packetCount` and `role`) and fail at
+ * render instead of at compile time.
+ */
+function host(ip: string, overrides: Partial<HostSummary> = {}): HostSummary {
+  return {
+    ip,
+    hostname: null,
+    hostnameSource: null,
+    totalBytes: 1000,
+    packetCount: 10,
+    conversationCount: 1,
+    riskCount: 0,
+    country: null,
+    org: null,
+    geoSource: null,
+    deviceType: null,
+    role: 'unknown',
+    ...overrides,
+  }
+}
+
+const many = (n: number) => Array.from({ length: n }, (_, i) => host(`10.0.0.${i + 1}`))
+
+function renderTable(hosts: HostSummary[], props: Partial<Parameters<typeof TopHostsTable>[0]> = {}) {
+  const onSortByChange = vi.fn()
+  render(
+    <TopHostsTable
+      hosts={hosts}
+      loading={false}
+      sortBy="bytes"
+      onSortByChange={onSortByChange}
+      {...props}
+    />
+  )
+  return { onSortByChange }
+}
+
+/** Rank cells are the first column of each body row. */
+function ranks(): string[] {
+  const rows = screen.getAllByRole('row').slice(1) // drop the header
+  return rows.map(r => within(r).getAllByRole('cell')[0].textContent ?? '')
+}
+
+describe('TopHostsTable', () => {
+  it('shows one page of hosts at a time', () => {
+    renderTable(many(45))
+
+    expect(screen.getAllByRole('row')).toHaveLength(21) // 20 hosts + header
+  })
+
+  it('continues the rank numbering onto the next page', async () => {
+    renderTable(many(45))
+    expect(ranks()[0]).toBe('1')
+
+    await userEvent.click(screen.getByRole('button', { name: '2' }))
+
+    // Restarting at 1 on page two would make the 21st-busiest host look like the busiest —
+    // the ranking is the entire point of the table.
+    expect(ranks()[0]).toBe('21')
+  })
+
+  it('returns to the first page when the sort changes', async () => {
+    const { onSortByChange } = renderTable(many(45))
+    await userEvent.click(screen.getByRole('button', { name: '2' }))
+    expect(ranks()[0]).toBe('21')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Packets' }))
+
+    // A re-sort makes page two meaningless — those are different hosts now.
+    expect(onSortByChange).toHaveBeenCalledWith('packets')
+    expect(ranks()[0]).toBe('1')
+  })
+
+  it('marks the active sort so the ranking is not ambiguous', () => {
+    renderTable(many(3), { sortBy: 'risks' })
+
+    // Without this the table shows an order with no indication of what it is ordered by.
+    expect(screen.getByRole('button', { name: 'Risks' })).toHaveClass('btn-primary')
+    expect(screen.getByRole('button', { name: 'Bytes' })).not.toHaveClass('btn-primary')
+  })
+
+  it('disables sorting while a fetch is in flight', () => {
+    renderTable(many(3), { loading: true })
+
+    // Queueing a second sort before the first returns races two responses into one table.
+    //
+    // Only the disabled state is asserted. The shared Spinner *does* forward `role` — it
+    // defaults to "status" — but it also sets aria-hidden="true", which removes it from the
+    // accessibility tree, so getByRole('status') cannot reach it. That contradiction is pinned
+    // in Spinner's own tests; asserting it from here would test markup this component does not
+    // control.
+    expect(screen.getByRole('button', { name: 'Packets' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Bytes' })).toBeDisabled()
+  })
+
+  describe('geo source badge', () => {
+    it('labels a live lookup as Live', () => {
+      renderTable([host('8.8.8.8', { country: 'US', geoSource: 'ipinfo' })])
+
+      expect(screen.getByText(/Live/)).toBeInTheDocument()
+    })
+
+    it('labels an offline lookup as MMDB', () => {
+      renderTable([host('8.8.8.8', { country: 'US', geoSource: 'mmdb' })])
+
+      // The offline database is approximate — cloud IPs frequently resolve to the wrong city.
+      // Saying so is what stops an analyst treating it as ground truth.
+      expect(screen.getByText(/MMDB/)).toBeInTheDocument()
+    })
+
+    it('falls back to the cautious label for an unknown source', () => {
+      renderTable([host('8.8.8.8', { country: 'US', geoSource: 'something-new' })])
+
+      // Defaulting to "Live" would overstate the accuracy of a lookup whose provenance is
+      // unknown. Understating it is the safe direction.
+      expect(screen.getByText(/MMDB/)).toBeInTheDocument()
+      expect(screen.queryByText(/Live/)).not.toBeInTheDocument()
+    })
+
+    it('shows no badge when no geo lookup happened', () => {
+      renderTable([host('10.0.0.1')])
+
+      expect(screen.queryByText(/MMDB|Live/)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/monitor/ChangeEventBadge/__tests__/ChangeEventBadge.test.tsx
+++ b/frontend/src/components/monitor/ChangeEventBadge/__tests__/ChangeEventBadge.test.tsx
@@ -134,14 +134,21 @@ describe('ChangeEventBadge', () => {
     expect(screen.getByText(/Snapshot 1: monday\.pcap/)).toBeInTheDocument()
   })
 
-  it('marks an event reviewed optimistically and persists it', async () => {
-    const onPatch = vi.fn().mockResolvedValue(undefined)
+  it('flips the state before the save resolves, not after', async () => {
+    // Deferred so the assertion lands while the request is still in flight. Asserting only
+    // after it resolves cannot tell an optimistic update from a pessimistic one — both end in
+    // the same place, and the difference is the whole point of the local state.
+    let resolvePatch: () => void = () => {}
+    const onPatch = vi.fn(() => new Promise<void>(res => { resolvePatch = () => res() }))
     renderBadge(event(), onPatch)
 
     await userEvent.click(screen.getByTitle('Mark as reviewed'))
 
-    await waitFor(() => expect(onPatch).toHaveBeenCalledWith('e1', { reviewed: true }))
-    // The title flips because localReviewed did — that is the optimistic update landing.
+    expect(onPatch).toHaveBeenCalledWith('e1', { reviewed: true })
+    // Mid-flight: the row greys out immediately so a triage queue stays responsive.
+    expect(screen.getByTitle('Mark as unreviewed')).toBeInTheDocument()
+
+    resolvePatch()
     await waitFor(() => expect(screen.getByTitle('Mark as unreviewed')).toBeInTheDocument())
   })
 

--- a/frontend/src/components/monitor/ChangeEventBadge/__tests__/ChangeEventBadge.test.tsx
+++ b/frontend/src/components/monitor/ChangeEventBadge/__tests__/ChangeEventBadge.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * The first component test in the codebase.
+ *
+ * A change event row is the sentence an operator reads to decide whether something matters.
+ * The wording is not cosmetic: IP_MAC_DRIFT renders either "Potential ARP spoof" or "IP
+ * reassignment" from the same change type, depending on which side moved — one is an attack
+ * signature, the other is DHCP doing its job.
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ChangeEvent, NetworkSnapshot } from '@/features/monitor/types/monitor.types'
+import { ChangeEventBadge } from '../ChangeEventBadge'
+
+function event(overrides: Partial<ChangeEvent> = {}): ChangeEvent {
+  return {
+    id: 'e1',
+    changeType: 'MAC_ADDED',
+    severity: 'INFO',
+    entityKey: 'aa:bb:cc:dd:ee:ff',
+    detectedAt: '2026-08-12T10:00:00Z',
+    reviewed: false,
+    notes: null,
+    newValue: {},
+    oldValue: {},
+    ...overrides,
+  } as ChangeEvent
+}
+
+const snapshots = [
+  { id: 's1', fileName: 'monday.pcap', snapshotOrder: 0 } as NetworkSnapshot,
+]
+
+function renderBadge(e: ChangeEvent, onPatch = vi.fn().mockResolvedValue(undefined)) {
+  render(<ChangeEventBadge event={e} snapshots={snapshots} onPatch={onPatch} />)
+  return { onPatch }
+}
+
+describe('ChangeEventBadge', () => {
+  describe('IP_MAC_DRIFT wording', () => {
+    it('calls a changed MAC on a stable IP a potential ARP spoof', () => {
+      renderBadge(
+        event({
+          changeType: 'IP_MAC_DRIFT',
+          entityKey: '10.0.0.1',
+          oldValue: { mac: 'aa:aa:aa:aa:aa:aa' },
+          newValue: { mac: 'bb:bb:bb:bb:bb:bb' },
+        })
+      )
+
+      // Same IP, different MAC. This is the wording that makes an analyst look.
+      expect(screen.getByText(/Potential ARP spoof/)).toBeInTheDocument()
+      expect(screen.getByText(/aa:aa:aa:aa:aa:aa/)).toBeInTheDocument()
+    })
+
+    it('calls a changed IP on a stable MAC a reassignment, not a spoof', () => {
+      renderBadge(
+        event({
+          changeType: 'IP_MAC_DRIFT',
+          entityKey: 'aa:bb:cc:dd:ee:ff',
+          oldValue: { ip: '10.0.0.1' },
+          newValue: { ip: '10.0.0.2' },
+        })
+      )
+
+      // Routine DHCP. Labelling this an ARP spoof would cry wolf on every lease renewal.
+      expect(screen.getByText(/IP reassignment/)).toBeInTheDocument()
+      expect(screen.queryByText(/ARP spoof/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('names the device and where it appeared', () => {
+    renderBadge(
+      event({
+        changeType: 'MAC_ADDED',
+        entityKey: 'aa:bb:cc:dd:ee:ff',
+        newValue: { manufacturer: 'Cisco', deviceType: 'router', ip: '10.0.0.1' },
+      })
+    )
+
+    expect(screen.getByText(/New device: aa:bb:cc:dd:ee:ff \(Cisco, router\) at 10\.0\.0\.1/))
+      .toBeInTheDocument()
+  })
+
+  it('omits the parenthetical when nothing is known about the device', () => {
+    renderBadge(event({ changeType: 'MAC_ADDED', entityKey: 'aa:bb:cc:dd:ee:ff' }))
+
+    // "New device: aa:… ()" would read as missing data rather than unknown data.
+    expect(screen.getByText('New device: aa:bb:cc:dd:ee:ff')).toBeInTheDocument()
+  })
+
+  it('distinguishes a VPN appearing from one going away', () => {
+    const { unmount } = render(
+      <ChangeEventBadge
+        event={event({ changeType: 'VPN_DRIFT', newValue: { riskType: 'WireGuard' } })}
+        snapshots={snapshots}
+        onPatch={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/VPN detected: WireGuard/)).toBeInTheDocument()
+    unmount()
+
+    renderBadge(
+      event({ changeType: 'VPN_DRIFT', newValue: {}, oldValue: { riskType: 'WireGuard' } })
+    )
+    expect(screen.getByText(/VPN signal gone: WireGuard/)).toBeInTheDocument()
+  })
+
+  it('names the security signal kind rather than saying "security signal"', () => {
+    renderBadge(
+      event({
+        changeType: 'SECURITY_ALERT_ADDED',
+        entityKey: '10.0.0.1',
+        newValue: { signalKind: 'ids' },
+      })
+    )
+
+    expect(screen.getByText(/IDS alert appeared: 10\.0\.0\.1/)).toBeInTheDocument()
+  })
+
+  it('falls back to the entity key for an unrecognised change type', () => {
+    renderBadge(event({ changeType: 'SOMETHING_NEW' as ChangeEvent['changeType'] }))
+
+    // A backend that adds a change type before the frontend knows it still renders something
+    // identifiable rather than a blank row.
+    expect(screen.getByText('aa:bb:cc:dd:ee:ff')).toBeInTheDocument()
+  })
+
+  it('shows which snapshot the change was detected in', () => {
+    renderBadge(event({ toSnapshotId: 's1' }))
+
+    // snapshotOrder is zero-based internally and one-based in the UI.
+    expect(screen.getByText(/Snapshot 1: monday\.pcap/)).toBeInTheDocument()
+  })
+
+  it('marks an event reviewed optimistically and persists it', async () => {
+    const onPatch = vi.fn().mockResolvedValue(undefined)
+    renderBadge(event(), onPatch)
+
+    await userEvent.click(screen.getByTitle('Mark as reviewed'))
+
+    await waitFor(() => expect(onPatch).toHaveBeenCalledWith('e1', { reviewed: true }))
+    // The title flips because localReviewed did — that is the optimistic update landing.
+    await waitFor(() => expect(screen.getByTitle('Mark as unreviewed')).toBeInTheDocument())
+  })
+
+  it('reverts the review state when the save fails', async () => {
+    const onPatch = vi.fn().mockRejectedValue(new Error('offline'))
+    renderBadge(event(), onPatch)
+
+    await userEvent.click(screen.getByTitle('Mark as reviewed'))
+    await waitFor(() => expect(onPatch).toHaveBeenCalled())
+
+    // Assert the state that actually reverts, not merely that a button exists — an earlier
+    // version of this test checked for the button by role and passed with the revert deleted,
+    // because the button is present either way. The title is derived from localReviewed, so
+    // it is the visible consequence of the rollback.
+    //
+    // Optimistic UI without a revert leaves the row greyed out as reviewed while the backend
+    // still has it outstanding: the operator's triage queue and the truth diverge silently.
+    await waitFor(() => expect(screen.getByTitle('Mark as reviewed')).toBeInTheDocument())
+    expect(screen.queryByTitle('Mark as unreviewed')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/story/StoryInfoCard/__tests__/StoryInfoCard.test.tsx
+++ b/frontend/src/components/story/StoryInfoCard/__tests__/StoryInfoCard.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Caps on how many findings and risk-matrix rows go into a generated story. These are LLM
+ * prompt-size controls: too low and the narrative omits evidence the analyst has already seen,
+ * too high and the prompt exceeds the context window and the generation fails outright.
+ */
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { StoryInfoCard } from '../StoryInfoCard'
+
+function renderCard(props: Parameters<typeof StoryInfoCard>[0] = {}) {
+  const onMaxFindingsChange = vi.fn()
+  const onMaxRiskMatrixChange = vi.fn()
+  render(
+    <StoryInfoCard
+      onMaxFindingsChange={onMaxFindingsChange}
+      onMaxRiskMatrixChange={onMaxRiskMatrixChange}
+      {...props}
+    />
+  )
+  return { onMaxFindingsChange, onMaxRiskMatrixChange }
+}
+
+/**
+ * The row of controls belonging to one cap, located by its exact label. A regex like /findings/i
+ * also matches the explanatory prose above the controls, so the exact string is what isolates
+ * the row.
+ */
+function capRow(label: 'Max findings:' | 'Max risk matrix rows:'): HTMLElement {
+  return screen.getByText(label).parentElement as HTMLElement
+}
+
+async function expand() {
+  await userEvent.click(screen.getByText(/How Stories Are Generated/i))
+}
+
+describe('StoryInfoCard cap controls', () => {
+  it('starts collapsed so the controls do not crowd the story', async () => {
+    renderCard()
+
+    expect(screen.queryByPlaceholderText(/Custom/)).not.toBeInTheDocument()
+  })
+
+  it('reports a preset selection', async () => {
+    const { onMaxFindingsChange } = renderCard({ maxFindings: 20, totalFindings: 100 })
+    await expand()
+
+    const row = capRow('Max findings:')
+    await userEvent.click(within(row).getByRole('button', { name: '50' }))
+
+    expect(onMaxFindingsChange).toHaveBeenCalledWith(50)
+  })
+
+  it('sends the real total when "All" is chosen and the total is known', async () => {
+    const { onMaxFindingsChange } = renderCard({ totalFindings: 137 })
+    await expand()
+
+    await userEvent.click(within(capRow('Max findings:')).getByRole('button', { name: /All 137/ }))
+
+    // Not a sentinel: the caller gets the actual count, so the prompt is built from a real
+    // number rather than one that happens to exceed it.
+    expect(onMaxFindingsChange).toHaveBeenCalledWith(137)
+  })
+
+  it('falls back to a large sentinel when the total is unknown', async () => {
+    const { onMaxRiskMatrixChange } = renderCard()
+    await expand()
+
+    await userEvent.click(within(capRow('Max risk matrix rows:')).getByRole('button', { name: 'All' }))
+
+    // The total is not always loaded. A sentinel keeps "All" meaning "no cap" rather than
+    // silently capping at zero.
+    expect(onMaxRiskMatrixChange).toHaveBeenCalledWith(999999)
+  })
+
+  it('applies a custom value on Enter', async () => {
+    const { onMaxFindingsChange } = renderCard()
+    await expand()
+
+    const input = within(capRow('Max findings:')).getByPlaceholderText(/Custom/)
+    await userEvent.type(input, '37{Enter}')
+
+    expect(onMaxFindingsChange).toHaveBeenCalledWith(37)
+  })
+
+  it('applies a custom value on blur, so a typed number is not silently lost', async () => {
+    const { onMaxFindingsChange } = renderCard()
+    await expand()
+
+    const input = within(capRow('Max findings:')).getByPlaceholderText(/Custom/)
+    await userEvent.type(input, '42')
+    await userEvent.tab()
+
+    expect(onMaxFindingsChange).toHaveBeenCalledWith(42)
+  })
+
+  it.each(['0', '-5', 'abc'])('ignores an invalid custom value (%s)', async bad => {
+    const { onMaxFindingsChange } = renderCard()
+    await expand()
+
+    const input = within(capRow('Max findings:')).getByPlaceholderText(/Custom/)
+    await userEvent.type(input, `${bad}{Enter}`)
+
+    // A cap of zero or a NaN would produce a story with no evidence in it at all.
+    expect(onMaxFindingsChange).not.toHaveBeenCalled()
+  })
+
+  it('clears the custom box after applying, ready for the next edit', async () => {
+    renderCard()
+    await expand()
+
+    const input = within(capRow('Max findings:')).getByPlaceholderText(/Custom/) as HTMLInputElement
+    await userEvent.type(input, '37{Enter}')
+
+    expect(input.value).toBe('')
+  })
+})

--- a/frontend/src/components/upload/UploadProgress/__tests__/UploadProgress.test.tsx
+++ b/frontend/src/components/upload/UploadProgress/__tests__/UploadProgress.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * The upload card. Its job is to distinguish four states that a user experiences very
+ * differently — uploading, processing, done, failed — and the awkward one is "processing": the
+ * bytes are transferred but the server is still working, so a naive reading of progress===100
+ * would announce success while analysis is still running.
+ */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { UploadProgress } from '../UploadProgress'
+
+function renderCard(props: Partial<Parameters<typeof UploadProgress>[0]> = {}) {
+  const onAnalyze = vi.fn()
+  const onOpenExisting = vi.fn()
+  render(
+    <UploadProgress
+      fileName="capture.pcap"
+      progress={0}
+      isUploading
+      onAnalyze={onAnalyze}
+      onOpenExisting={onOpenExisting}
+      {...props}
+    />
+  )
+  return { onAnalyze, onOpenExisting }
+}
+
+const bar = () => screen.getByRole('progressbar')
+
+describe('UploadProgress', () => {
+  it('counts up while bytes are still going', () => {
+    renderCard({ progress: 42, isUploading: true })
+
+    expect(screen.getByText('Uploading 42%')).toBeInTheDocument()
+    expect(bar()).toHaveAttribute('aria-valuenow', '42')
+  })
+
+  it('says Processing when the bytes are in but the server is still working', () => {
+    renderCard({ progress: 100, isUploading: true })
+
+    // The distinction that matters. Announcing "Complete" here sends the user to look for an
+    // analysis that does not exist yet.
+    expect(screen.getByText('Processing…')).toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+  })
+
+  it('announces completion only once the server is done', () => {
+    renderCard({ progress: 100, isUploading: false })
+
+    expect(screen.getByText('Complete')).toBeInTheDocument()
+  })
+
+  it('reports a failure instead of a percentage', () => {
+    renderCard({ progress: 60, isUploading: false, error: 'Not a valid pcap' })
+
+    // The status line and the reason are separate: one says what happened, the other why.
+    expect(screen.getByText('Upload failed')).toBeInTheDocument()
+    expect(screen.getByText('Not a valid pcap')).toBeInTheDocument()
+  })
+
+  it('prefers the error over any progress state', () => {
+    renderCard({ progress: 100, isUploading: false, error: 'Storage error' })
+
+    // A failure at 100% must not read as Complete — this is the combination most likely to be
+    // rendered wrong, because both conditions are satisfied.
+    expect(screen.getByText('Upload failed')).toBeInTheDocument()
+    expect(screen.queryByText('Complete')).not.toBeInTheDocument()
+  })
+
+  it('offers Analyze only when the upload has finished', async () => {
+    const { onAnalyze } = renderCard({ progress: 100, isUploading: false })
+
+    await userEvent.click(screen.getByRole('button', { name: /Analyze/ }))
+
+    expect(onAnalyze).toHaveBeenCalled()
+  })
+
+  it('does not offer Analyze mid-upload', () => {
+    renderCard({ progress: 80, isUploading: true })
+
+    // Analysing a partially uploaded capture would read a truncated file.
+    expect(screen.queryByRole('button', { name: /Analyze/ })).not.toBeInTheDocument()
+  })
+
+  it('explains what to do about a duplicate rather than just flagging it', async () => {
+    const { onOpenExisting } = renderCard({
+      progress: 100,
+      isUploading: false,
+      isDuplicate: true,
+    })
+
+    // A duplicate is not an error, so the card offers the existing analysis and says how to
+    // reprocess — an unexplained warning leaves the user stuck.
+    expect(screen.getByText(/already been uploaded/)).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /Open existing/ }))
+    expect(onOpenExisting).toHaveBeenCalled()
+  })
+
+  it('does not flag a duplicate while the upload is still in flight', () => {
+    renderCard({ progress: 100, isUploading: true, isDuplicate: true })
+
+    // The duplicate verdict comes from the server's response; showing it during processing
+    // would pre-empt a result that has not arrived.
+    expect(screen.queryByText(/already been uploaded/)).not.toBeInTheDocument()
+  })
+
+  it('fills the bar during processing even though progress is indeterminate', () => {
+    renderCard({ progress: 100, isUploading: true })
+
+    expect(bar()).toHaveStyle({ width: '100%' })
+    expect(bar()).toHaveClass('progress-bar-animated')
+  })
+})

--- a/frontend/src/features/analysis/hooks/__tests__/useAnalysisData.test.tsx
+++ b/frontend/src/features/analysis/hooks/__tests__/useAnalysisData.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Analysis runs asynchronously on the backend, so this hook polls until it finishes. Three HTTP
+ * statuses mean three different things — done, still working, failed — and treating any of them
+ * as another either spins forever or reports success on a failed run.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { HttpResponse, http } from 'msw'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { server } from '@/test/msw'
+import { useStore } from '@/store'
+import { useAnalysisData } from '../useAnalysisData'
+
+const FILE = '11111111-1111-1111-1111-111111111111'
+const summary = { fileId: FILE, fileName: 'a.pcap', totalPackets: 10 }
+
+/** Serves /system/limits plus a scripted sequence of summary responses. */
+function serveSequence(statuses: number[]) {
+  let call = 0
+  const seen = { calls: 0 }
+  server.use(
+    http.get('*/system/limits', () => HttpResponse.json({ analysisTimeoutMs: 300000 })),
+    http.get('*/analysis/*/summary', () => {
+      seen.calls += 1
+      const status = statuses[Math.min(call++, statuses.length - 1)]
+      if (status === 200) return HttpResponse.json(summary)
+      return HttpResponse.json({ message: 'x' }, { status })
+    })
+  )
+  return seen
+}
+
+beforeEach(() => {
+  useStore.setState({ analysisSummaries: {} } as never)
+})
+afterEach(() => vi.useRealTimers())
+
+describe('useAnalysisData', () => {
+  it('resolves immediately on a 200', async () => {
+    serveSequence([200])
+
+    const { result } = renderHook(() => useAnalysisData(FILE))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.data).toMatchObject({ fileId: FILE })
+    expect(result.current.error).toBeNull()
+  })
+
+  it('keeps polling on a 202 and settles once analysis completes', async () => {
+    const seen = serveSequence([202, 202, 200])
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const { result } = renderHook(() => useAnalysisData(FILE))
+    await waitFor(() => expect(seen.calls).toBeGreaterThanOrEqual(1))
+
+    // 202 means "still working" — treating it as an error would abandon every large capture
+    // partway through.
+    expect(result.current.loading).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(2000)
+
+    await waitFor(() => expect(result.current.data).toMatchObject({ fileId: FILE }))
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('reports a server-side failure rather than polling forever', async () => {
+    serveSequence([500])
+
+    const { result } = renderHook(() => useAnalysisData(FILE))
+
+    await waitFor(() => expect(result.current.error).not.toBeNull())
+    expect(result.current.error?.message).toBe('Analysis failed on server')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('stops polling after a failure — but only from the second poll onward', async () => {
+    const seen = serveSequence([500])
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const { result } = renderHook(() => useAnalysisData(FILE))
+    await waitFor(() => expect(result.current.error).not.toBeNull())
+
+    await vi.advanceTimersByTimeAsync(6000)
+
+    // Pinned, not endorsed. The interval is created *after* the first poll is awaited:
+    //
+    //   await pollStatus();                         // 500 → clearInterval(pollInterval)
+    //   pollInterval = setInterval(pollStatus, ...) // …but it was still null above
+    //
+    // so the terminal status on the first poll clears nothing and the interval starts anyway.
+    // The second poll hits the same status and clears it properly, which caps the leak at one
+    // extra request rather than letting it run forever. The same ordering applies to a 200, so
+    // every completed analysis costs one redundant fetch.
+    //
+    // Cheap to fix by hoisting the setInterval above the await, but that changes request
+    // timing on a path this suite is meant to hold still first.
+    expect(seen.calls).toBe(2)
+  })
+
+  it('stops polling on unmount', async () => {
+    const seen = serveSequence([202])
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const { unmount } = renderHook(() => useAnalysisData(FILE))
+    await waitFor(() => expect(seen.calls).toBeGreaterThanOrEqual(1))
+
+    unmount()
+    const afterUnmount = seen.calls
+    await vi.advanceTimersByTimeAsync(6000)
+
+    // Navigating away from a still-processing capture must not leave a 2s interval running for
+    // the life of the session.
+    expect(seen.calls).toBe(afterUnmount)
+  })
+
+  it('serves a cached summary without hitting the network', async () => {
+    const seen = serveSequence([200])
+    useStore.setState({ analysisSummaries: { [FILE]: summary } } as never)
+
+    const { result } = renderHook(() => useAnalysisData(FILE))
+
+    // Revisiting an analysed capture is the common case; re-polling it would add latency to
+    // every navigation for a result that cannot change.
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.data).toMatchObject({ fileId: FILE })
+    expect(seen.calls).toBe(0)
+  })
+})

--- a/frontend/src/features/conversation/services/__tests__/getConversations.test.ts
+++ b/frontend/src/features/conversation/services/__tests__/getConversations.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The conversation table is the primary data view, and this is its fetch path: query building,
+ * the paged envelope, and the row transform that turns backend DTOs into what the table renders.
+ *
+ * `getExportUrl` (covered separately) must produce the *same* filtering as this call — an export
+ * that quietly disagrees with the table on screen is worse than one that fails.
+ */
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { server } from '@/test/msw'
+import type { ConversationFilters } from '../../types'
+import { conversationService } from '../conversationService'
+
+const FILE = '11111111-1111-1111-1111-111111111111'
+
+function filters(overrides: Partial<ConversationFilters> = {}): ConversationFilters {
+  return {
+    ip: '',
+    port: '',
+    payloadContains: '',
+    protocols: [],
+    l7Protocols: [],
+    apps: [],
+    categories: [],
+    hasRisks: false,
+    fileTypes: [],
+    riskTypes: [],
+    customSignatures: [],
+    suricataAlerts: [],
+    deviceTypes: [],
+    countries: [],
+    sortBy: '' as ConversationFilters['sortBy'],
+    sortDir: 'asc',
+    page: 1,
+    pageSize: 25,
+    ...overrides,
+  }
+}
+
+const row = {
+  conversationId: 'c1',
+  srcIp: '10.0.0.1',
+  srcPort: 1234,
+  dstIp: '8.8.8.8',
+  dstPort: 53,
+  protocol: 'UDP',
+  packetCount: 4,
+  totalBytes: 400,
+}
+
+/** Captures the query the service sent and replies with one page of results. */
+function captureFetch(body?: Record<string, unknown>) {
+  const seen: { query?: URLSearchParams } = {}
+  server.use(
+    http.get('*/api/v1/conversations/*', ({ request }) => {
+      seen.query = new URL(request.url).searchParams
+      return HttpResponse.json(
+        body ?? { data: [row], page: 1, pageSize: 25, total: 1, totalPages: 1 }
+      )
+    })
+  )
+  return seen
+}
+
+describe('conversationService.getConversations', () => {
+  it('passes the paged envelope through unchanged', async () => {
+    captureFetch({ data: [], page: 3, pageSize: 50, total: 120, totalPages: 3 })
+
+    const result = await conversationService.getConversations(FILE, filters())
+
+    // The table's pagination reads these directly; a renamed field would break every page
+    // control at once (guarded at compile time too by contractConformance.test-d.ts).
+    expect(result).toMatchObject({ page: 3, pageSize: 50, total: 120, totalPages: 3 })
+  })
+
+  it('reshapes each row into the endpoint pair the table renders', async () => {
+    captureFetch()
+
+    const result = await conversationService.getConversations(FILE, filters())
+
+    expect(result.data[0].id).toBe('c1')
+    expect(result.data[0].endpoints).toEqual([
+      { ip: '10.0.0.1', port: 1234 },
+      { ip: '8.8.8.8', port: 53 },
+    ])
+  })
+
+  it('defaults a missing port to 0 rather than leaving it undefined', async () => {
+    captureFetch({
+      data: [{ ...row, srcPort: null, dstPort: null }],
+      page: 1,
+      pageSize: 25,
+      total: 1,
+      totalPages: 1,
+    })
+
+    const result = await conversationService.getConversations(FILE, filters())
+
+    // ICMP has no ports. The table sorts on this field, so undefined would order unpredictably.
+    expect(result.data[0].endpoints.map(e => e.port)).toEqual([0, 0])
+  })
+
+  it('defaults absent risk and signature lists to arrays', async () => {
+    captureFetch()
+
+    const result = await conversationService.getConversations(FILE, filters())
+
+    // The row renders badges by mapping these; undefined would throw mid-table.
+    expect(result.data[0].flowRisks).toEqual([])
+    expect(result.data[0].suricataAlerts).toEqual([])
+    expect(result.data[0].detectedFileTypes).toEqual([])
+  })
+
+  it('always sends page and pageSize, even at their defaults', async () => {
+    const seen = captureFetch()
+
+    await conversationService.getConversations(FILE, filters())
+
+    // Deliberately unlike getExportUrl, which omits defaults to keep shared links short. Here
+    // the backend needs an explicit page size, so omitting it would let its default win and
+    // return a different number of rows than the UI expects.
+    expect(seen.query!.get('page')).toBe('1')
+    expect(seen.query!.get('pageSize')).toBe('25')
+  })
+
+  it('serialises list filters the same way the export URL does', async () => {
+    const seen = captureFetch()
+
+    await conversationService.getConversations(
+      FILE,
+      filters({ protocols: ['TCP', 'UDP'], hasRisks: true })
+    )
+
+    expect(seen.query!.get('protocols')).toBe('TCP,UDP')
+    expect(seen.query!.get('hasRisks')).toBe('true')
+  })
+
+  it('omits sortDir unless a sort field is chosen', async () => {
+    const seen = captureFetch()
+
+    await conversationService.getConversations(FILE, filters({ sortDir: 'desc' }))
+
+    // Matches the export builder and the filter hook: a direction with no field means nothing.
+    expect(seen.query!.has('sortDir')).toBe(false)
+  })
+
+  it('surfaces a failed page fetch rather than resolving empty', async () => {
+    let handled = false
+    server.use(
+      http.get('*/api/v1/conversations/*', () => {
+        handled = true
+        return HttpResponse.json({ message: 'boom' }, { status: 500 })
+      })
+    )
+
+    // An empty resolve would render "no conversations" for a capture that has thousands.
+    await expect(conversationService.getConversations(FILE, filters())).rejects.toThrow()
+    expect(handled).toBe(true)
+  })
+})

--- a/frontend/src/features/insights/services/__tests__/adjudicationService.test.ts
+++ b/frontend/src/features/insights/services/__tests__/adjudicationService.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Human overrides and analyst evidence are the audit trail behind an adjudicated verdict — the
+ * record of why a person disagreed with the machine. Every write here causes the backend to
+ * re-run adjudication, so a wrong body silently changes a host's identity.
+ */
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { server } from '@/test/msw'
+import { adjudicationService } from '../adjudicationService'
+
+const FILE = '11111111-1111-1111-1111-111111111111'
+const Q = 'host-identity'
+const KEY = '10.0.0.1'
+
+const override = {
+  question: Q,
+  entityKey: KEY,
+  label: 'printer',
+  rationale: 'banner says so',
+  actor: 'analyst',
+  createdAt: '2026-08-12T00:00:00Z',
+  updatedAt: '2026-08-12T00:00:00Z',
+}
+
+describe('adjudicationService', () => {
+  describe('getOverride', () => {
+    it('returns the stored override', async () => {
+      server.use(http.get('*/adjudications/*', () => HttpResponse.json(override)))
+
+      await expect(adjudicationService.getOverride(FILE, Q, KEY)).resolves.toEqual(override)
+    })
+
+    it('treats 404 as "no override set"', async () => {
+      let handled = false
+      server.use(
+        http.get('*/adjudications/*', () => {
+          handled = true
+          return new HttpResponse(null, { status: 404 })
+        })
+      )
+
+      await expect(adjudicationService.getOverride(FILE, Q, KEY)).resolves.toBeNull()
+      expect(handled).toBe(true)
+    })
+
+    it('returns an empty string, not null, for a 204 — the catch never sees it', async () => {
+      server.use(http.get('*/adjudications/*', () => new HttpResponse(null, { status: 204 })))
+
+      // The catch tests for `status === 204`, but that branch is dead: axios resolves 2xx, so
+      // a 204 never throws. `r.data` is '' for an empty body, and that is what callers get
+      // despite the declared `AdjudicationOverride | null`.
+      //
+      // It happens to work today because '' is falsy and every call site does a truthiness
+      // check — but a call site written to the signature, e.g. `override?.label`, would read
+      // a string's properties instead of hitting the null branch. Pinned, not fixed: the fix
+      // is to map a 204 to null, which is a behaviour change for those call sites.
+      await expect(adjudicationService.getOverride(FILE, Q, KEY)).resolves.toBe('')
+    })
+
+    it('rethrows a server error instead of reporting "no override"', async () => {
+      let handled = false
+      server.use(
+        http.get('*/adjudications/*', () => {
+          handled = true
+          return HttpResponse.json({ message: 'boom' }, { status: 500 })
+        })
+      )
+
+      // This is the distinction entityNotesService.getNote misses: it collapses *every* error
+      // to null, so an outage reads as "nothing recorded". Here only the two statuses that
+      // genuinely mean "absent" are swallowed, and an outage stays visible — which matters
+      // because the UI would otherwise offer to create an override on top of one that exists.
+      await expect(adjudicationService.getOverride(FILE, Q, KEY)).rejects.toThrow()
+      expect(handled).toBe(true)
+    })
+  })
+
+  it('sends an explicit null rationale rather than omitting the field', async () => {
+    let body: Record<string, unknown> | null = null
+    server.use(
+      http.put('*/adjudications/*', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(override)
+      })
+    )
+
+    await adjudicationService.setOverride(FILE, Q, KEY, 'printer')
+
+    // `rationale ?? null` — an absent key and an explicit null are different to a JSON merge
+    // patch, and clearing a rationale must actually clear it.
+    expect(body).toEqual({ label: 'printer', rationale: null })
+  })
+
+  it('creates evidence with POST and edits it with PUT', async () => {
+    const methods: string[] = []
+    server.use(
+      http.post('*/evidence', async ({ request }) => {
+        methods.push(request.method)
+        return HttpResponse.json({ id: 1 }, { status: 201 })
+      }),
+      http.put('*/evidence/*', async ({ request }) => {
+        methods.push(request.method)
+        return HttpResponse.json({ id: 1 })
+      })
+    )
+
+    await adjudicationService.appendEvidence(FILE, Q, KEY, 'printer', 3, 'banner')
+    await adjudicationService.updateEvidence(FILE, Q, KEY, 1, 'printer', 4, 'banner')
+
+    // Append creates, edit replaces a known id — using POST for both would duplicate evidence
+    // and re-weight the verdict every time an analyst corrected a typo.
+    expect(methods).toEqual(['POST', 'PUT'])
+  })
+
+  it('carries the evidence weight and reason through unchanged', async () => {
+    let body: Record<string, unknown> | null = null
+    server.use(
+      http.post('*/evidence', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json({ id: 1 }, { status: 201 })
+      })
+    )
+
+    await adjudicationService.appendEvidence(FILE, Q, KEY, 'printer', 3, 'HTTP banner')
+
+    // Weight feeds the adjudicator's vote directly, so a dropped or coerced value changes the
+    // verdict rather than just the display.
+    expect(body).toEqual({ label: 'printer', weight: 3, reason: 'HTTP banner' })
+  })
+
+  it('propagates a 403 when editing evidence you do not own', async () => {
+    let handled = false
+    server.use(
+      http.put('*/evidence/*', () => {
+        handled = true
+        return HttpResponse.json({ message: 'not yours' }, { status: 403 })
+      })
+    )
+
+    // Author-only. Swallowing this would tell an analyst their correction was saved when the
+    // backend refused it.
+    await expect(
+      adjudicationService.updateEvidence(FILE, Q, KEY, 1, 'printer', 4, 'x')
+    ).rejects.toThrow()
+    expect(handled).toBe(true)
+  })
+
+  it('resolves undefined when clearing an override returns 204', async () => {
+    server.use(http.delete('*/adjudications/*', () => new HttpResponse(null, { status: 204 })))
+
+    await expect(adjudicationService.clearOverride(FILE, Q, KEY)).resolves.toBeUndefined()
+  })
+})

--- a/frontend/src/features/insights/services/__tests__/insightsService.test.ts
+++ b/frontend/src/features/insights/services/__tests__/insightsService.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Node roles are the operator's persistent labels for hosts — they feed monitor mode and the
+ * graph. The suggestion endpoints are LLM-backed and answer 422 when there is not enough
+ * evidence, which is a normal outcome an analyst must be able to read, not a crash.
+ */
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { server } from '@/test/msw'
+import { insightsService } from '../insightsService'
+
+const FILE = '11111111-1111-1111-1111-111111111111'
+
+describe('insightsService', () => {
+  describe('getNodeRole', () => {
+    it('returns null when no role is set', async () => {
+      server.use(http.get('*/node-roles', () => new HttpResponse(null, { status: 404 })))
+
+      await expect(insightsService.getNodeRole('IP', '10.0.0.1', FILE)).resolves.toBeNull()
+    })
+
+    it('rethrows a server error rather than reporting "no role"', async () => {
+      let handled = false
+      server.use(
+        http.get('*/node-roles', () => {
+          handled = true
+          return HttpResponse.json({ message: 'boom' }, { status: 500 })
+        })
+      )
+
+      // Same correct shape as adjudicationService, and the opposite of
+      // entityNotesService.getNote — an outage must not read as "this host has no role".
+      await expect(insightsService.getNodeRole('IP', '10.0.0.1', FILE)).rejects.toThrow()
+      expect(handled).toBe(true)
+    })
+  })
+
+  it('defaults a null role list to an empty array', async () => {
+    server.use(http.get('*/files/*/node-roles', () => HttpResponse.json(null)))
+
+    // `r.data ?? []` — the graph maps over this to label nodes, so null would throw on render.
+    await expect(insightsService.listNodeRoles(FILE)).resolves.toEqual([])
+  })
+
+  describe('role suggestion (LLM-backed)', () => {
+    it('surfaces the backend message when there is not enough evidence', async () => {
+      server.use(
+        http.post('*/suggest', () =>
+          HttpResponse.json({ message: 'Only 2 conversations seen' }, { status: 422 })
+        )
+      )
+
+      // 422 is a normal answer, not a fault: the analyst needs to read *why* no role was
+      // suggested, so the backend's own wording is preserved rather than replaced.
+      await expect(
+        insightsService.suggestNodeRole('IP', '10.0.0.1', FILE)
+      ).rejects.toThrow('Only 2 conversations seen')
+    })
+
+    it('falls back to the error field when message is absent', async () => {
+      server.use(
+        http.post('*/suggest', () => HttpResponse.json({ error: 'no evidence' }, { status: 422 }))
+      )
+
+      await expect(
+        insightsService.suggestNodeRole('IP', '10.0.0.1', FILE)
+      ).rejects.toThrow('no evidence')
+    })
+
+    it('falls back to a readable default when the body carries neither', async () => {
+      server.use(http.post('*/suggest', () => HttpResponse.json({}, { status: 422 })))
+
+      // Without this the analyst would see a bare "Request failed with status code 422".
+      await expect(
+        insightsService.suggestNodeRole('IP', '10.0.0.1', FILE)
+      ).rejects.toThrow('Insufficient evidence for a role suggestion.')
+    })
+
+    it('leaves a non-422 failure as the original error', async () => {
+      let handled = false
+      server.use(
+        http.post('*/suggest', () => {
+          handled = true
+          return HttpResponse.json({ message: 'boom' }, { status: 500 })
+        })
+      )
+
+      // Only 422 is reinterpreted; a real outage keeps its axios error so callers can tell the
+      // two apart.
+      await expect(insightsService.suggestNodeRole('IP', '10.0.0.1', FILE)).rejects.toThrow()
+      expect(handled).toBe(true)
+    })
+
+    it('applies the same message handling to the preview variant', async () => {
+      server.use(
+        http.post('*/suggest-preview', () =>
+          HttpResponse.json({ message: 'not enough traffic' }, { status: 422 })
+        )
+      )
+
+      // The preview pre-fills the editor without persisting, so it hits the same wall and must
+      // explain itself the same way.
+      await expect(
+        insightsService.suggestNodeRolePreview('IP', '10.0.0.1', FILE)
+      ).rejects.toThrow('not enough traffic')
+    })
+  })
+})

--- a/frontend/src/features/intelligence/services/__tests__/intelligenceService.test.ts
+++ b/frontend/src/features/intelligence/services/__tests__/intelligenceService.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The intelligence view clusters hosts by ASN, country, subnet and so on, filtered by the same
+ * criteria as the conversation table. If a filter is dropped on the way out, the operator sees
+ * clusters built from more traffic than they asked for — and nothing says so.
+ */
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { server } from '@/test/msw'
+import { intelligenceService } from '../intelligenceService'
+
+const FILE = '11111111-1111-1111-1111-111111111111'
+
+/** Captures the query string the service actually requested. */
+function captureClusters() {
+  const seen: { query?: URLSearchParams } = {}
+  server.use(
+    http.get('*/api/v1/intelligence/*/clusters', ({ request }) => {
+      seen.query = new URL(request.url).searchParams
+      return HttpResponse.json({ clusters: [], edges: [] })
+    })
+  )
+  return seen
+}
+
+describe('intelligenceService.getClusters', () => {
+  it('always sends the grouping dimension', async () => {
+    const seen = captureClusters()
+
+    await intelligenceService.getClusters(FILE, 'asn')
+
+    // groupBy comes from the endpoint itself rather than the filter block, which is why the
+    // query is appended with "&" — see the joining test below.
+    expect(seen.query!.get('groupBy')).toBe('asn')
+  })
+
+  it('appends filters alongside groupBy rather than replacing the query string', async () => {
+    const seen = captureClusters()
+
+    await intelligenceService.getClusters(FILE, 'country', { ip: '10.0.0.1' })
+
+    // The builder joins with "&" because the endpoint already carries "?groupBy=". Both must
+    // survive: losing groupBy silently regroups the view, losing the filter silently widens it.
+    expect(seen.query!.get('groupBy')).toBe('country')
+    expect(seen.query!.get('ip')).toBe('10.0.0.1')
+  })
+
+  it('serialises list filters as comma-joined values', async () => {
+    const seen = captureClusters()
+
+    await intelligenceService.getClusters(FILE, 'asn', {
+      protocols: ['TCP', 'UDP'],
+      countries: ['SG'],
+      networkLabels: ['Corp', 'Guest'],
+    })
+
+    expect(seen.query!.get('protocols')).toBe('TCP,UDP')
+    expect(seen.query!.get('countries')).toBe('SG')
+    expect(seen.query!.get('networkLabels')).toBe('Corp,Guest')
+  })
+
+  it('omits empty lists rather than sending empty parameters', async () => {
+    const seen = captureClusters()
+
+    await intelligenceService.getClusters(FILE, 'asn', { protocols: [], apps: [] })
+
+    // An empty "protocols=" would be a filter matching nothing, inverting the intent.
+    expect(seen.query!.has('protocols')).toBe(false)
+    expect(seen.query!.has('apps')).toBe(false)
+  })
+
+  it('sends hasRisks only when true', async () => {
+    const off = captureClusters()
+    await intelligenceService.getClusters(FILE, 'asn', { hasRisks: false })
+    expect(off.query!.has('hasRisks')).toBe(false)
+
+    const on = captureClusters()
+    await intelligenceService.getClusters(FILE, 'asn', { hasRisks: true })
+    expect(on.query!.get('hasRisks')).toBe('true')
+  })
+
+  it('works with no filter argument at all', async () => {
+    const seen = captureClusters()
+
+    await intelligenceService.getClusters(FILE, 'subnet24')
+
+    expect(seen.query!.get('groupBy')).toBe('subnet24')
+    expect([...seen.query!.keys()]).toEqual(['groupBy'])
+  })
+})

--- a/frontend/src/features/network/hooks/__tests__/useCompareData.test.tsx
+++ b/frontend/src/features/network/hooks/__tests__/useCompareData.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Compare mode overlays several captures on one graph to show what changed between them. The
+ * ordering matters: each file is built without a node cap, the graphs are merged, and only then
+ * is significance applied — capping per file first would drop a host that is minor in one
+ * capture but dominant in another, which is exactly the thing a comparison is for.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { conversationService } from '@/features/conversation/services/conversationService'
+import { networkService } from '../../services/networkService'
+import type { GraphNode } from '../../types'
+import { useCompareData } from '../useCompareData'
+
+vi.mock('@/features/conversation/services/conversationService', () => ({
+  conversationService: { getConversations: vi.fn(), getHostClassifications: vi.fn() },
+}))
+vi.mock('../../services/networkService', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../services/networkService')>()
+  return { ...actual, networkService: { buildNetworkGraph: vi.fn() } }
+})
+
+const convService = vi.mocked(conversationService)
+const netService = vi.mocked(networkService)
+
+function node(id: string, totalBytes = 100): GraphNode {
+  return {
+    id,
+    label: id,
+    data: {
+      ip: id,
+      packetsSent: 1,
+      packetsReceived: 1,
+      bytesSent: totalBytes,
+      bytesReceived: 0,
+      totalBytes,
+      connections: 1,
+      role: 'unknown',
+    },
+  } as GraphNode
+}
+
+function graph(nodes: GraphNode[]) {
+  return {
+    nodes,
+    edges: [],
+    stats: { totalNodes: nodes.length, totalEdges: 0, totalPackets: 1, totalBytes: 1 },
+  }
+}
+
+afterEach(() => vi.resetAllMocks())
+
+describe('useCompareData', () => {
+  it('does not fetch until labels have resolved', async () => {
+    const { result } = renderHook(() => useCompareData(['f1'], [], 50))
+
+    // Empty labels mean the filenames have not loaded yet. Fetching now would build a graph
+    // whose per-file series cannot be named.
+    await waitFor(() => expect(convService.getConversations).not.toHaveBeenCalled())
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('builds every file without a per-file node cap', async () => {
+    convService.getConversations.mockResolvedValue({ data: [] } as never)
+    convService.getHostClassifications.mockResolvedValue([] as never)
+    netService.buildNetworkGraph.mockReturnValue(graph([node('a')]) as never)
+
+    renderHook(() => useCompareData(['f1', 'f2'], ['A', 'B'], 50))
+
+    await waitFor(() => expect(netService.buildNetworkGraph).toHaveBeenCalledTimes(2))
+    // The 5th argument is maxNodes; 0 means unlimited. Capping per file would drop a host that
+    // is minor in one capture and dominant in another — the comparison's whole subject.
+    expect(netService.buildNetworkGraph).toHaveBeenCalledWith(
+      expect.anything(), undefined, 500, expect.anything(), 0
+    )
+  })
+
+  it('reports per-file stats against their labels, in order', async () => {
+    convService.getConversations.mockResolvedValue({ data: [] } as never)
+    convService.getHostClassifications.mockResolvedValue([] as never)
+    netService.buildNetworkGraph
+      .mockReturnValueOnce(graph([node('a'), node('b')]) as never)
+      .mockReturnValueOnce(graph([node('c')]) as never)
+
+    const { result } = renderHook(() => useCompareData(['f1', 'f2'], ['Monday', 'Tuesday'], 50))
+
+    await waitFor(() => expect(result.current.perFileStats).toHaveLength(2))
+    // Misaligning labels and stats would attribute one capture's totals to the other, which is
+    // the single most misleading thing this screen could do.
+    expect(result.current.perFileStats[0]).toMatchObject({
+      label: 'Monday',
+      stats: expect.objectContaining({ totalNodes: 2 }),
+    })
+    expect(result.current.perFileStats[1]).toMatchObject({ label: 'Tuesday' })
+  })
+
+  it('applies the node limit after merging and reports what was hidden', async () => {
+    convService.getConversations.mockResolvedValue({ data: [] } as never)
+    convService.getHostClassifications.mockResolvedValue([] as never)
+    netService.buildNetworkGraph.mockReturnValue(
+      graph([node('big', 1000), node('mid', 500), node('small', 1)]) as never
+    )
+
+    const { result } = renderHook(() => useCompareData(['f1'], ['A'], 2))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.mergedNodes).toHaveLength(2)
+    expect(result.current.hiddenNodes).toBe(1)
+    // totalNodes reports the merged graph, not the visible slice, so the UI can say "showing 2
+    // of 3" rather than silently presenting a subset as the whole.
+    expect(result.current.totalNodes).toBe(3)
+  })
+
+  it('surfaces a fetch failure', async () => {
+    convService.getConversations.mockRejectedValue(new Error('backend down'))
+    convService.getHostClassifications.mockResolvedValue([] as never)
+
+    const { result } = renderHook(() => useCompareData(['f1'], ['A'], 50))
+
+    await waitFor(() => expect(result.current.error).toBe('backend down'))
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('recomputes the visible slice when the limit changes without refetching', async () => {
+    convService.getConversations.mockResolvedValue({ data: [] } as never)
+    convService.getHostClassifications.mockResolvedValue([] as never)
+    netService.buildNetworkGraph.mockReturnValue(
+      graph([node('big', 1000), node('mid', 500), node('small', 1)]) as never
+    )
+
+    const { result, rerender } = renderHook(({ limit }) => useCompareData(['f1'], ['A'], limit), {
+      initialProps: { limit: 1 },
+    })
+    await waitFor(() => expect(result.current.mergedNodes).toHaveLength(1))
+    const fetches = convService.getConversations.mock.calls.length
+
+    rerender({ limit: 3 })
+
+    // Memoised on the merged graph, so moving the slider re-slices rather than re-downloading
+    // every capture.
+    await waitFor(() => expect(result.current.mergedNodes).toHaveLength(3))
+    expect(convService.getConversations.mock.calls.length).toBe(fetches)
+  })
+})

--- a/frontend/src/features/network/hooks/__tests__/useNetworkData.test.tsx
+++ b/frontend/src/features/network/hooks/__tests__/useNetworkData.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * The network graph's data hook. It fans out to four endpoints, but only one of them is
+ * required: captures analysed before the classification, identity and role endpoints existed
+ * simply have none, and the graph must still draw.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { conversationService } from '@/features/conversation/services/conversationService'
+import { insightsService } from '@/features/insights/services/insightsService'
+import { useNetworkData } from '../useNetworkData'
+
+vi.mock('@/features/conversation/services/conversationService', () => ({
+  conversationService: {
+    getConversations: vi.fn(),
+    getHostClassifications: vi.fn(),
+    getHostIdentities: vi.fn(),
+  },
+}))
+vi.mock('@/features/insights/services/insightsService', () => ({
+  insightsService: { listNodeRoles: vi.fn() },
+}))
+
+const convService = vi.mocked(conversationService)
+const insights = vi.mocked(insightsService)
+
+const FILE = '11111111-1111-1111-1111-111111111111'
+
+const conversation = (src: string, dst: string) => ({
+  id: `${src}->${dst}`,
+  endpoints: [
+    { ip: src, port: 1 },
+    { ip: dst, port: 2 },
+  ],
+  protocol: { name: 'TCP', layer: 'transport' },
+  packetCount: 1,
+  totalBytes: 100,
+  startTime: 0,
+  endTime: 1,
+  flowRisks: [],
+  customSignatures: [],
+  suricataAlerts: [],
+})
+
+/** All four endpoints succeed unless a test overrides one. */
+function serveAll() {
+  convService.getConversations.mockResolvedValue({
+    data: [conversation('10.0.0.1', '8.8.8.8')],
+  } as never)
+  convService.getHostClassifications.mockResolvedValue([] as never)
+  convService.getHostIdentities.mockResolvedValue([] as never)
+  insights.listNodeRoles.mockResolvedValue([] as never)
+}
+
+afterEach(() => vi.resetAllMocks())
+
+describe('useNetworkData', () => {
+  it('builds a graph from the conversations', async () => {
+    serveAll()
+
+    const { result } = renderHook(() => useNetworkData(FILE, undefined, 50))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.nodes.map(n => n.id).sort()).toEqual(['10.0.0.1', '8.8.8.8'])
+    expect(result.current.error).toBeNull()
+  })
+
+  it.each([
+    ['host classifications', 'getHostClassifications'],
+    ['host identities', 'getHostIdentities'],
+  ] as const)('still renders when %s are unavailable', async (_label, method) => {
+    serveAll()
+    convService[method].mockRejectedValue(new Error('404'))
+
+    const { result } = renderHook(() => useNetworkData(FILE, undefined, 50))
+
+    // Best-effort enrichment. Captures analysed before these endpoints existed have none, and
+    // an all-or-nothing fetch would blank the graph for every historical file.
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.nodes).toHaveLength(2)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('still renders when node roles are unavailable', async () => {
+    serveAll()
+    insights.listNodeRoles.mockRejectedValue(new Error('404'))
+
+    const { result } = renderHook(() => useNetworkData(FILE, undefined, 50))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.nodes).toHaveLength(2)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('fails when conversations cannot be loaded', async () => {
+    serveAll()
+    convService.getConversations.mockRejectedValue(new Error('backend down'))
+
+    const { result } = renderHook(() => useNetworkData(FILE, undefined, 50))
+
+    // Conversations are the graph. Without them there is nothing to draw, so this is the one
+    // rejection that must surface rather than degrade.
+    await waitFor(() => expect(result.current.error).toBe('backend down'))
+    expect(result.current.nodes).toEqual([])
+  })
+
+  it('re-slices without refetching when the node limit changes', async () => {
+    serveAll()
+
+    const { result, rerender } = renderHook(
+      ({ max }) => useNetworkData(FILE, undefined, max),
+      { initialProps: { max: 50 } }
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const fetches = convService.getConversations.mock.calls.length
+
+    rerender({ max: 1 })
+
+    // Conversations are cached in a ref precisely so the node-limit slider is instant. Moving
+    // it re-downloading a 10,000-conversation page would make the control unusable.
+    await waitFor(() => expect(result.current.nodes).toHaveLength(1))
+    expect(convService.getConversations.mock.calls.length).toBe(fetches)
+    expect(result.current.hiddenNodes).toBe(1)
+  })
+
+  it('refetches on demand', async () => {
+    serveAll()
+
+    const { result } = renderHook(() => useNetworkData(FILE, undefined, 50))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const before = convService.getConversations.mock.calls.length
+
+    await result.current.refetch()
+
+    expect(convService.getConversations.mock.calls.length).toBe(before + 1)
+  })
+})

--- a/frontend/src/features/network/services/__tests__/buildNetworkGraph.test.ts
+++ b/frontend/src/features/network/services/__tests__/buildNetworkGraph.test.ts
@@ -1,0 +1,114 @@
+/**
+ * buildNetworkGraph turns conversations into the graph an analyst reads. It is the largest
+ * function in the frontend and had no tests, so these cover its observable contracts — node and
+ * edge construction, the caps that keep a big capture renderable, and the seeding that makes the
+ * node count agree with the analysis summary — rather than every internal branch.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { Conversation } from '@/types'
+import { buildNetworkGraph } from '../networkService'
+
+function conversation(src: string, dst: string, overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: `${src}->${dst}`,
+    endpoints: [
+      { ip: src, port: 1234 },
+      { ip: dst, port: 443 },
+    ],
+    protocol: { name: 'TCP', layer: 'transport' },
+    packetCount: 10,
+    totalBytes: 1000,
+    startTime: 0,
+    endTime: 1,
+    flowRisks: [],
+    customSignatures: [],
+    suricataAlerts: [],
+    ...overrides,
+  } as unknown as Conversation
+}
+
+describe('buildNetworkGraph', () => {
+  it('creates one node per distinct host and one edge per conversation', () => {
+    const result = buildNetworkGraph([conversation('10.0.0.1', '8.8.8.8')])
+
+    expect(result.nodes.map(n => n.id).sort()).toEqual(['10.0.0.1', '8.8.8.8'])
+    expect(result.edges).toHaveLength(1)
+  })
+
+  it('reuses a node when a host appears in several conversations', () => {
+    const result = buildNetworkGraph([
+      conversation('10.0.0.1', '8.8.8.8'),
+      conversation('10.0.0.1', '1.1.1.1'),
+    ])
+
+    // Three hosts, not four: the shared host must be one node or the graph double-counts it.
+    expect(result.nodes).toHaveLength(3)
+    expect(result.edges).toHaveLength(2)
+  })
+
+  it('accumulates traffic onto the shared node rather than overwriting it', () => {
+    const result = buildNetworkGraph([
+      conversation('10.0.0.1', '8.8.8.8', { packetCount: 10, totalBytes: 1000 }),
+      conversation('10.0.0.1', '1.1.1.1', { packetCount: 5, totalBytes: 500 }),
+    ])
+
+    const shared = result.nodes.find(n => n.id === '10.0.0.1')!
+    // Node size and ranking are driven by these totals, so overwriting would shrink a busy host.
+    expect(shared.data.bytesSent).toBe(1500)
+  })
+
+  it('caps the conversations it will render', () => {
+    const many = Array.from({ length: 10 }, (_, i) => conversation('10.0.0.1', `8.8.8.${i}`))
+
+    const result = buildNetworkGraph(many, undefined, 3)
+
+    // The cap exists so a 100k-conversation capture still renders; without it the browser hangs.
+    expect(result.edges).toHaveLength(3)
+  })
+
+  it('reports statistics consistent with the graph it built', () => {
+    const result = buildNetworkGraph([
+      conversation('10.0.0.1', '8.8.8.8', { packetCount: 10 }),
+      conversation('10.0.0.2', '1.1.1.1', { packetCount: 5 }),
+    ])
+
+    expect(result.stats.totalNodes).toBe(result.nodes.length)
+    expect(result.stats.totalEdges).toBe(result.edges.length)
+  })
+
+  it('breaks packet counts down by protocol', () => {
+    const result = buildNetworkGraph([
+      conversation('10.0.0.1', '8.8.8.8', {
+        protocol: { name: 'TCP', layer: 'transport' },
+        packetCount: 10,
+      } as Partial<Conversation>),
+      conversation('10.0.0.2', '1.1.1.1', {
+        protocol: { name: 'UDP', layer: 'transport' },
+        packetCount: 4,
+      } as Partial<Conversation>),
+    ])
+
+    expect(result.stats.protocolBreakdown).toMatchObject({ TCP: 10, UDP: 4 })
+  })
+
+  it('marks an edge as risky when the conversation carries flow risks', () => {
+    const result = buildNetworkGraph([
+      conversation('10.0.0.1', '8.8.8.8', {
+        flowRisks: ['Self-signed certificate'],
+      } as Partial<Conversation>),
+    ])
+
+    // selectSignificantNodes reads hasRisks to decide visibility, so this flag is what keeps a
+    // flagged host on screen when the graph is capped.
+    expect(result.edges[0].data.hasRisks).toBe(true)
+  })
+
+  it('returns an empty graph for no conversations rather than throwing', () => {
+    const result = buildNetworkGraph([])
+
+    expect(result.nodes).toEqual([])
+    expect(result.edges).toEqual([])
+    expect(result.stats.totalNodes).toBe(0)
+  })
+})

--- a/frontend/src/features/network/services/__tests__/clusterService.test.ts
+++ b/frontend/src/features/network/services/__tests__/clusterService.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Subnet clustering decides what the network graph actually shows. Collapse too eagerly and
+ * hosts an analyst is looking for vanish into a cluster; collapse too little and the graph is
+ * unreadable. It is pure — no HTTP — so this is the cheapest high-value logic in the frontend
+ * and it had no tests.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { GraphEdge, GraphNode } from '@/features/network/types'
+import { applySubnetClustering } from '../clusterService'
+
+function node(ip: string): GraphNode {
+  return {
+    id: ip,
+    label: ip,
+    data: {
+      ip,
+      packetsSent: 1,
+      packetsReceived: 1,
+      bytesSent: 1,
+      bytesReceived: 1,
+      totalBytes: 2,
+      role: 'unknown',
+    } as GraphNode['data'],
+  }
+}
+
+function edge(source: string, target: string): GraphEdge {
+  return {
+    id: `${source}->${target}`,
+    source,
+    target,
+    label: 'TCP',
+    data: {
+      protocol: 'TCP',
+      packetCount: 1,
+      totalBytes: 1,
+      conversationId: `${source}->${target}`,
+      bidirectional: false,
+    } as GraphEdge['data'],
+  }
+}
+
+const ids = (nodes: GraphNode[]) => nodes.map(n => n.id).sort()
+
+describe('applySubnetClustering', () => {
+  it('collapses two or more hosts sharing a /24', () => {
+    const nodes = [node('10.0.1.5'), node('10.0.1.6'), node('10.0.1.7')]
+
+    const result = applySubnetClustering(nodes, [], new Set())
+
+    // One cluster stands in for all three; the members are no longer drawn individually.
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0].id).toContain('10.0.1.0/24')
+  })
+
+  it('leaves a lone host in its /24 uncollapsed rather than making a cluster of one', () => {
+    const nodes = [node('10.0.1.5'), node('192.168.9.9')]
+
+    const result = applySubnetClustering(nodes, [], new Set())
+
+    // A cluster of one is strictly worse than the node: same information, extra indirection.
+    expect(result.nodes).toHaveLength(2)
+  })
+
+  it('promotes scattered single-host /24s to a /16 so they still group', () => {
+    // The case the two-pass strategy exists for: 250 unique /24s would otherwise stay 250
+    // separate nodes and make the graph unreadable.
+    const nodes = [node('10.0.1.5'), node('10.0.2.5'), node('10.0.3.5')]
+
+    const result = applySubnetClustering(nodes, [], new Set())
+
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0].id).toContain('10.0.0.0/16')
+  })
+
+  it('expands a cluster back into its members on request', () => {
+    const nodes = [node('10.0.1.5'), node('10.0.1.6')]
+    const collapsed = applySubnetClustering(nodes, [], new Set())
+    const clusterId = collapsed.nodes[0].id
+
+    const expanded = applySubnetClustering(nodes, [], new Set([clusterId]))
+
+    expect(ids(expanded.nodes)).toEqual(['10.0.1.5', '10.0.1.6'])
+  })
+
+  it('rewires an edge to the cluster that swallowed its endpoint', () => {
+    const nodes = [node('10.0.1.5'), node('10.0.1.6'), node('8.8.8.8')]
+    const edges = [edge('10.0.1.5', '8.8.8.8')]
+
+    const result = applySubnetClustering(nodes, edges, new Set())
+
+    // The edge must survive: dropping it would hide that the cluster talks to 8.8.8.8 at all.
+    expect(result.edges).toHaveLength(1)
+    expect(result.edges[0].source).toContain('10.0.1.0/24')
+    expect(result.edges[0].target).toBe('8.8.8.8')
+  })
+
+  it.each([
+    ['127.0.0.1', 'loopback'],
+    ['169.254.1.1', 'link-local'],
+    ['224.0.0.251', 'multicast'],
+    ['239.255.255.250', 'multicast (SSDP)'],
+    ['fe80::1', 'IPv6 link-local'],
+  ])('never clusters %s (%s)', ip => {
+    // These carry meaning individually — mDNS and SSDP traffic is how devices are identified,
+    // so folding them into a subnet blob destroys the signal.
+    const nodes = [node(ip), node(ip.replace(/1$/, '2')), node(ip.replace(/1$/, '3'))]
+
+    const result = applySubnetClustering(nodes, [], new Set())
+
+    expect(result.nodes).toHaveLength(3)
+  })
+
+  it('returns nodes untouched when there is nothing to cluster', () => {
+    const nodes = [node('8.8.8.8')]
+
+    const result = applySubnetClustering(nodes, [], new Set())
+
+    expect(ids(result.nodes)).toEqual(['8.8.8.8'])
+  })
+})

--- a/frontend/src/features/network/services/__tests__/selectSignificantNodes.test.ts
+++ b/frontend/src/features/network/services/__tests__/selectSignificantNodes.test.ts
@@ -1,0 +1,129 @@
+/**
+ * When a capture has more hosts than the graph will draw, this function decides which ones an
+ * analyst sees. Getting it wrong hides hosts that matter, and the hiding is silent — the graph
+ * looks complete either way.
+ *
+ * Score = 0.5 * (bytes / maxBytes) + 0.3 * (has risk) + 0.2 * (connections / maxConnections).
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { GraphEdge, GraphNode } from '@/features/network/types'
+import { selectSignificantNodes } from '../networkService'
+
+function node(id: string, totalBytes: number, connections = 1): GraphNode {
+  return {
+    id,
+    label: id,
+    data: {
+      ip: id,
+      packetsSent: 1,
+      packetsReceived: 1,
+      bytesSent: totalBytes,
+      bytesReceived: 0,
+      totalBytes,
+      connections,
+      role: 'unknown',
+    } as GraphNode['data'],
+  }
+}
+
+function edge(source: string, target: string, risky = false): GraphEdge {
+  return {
+    id: `${source}->${target}`,
+    source,
+    target,
+    label: 'TCP',
+    data: {
+      protocol: 'TCP',
+      packetCount: 1,
+      totalBytes: 1,
+      conversationId: `${source}->${target}`,
+      bidirectional: false,
+      hasRisks: risky,
+    } as GraphEdge['data'],
+  }
+}
+
+const ids = (nodes: GraphNode[]) => nodes.map(n => n.id)
+
+describe('selectSignificantNodes', () => {
+  it('hides nothing when the graph fits inside the limit', () => {
+    const nodes = [node('a', 10), node('b', 20)]
+
+    const result = selectSignificantNodes(nodes, [], 5)
+
+    expect(result.hiddenCount).toBe(0)
+    expect(result.hiddenNodesList).toEqual([])
+    expect(result.crossEdges).toEqual([])
+  })
+
+  it('keeps the highest-traffic host when traffic is the only signal', () => {
+    const nodes = [node('quiet', 1), node('loud', 1000)]
+
+    const result = selectSignificantNodes(nodes, [], 1)
+
+    expect(ids(result.significantNodes)).toEqual(['loud'])
+    expect(result.hiddenCount).toBe(1)
+  })
+
+  it('promotes a risky host over an equally busy clean one', () => {
+    const nodes = [node('clean', 100), node('risky', 100)]
+    const edges = [edge('risky', 'peer', true)]
+
+    const result = selectSignificantNodes(nodes, edges, 1)
+
+    // Risk is worth 0.3, so it breaks the tie — which is the point of scoring rather than
+    // sorting on bytes alone.
+    expect(ids(result.significantNodes)).toEqual(['risky'])
+  })
+
+  it('marks both endpoints of a risky edge, not just the source', () => {
+    // Scores, with maxBytes = 2 and every node on 1 connection:
+    //   src  0.5*(1/2) + 0.3 + 0.2 = 0.75
+    //   dst  0.5*(1/2) + 0.3 + 0.2 = 0.75
+    //   bulk 0.5*(2/2) + 0.0 + 0.2 = 0.70
+    // so the risky pair edges out the busier host by a margin the risk flag supplies.
+    const nodes = [node('src', 1), node('dst', 1), node('bulk', 2)]
+    const edges = [edge('src', 'dst', true)]
+
+    const result = selectSignificantNodes(nodes, edges, 2)
+
+    // A risk belongs to the conversation, so the peer is as interesting as the initiator.
+    expect(ids(result.significantNodes).sort()).toEqual(['dst', 'src'])
+  })
+
+  it('reports cross-edges only where exactly one endpoint was hidden', () => {
+    const nodes = [node('keep1', 100), node('keep2', 90), node('drop', 1)]
+    const edges = [edge('keep1', 'keep2'), edge('keep1', 'drop'), edge('drop', 'drop')]
+
+    const result = selectSignificantNodes(nodes, edges, 2)
+
+    // These drive the "N hidden hosts" affordance. A visible↔visible edge is already drawn,
+    // and a hidden↔hidden edge is invisible either way.
+    expect(result.crossEdges.map(e => e.id)).toEqual(['keep1->drop'])
+  })
+
+  it('counts hidden nodes consistently with the returned list', () => {
+    const nodes = [node('a', 5), node('b', 4), node('c', 3), node('d', 2)]
+
+    const result = selectSignificantNodes(nodes, [], 2)
+
+    expect(result.hiddenCount).toBe(result.hiddenNodesList.length)
+    expect(result.hiddenCount).toBe(2)
+  })
+
+  describe('known looseness — pinned, not endorsed', () => {
+    it('still hides a risky host when its traffic is small enough', () => {
+      // Risk contributes at most 0.3 while traffic contributes up to 0.5, so a flagged host
+      // with little traffic loses to busy clean ones. An analyst who assumes "risky hosts are
+      // always shown" would be wrong, and nothing in the UI says otherwise.
+      const nodes = [node('loud1', 1000), node('loud2', 999), node('risky', 1)]
+      const edges = [edge('risky', 'peer', true)]
+
+      const result = selectSignificantNodes(nodes, edges, 2)
+
+      expect(ids(result.significantNodes)).toEqual(['loud1', 'loud2'])
+      expect(ids(result.hiddenNodesList)).toContain('risky')
+    })
+  })
+})

--- a/frontend/src/features/notes/services/__tests__/entityNotesService.test.ts
+++ b/frontend/src/features/notes/services/__tests__/entityNotesService.test.ts
@@ -1,6 +1,7 @@
 /**
- * Entity notes are operator-written annotations on hosts and protocols — the one place a human
- * puts findings back into the tool. Losing one silently is worse than failing loudly.
+ * Entity notes are operator-authored evidence attached to an IP, device, protocol or app.
+ * Losing one silently is worse than failing loudly: the note is the analyst's own record of
+ * why a host was judged the way it was.
  */
 import { HttpResponse, http } from 'msw'
 import { describe, expect, it } from 'vitest'
@@ -8,65 +9,116 @@ import { describe, expect, it } from 'vitest'
 import { server } from '@/test/msw'
 import { entityNotesService } from '../entityNotesService'
 
-const NOTE = {
+const note = {
   entityType: 'IP' as const,
   entityKey: '10.0.0.1',
-  note: 'Jump box',
+  note: 'DNS server for the branch office',
   createdAt: '2026-08-12T00:00:00Z',
   updatedAt: '2026-08-12T00:00:00Z',
 }
 
 describe('entityNotesService', () => {
-  it('returns the note when one exists', async () => {
-    server.use(http.get('*/api/v1/entity-notes', () => HttpResponse.json(NOTE)))
-    await expect(entityNotesService.getNote('IP', '10.0.0.1')).resolves.toEqual(NOTE)
+  it('returns the stored note', async () => {
+    server.use(http.get('*/api/v1/entity-notes', () => HttpResponse.json(note)))
+
+    await expect(entityNotesService.getNote('IP', '10.0.0.1')).resolves.toEqual(note)
   })
 
-  it('sends the entity as query parameters', async () => {
-    let params: URLSearchParams | null = null
+  it('upserts through PUT, carrying the entity identity in the body', async () => {
+    let body: unknown = null
+    let method: string | null = null
+    server.use(
+      http.put('*/api/v1/entity-notes', async ({ request }) => {
+        method = request.method
+        body = await request.json()
+        return HttpResponse.json(note)
+      })
+    )
+
+    await entityNotesService.upsertNote('IP', '10.0.0.1', 'DNS server for the branch office')
+
+    // PUT rather than POST: upsert is idempotent, so re-saving a note must not create a
+    // second one (CLAUDE.md: PUT/PATCH update).
+    expect(method).toBe('PUT')
+    expect(body).toEqual({
+      entityType: 'IP',
+      entityKey: '10.0.0.1',
+      note: 'DNS server for the branch office',
+    })
+  })
+
+  it('passes the entity identity as query parameters when reading', async () => {
+    let query: URLSearchParams | null = null
     server.use(
       http.get('*/api/v1/entity-notes', ({ request }) => {
-        params = new URL(request.url).searchParams
-        return HttpResponse.json(NOTE)
+        query = new URL(request.url).searchParams
+        return HttpResponse.json(note)
       })
     )
 
     await entityNotesService.getNote('DEVICE', 'aa:bb:cc:dd:ee:ff')
 
-    expect(params!.get('entityType')).toBe('DEVICE')
-    // A MAC address contains colons, which must survive encoding or the lookup silently misses.
-    expect(params!.get('entityKey')).toBe('aa:bb:cc:dd:ee:ff')
+    expect(query!.get('entityType')).toBe('DEVICE')
+    // A MAC contains colons, which must survive encoding or the note is read for the wrong key.
+    expect(query!.get('entityKey')).toBe('aa:bb:cc:dd:ee:ff')
   })
 
-  it('swallows a server error and reports "no note" — pinned, not endorsed', async () => {
-    // The catch reads `if (status === 204) return null; return null;` — the condition is dead
-    // code, so every failure becomes an absent note. An operator whose note failed to load sees
-    // an empty box and may overwrite it. Pinned so fixing it is a visible, deliberate change.
-    server.use(
-      http.get('*/api/v1/entity-notes', () => HttpResponse.json({ message: 'boom' }, { status: 500 }))
-    )
-    await expect(entityNotesService.getNote('IP', '10.0.0.1')).resolves.toBeNull()
+  it('reads the history list for an entity', async () => {
+    const history = [
+      {
+        fileId: 'f1',
+        fileName: 'a.pcap',
+        startTime: null,
+        endTime: null,
+        packetCount: null,
+        totalBytes: null,
+      },
+    ]
+    server.use(http.get('*/api/v1/entity-notes/history', () => HttpResponse.json(history)))
+
+    await expect(entityNotesService.getHistory('IP', '10.0.0.1')).resolves.toEqual(history)
   })
 
-  it('upserts through PUT and returns the saved note', async () => {
-    let body: unknown = null
+  describe('known looseness — pinned, not endorsed', () => {
+    it('turns a server error into "no note" instead of surfacing it', async () => {
+      let handled = false
+      server.use(
+        http.get('*/api/v1/entity-notes', () => {
+          handled = true
+          return HttpResponse.json({ message: 'boom' }, { status: 500 })
+        })
+      )
+
+      // The catch names a 204 but returns null for *every* error, so an outage is
+      // indistinguishable from "this entity has no note". An operator opening a host during a
+      // backend failure sees an empty note field and may overwrite a note that still exists.
+      await expect(entityNotesService.getNote('IP', '10.0.0.1')).resolves.toBeNull()
+      expect(handled, 'the request never reached the handler').toBe(true)
+    })
+
+    it('also swallows a 404', async () => {
+      server.use(
+        http.get('*/api/v1/entity-notes', () =>
+          HttpResponse.json({ message: 'gone' }, { status: 404 })
+        )
+      )
+
+      await expect(entityNotesService.getNote('IP', '10.0.0.1')).resolves.toBeNull()
+    })
+  })
+
+  it('propagates a failed delete rather than reporting success', async () => {
+    let handled = false
     server.use(
-      http.put('*/api/v1/entity-notes', async ({ request }) => {
-        body = await request.json()
-        return HttpResponse.json(NOTE)
+      http.delete('*/api/v1/entity-notes', () => {
+        handled = true
+        return HttpResponse.json({ message: 'nope' }, { status: 500 })
       })
     )
 
-    await expect(entityNotesService.upsertNote('IP', '10.0.0.1', 'Jump box')).resolves.toEqual(NOTE)
-    expect(body).toEqual({ entityType: 'IP', entityKey: '10.0.0.1', note: 'Jump box' })
-  })
-
-  it('propagates a failed save rather than pretending it worked', async () => {
-    // Unlike getNote, a failed write must reject: silently discarding an operator's note is the
-    // worst outcome this module can produce.
-    server.use(
-      http.put('*/api/v1/entity-notes', () => HttpResponse.json({ message: 'nope' }, { status: 500 }))
-    )
-    await expect(entityNotesService.upsertNote('IP', '10.0.0.1', 'x')).rejects.toThrow()
+    // Unlike getNote, delete has no catch — so a failure is visible, which is what lets the UI
+    // avoid telling the analyst their note was removed when it was not.
+    await expect(entityNotesService.deleteNote('IP', '10.0.0.1')).rejects.toThrow()
+    expect(handled).toBe(true)
   })
 })

--- a/frontend/src/features/subnets/services/__tests__/subnetService.test.ts
+++ b/frontend/src/features/subnets/services/__tests__/subnetService.test.ts
@@ -1,7 +1,7 @@
 /**
- * Subnet definitions are the operator's map of their own network: which ranges are which.
- * `confirmed` is the flag separating "the tool guessed this" from "a human said so", and it
- * drives the staleness workflow, so a write that sets it wrongly launders a guess into a fact.
+ * The last untested service (#659). Subnet definitions decide how hosts are grouped and labelled
+ * across every capture in a monitor network, and the `confirmed` flag is what separates an
+ * analyst's judgement from a machine guess — which later drives staleness.
  */
 import { HttpResponse, http } from 'msw'
 import { describe, expect, it } from 'vitest'
@@ -9,90 +9,125 @@ import { describe, expect, it } from 'vitest'
 import { server } from '@/test/msw'
 import { subnetService } from '../subnetService'
 
-/** Captures the JSON body posted to a subnet endpoint. */
-function capturePost(path: string) {
-  const seen: { body?: Record<string, unknown>; handled: boolean } = { handled: false }
-  server.use(
-    http.post(path, async ({ request }) => {
-      seen.handled = true
-      seen.body = (await request.json()) as Record<string, unknown>
-      return HttpResponse.json({ id: 1, cidr: '10.0.0.0/8', label: 'Corp' }, { status: 201 })
-    })
-  )
+const subnet = { id: 1, cidr: '10.0.0.0/8', label: 'Corp', confirmed: true }
+
+/** Captures the body or query of whichever subnet endpoint is hit. */
+function capture(method: 'post' | 'get' | 'delete', path: string, status = 200) {
+  const seen: { body?: Record<string, unknown>; query?: URLSearchParams; calls: number } = {
+    calls: 0,
+  }
+  const handler = async ({ request }: { request: Request }) => {
+    seen.calls += 1
+    seen.query = new URL(request.url).searchParams
+    if (method === 'post') {
+      seen.body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+    }
+    return status === 200
+      ? HttpResponse.json(subnet)
+      : HttpResponse.json({ message: 'boom' }, { status })
+  }
+  server.use(http[method](path, handler))
   return seen
 }
 
 describe('subnetService', () => {
-  it('sends the confirmed flag the caller chose', async () => {
-    const seen = capturePost('*/api/v1/subnets')
+  it('lists subnet definitions', async () => {
+    server.use(http.get('*/api/v1/subnets', () => HttpResponse.json([subnet])))
 
-    await subnetService.upsert('10.0.0.0/8', 'Corp', 'HQ range', true)
+    await expect(subnetService.list()).resolves.toEqual([subnet])
+  })
 
-    expect(seen.body).toMatchObject({
+  it('carries the confirmed flag through an upsert', async () => {
+    const seen = capture('post', '*/api/v1/subnets')
+
+    await subnetService.upsert('10.0.0.0/8', 'Corp', 'head office', true, 'net-1')
+
+    // `confirmed` is the analyst-versus-machine distinction, and networkId is what lets the
+    // backend baseline staleness against that network's latest snapshot. Dropping either turns
+    // a deliberate label into an unanchored guess.
+    expect(seen.body).toEqual({
       cidr: '10.0.0.0/8',
       label: 'Corp',
-      description: 'HQ range',
+      description: 'head office',
       confirmed: true,
+      networkId: 'net-1',
     })
   })
 
-  it('omits networkId entirely when not supplied', async () => {
-    const seen = capturePost('*/api/v1/subnets')
+  it('omits networkId when none is given rather than sending undefined', async () => {
+    const seen = capture('post', '*/api/v1/subnets')
 
-    await subnetService.upsert('10.0.0.0/8', 'Corp', '', false)
+    await subnetService.upsert('10.0.0.0/8', 'Corp', '', false, undefined)
 
-    // The key is in the object literal but undefined, and JSON.stringify drops it. Sending an
-    // explicit null instead would clear the staleness baseline the backend captures from it.
-    expect(seen.body).not.toHaveProperty('networkId')
-  })
-
-  it('passes networkId through when supplied', async () => {
-    const seen = capturePost('*/api/v1/subnets')
-
-    await subnetService.upsert('10.0.0.0/8', 'Corp', '', true, 'net-1')
-
-    // Only present on a confirm, where it tells the backend which snapshot to baseline against.
-    expect(seen.body).toMatchObject({ networkId: 'net-1' })
+    expect(seen.body).toMatchObject({ confirmed: false })
+    expect(seen.body?.networkId).toBeUndefined()
   })
 
   it('always saves a detected subnet as unconfirmed', async () => {
-    const seen = capturePost('*/api/v1/subnets/detected')
+    const seen = capture('post', '*/api/v1/subnets/detected')
 
-    await subnetService.saveDetected('192.168.0.0/16', 'Guessed', 'from traffic')
+    await subnetService.saveDetected('10.0.0.0/8', 'Detected', 'auto')
 
-    // Hard-coded, and must stay so: a detected range is the tool's guess. Marking it confirmed
-    // would launder that guess into something the UI presents as operator-verified.
+    // Hard-coded, not a parameter. A machine-detected subnet must never arrive already
+    // confirmed, or it would suppress the staleness prompts that ask a human to check it.
     expect(seen.body).toMatchObject({ confirmed: false })
   })
 
-  it('surfaces a rejected subnet rather than reporting success', async () => {
-    let handled = false
-    server.use(
-      http.post('*/api/v1/subnets', () => {
-        handled = true
-        return HttpResponse.json({ message: 'overlaps an existing range' }, { status: 400 })
-      })
-    )
+  it('passes the file id when detecting from a capture', async () => {
+    const seen = capture('get', '*/api/v1/subnets/detect')
 
-    await expect(subnetService.upsert('10.0.0.0/8', 'Corp', '', true)).rejects.toThrow()
-    // Asserts the rejection came from the endpoint, not from an unmatched URL.
-    expect(handled, 'the subnets endpoint was never reached').toBe(true)
+    await subnetService.detect('file-1')
+
+    expect(seen.query?.get('fileId')).toBe('file-1')
   })
 
-  it('lists and deletes against the versioned paths', async () => {
-    let deleted: string | null = null
+  it('detects from a network through its own endpoint', async () => {
+    const seen = capture('get', '*/api/v1/subnets/detect/network')
+
+    await subnetService.detectFromNetwork('net-1')
+
+    // A separate route from the per-file detect: the network variant aggregates across
+    // snapshots, so routing one to the other silently changes what is detected.
+    expect(seen.query?.get('networkId')).toBe('net-1')
+  })
+
+  it('sends only the context it was given when suggesting a label', async () => {
+    const seen = capture('post', '*/api/v1/subnets/*/suggest-label')
+
+    await subnetService.suggestLabel(1, 'net-1')
+
+    // The endpoint builds its query conditionally; an empty fileId= would be a filter for a
+    // capture that does not exist.
+    expect(seen.query?.get('networkId')).toBe('net-1')
+    expect(seen.query?.has('fileId')).toBe(false)
+  })
+
+  it('surfaces a failed suggestion rather than resolving empty', async () => {
+    const seen = capture('post', '*/api/v1/subnets/*/suggest-label', 500)
+
+    await expect(subnetService.suggestLabel(1)).rejects.toThrow()
+    expect(seen.calls).toBe(1)
+  })
+
+  it('reads composition history for a subnet within a network', async () => {
+    const seen = capture('get', '*/api/v1/subnets/*/history')
+
+    await subnetService.history(1, 'net-1')
+
+    expect(seen.query?.get('networkId')).toBe('net-1')
+  })
+
+  it('deletes by id', async () => {
+    let deletedPath: string | null = null
     server.use(
-      http.get('*/api/v1/subnets', () =>
-        HttpResponse.json([{ id: 1, cidr: '10.0.0.0/8', label: 'Corp' }])
-      ),
       http.delete('*/api/v1/subnets/:id', ({ request }) => {
-        deleted = new URL(request.url).pathname
+        deletedPath = new URL(request.url).pathname
         return new HttpResponse(null, { status: 204 })
       })
     )
 
-    await expect(subnetService.list()).resolves.toHaveLength(1)
-    await subnetService.delete(4)
-    expect(deleted).toBe('/api/v1/subnets/4')
+    await subnetService.delete(7)
+
+    expect(deletedPath).toBe('/api/v1/subnets/7')
   })
 })

--- a/frontend/src/features/tracer/__tests__/tracerService.test.ts
+++ b/frontend/src/features/tracer/__tests__/tracerService.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The tracer walks an analyst through a single conversation packet by packet. Its explain
+ * endpoint is LLM-backed, and that path fails *softly*: a 200 carrying an `error` field rather
+ * than an HTTP error. A caller that only checks the status shows an empty explanation panel
+ * with no indication anything went wrong.
+ */
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { server } from '@/test/msw'
+import { tracerService } from '../tracerService'
+
+const CONV = 'conv-1'
+
+describe('tracerService', () => {
+  it('returns the step list with its conversation metadata', async () => {
+    const payload = {
+      conversationId: CONV,
+      srcIp: '10.0.0.1',
+      srcPort: 1234,
+      dstIp: '8.8.8.8',
+      dstPort: 53,
+      protocol: 'UDP',
+      appName: 'DNS',
+      steps: [
+        {
+          stepIndex: 0,
+          packetNumber: 1,
+          timestamp: null,
+          direction: 'CLIENT' as const,
+          protocol: 'UDP',
+          size: 74,
+          info: null,
+          payloadHex: null,
+        },
+      ],
+    }
+    server.use(http.get('*/api/v1/tracer/:id/steps', () => HttpResponse.json(payload)))
+
+    await expect(tracerService.getSteps(CONV)).resolves.toEqual(payload)
+  })
+
+  it('returns peers for a conversation', async () => {
+    const payload = {
+      conversationId: CONV,
+      hostIp: '10.0.0.1',
+      peers: [
+        { ip: '8.8.8.8', conversationId: CONV, protocol: 'UDP', packetCount: 2, responded: true },
+      ],
+    }
+    server.use(http.get('*/api/v1/tracer/:id/peers', () => HttpResponse.json(payload)))
+
+    await expect(tracerService.getPeers(CONV)).resolves.toEqual(payload)
+  })
+
+  it('requests an explanation with POST, since it triggers generation', async () => {
+    let method: string | null = null
+    server.use(
+      http.post('*/api/v1/tracer/:id/explanations', ({ request }) => {
+        method = request.method
+        return HttpResponse.json({ conversationId: CONV, explanations: [] })
+      })
+    )
+
+    await tracerService.explain(CONV)
+
+    // Not a GET: the call runs an LLM and creates a result, so it is not safe to retry or cache.
+    expect(method).toBe('POST')
+  })
+
+  it('surfaces a soft LLM failure as a 200 carrying an error field', async () => {
+    server.use(
+      http.post('*/api/v1/tracer/:id/explanations', () =>
+        HttpResponse.json({
+          conversationId: CONV,
+          explanations: [],
+          error: 'LLM server is not responding',
+        })
+      )
+    )
+
+    const result = await tracerService.explain(CONV)
+
+    // The promise resolves — the failure is in the body, not the status. Pinned because a
+    // caller that only checks for a rejection renders an empty panel and says nothing.
+    expect(result.error).toBe('LLM server is not responding')
+    expect(result.explanations).toEqual([])
+  })
+
+  it('still rejects on a hard failure from the explain endpoint', async () => {
+    let handled = false
+    server.use(
+      http.post('*/api/v1/tracer/:id/explanations', () => {
+        handled = true
+        return HttpResponse.json({ message: 'gateway' }, { status: 502 })
+      })
+    )
+
+    // Both failure modes exist, so the UI has to handle each. e2e/llm-error.spec.ts covers the
+    // 502 path end to end; this pins that the service does not swallow it.
+    await expect(tracerService.explain(CONV)).rejects.toThrow()
+    expect(handled).toBe(true)
+  })
+})

--- a/frontend/src/features/upload/hooks/__tests__/useFileUpload.test.tsx
+++ b/frontend/src/features/upload/hooks/__tests__/useFileUpload.test.tsx
@@ -138,13 +138,29 @@ describe('useFileUpload', () => {
     await waitFor(() => expect(result.current.uploads[0].progress).toBe(100))
   })
 
-  it('exposes isUploading only while work is outstanding', async () => {
-    mocked.uploadPcap.mockResolvedValue({ fileId: 'f1' } as never)
+  it('reports isUploading while a file is actually in flight', async () => {
+    // Held open so the flag can be observed mid-upload. Checking only before and after leaves
+    // isUploading trivially false at both ends — it would pass even if the flag were never
+    // set, which is exactly what the progress UI depends on.
+    let finishUpload: () => void = () => {}
+    mocked.uploadPcap.mockImplementation(
+      () => new Promise(res => { finishUpload = () => res({ fileId: 'f1' } as never) })
+    )
 
     const { result } = renderHook(() => useFileUpload())
     expect(result.current.isUploading).toBe(false)
 
-    await act(async () => { await result.current.uploadFiles([pcap('a.pcap')]) })
+    let pending!: Promise<void>
+    await act(async () => {
+      pending = result.current.uploadFiles([pcap('a.pcap')])
+    })
+
+    expect(result.current.isUploading).toBe(true)
+
+    await act(async () => {
+      finishUpload()
+      await pending
+    })
 
     expect(result.current.isUploading).toBe(false)
   })

--- a/frontend/src/features/upload/hooks/__tests__/useFileUpload.test.tsx
+++ b/frontend/src/features/upload/hooks/__tests__/useFileUpload.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Upload is the app's front door, and this hook drives its only progress UI. The two properties
+ * that matter are not visible in a single upload: that files go one at a time, and that a
+ * duplicate is reported as a duplicate rather than a failure.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { uploadService } from '../../services/uploadService'
+import { useFileUpload } from '../useFileUpload'
+
+vi.mock('../../services/uploadService', () => ({
+  uploadService: { uploadPcap: vi.fn() },
+}))
+
+const mocked = vi.mocked(uploadService)
+
+const pcap = (name: string) => new File([new Uint8Array([1, 2, 3])], name)
+
+/** An axios-shaped rejection, which is what the hook branches on. */
+function httpError(status: number, data: unknown) {
+  return Object.assign(new Error(`Request failed with status code ${status}`), {
+    response: { status, data },
+  })
+}
+
+afterEach(() => vi.resetAllMocks())
+
+describe('useFileUpload', () => {
+  it('records a fileId for each successful upload', async () => {
+    mocked.uploadPcap.mockResolvedValue({ fileId: 'f1' } as never)
+
+    const { result } = renderHook(() => useFileUpload())
+    await act(async () => { await result.current.uploadFiles([pcap('a.pcap')]) })
+
+    expect(result.current.uploads[0]).toMatchObject({
+      fileName: 'a.pcap',
+      fileId: 'f1',
+      progress: 100,
+      isUploading: false,
+    })
+  })
+
+  it('uploads one file at a time rather than all at once', async () => {
+    let inFlight = 0
+    let maxConcurrent = 0
+    mocked.uploadPcap.mockImplementation(async () => {
+      inFlight += 1
+      maxConcurrent = Math.max(maxConcurrent, inFlight)
+      await new Promise(r => setTimeout(r, 5))
+      inFlight -= 1
+      return { fileId: 'f' } as never
+    })
+
+    const { result } = renderHook(() => useFileUpload())
+    await act(async () => {
+      await result.current.uploadFiles([pcap('a.pcap'), pcap('b.pcap'), pcap('c.pcap')])
+    })
+
+    // Sequential by design: captures are large, and a Promise.all here would flood the backend
+    // and the network with concurrent multipart bodies.
+    expect(maxConcurrent).toBe(1)
+    expect(mocked.uploadPcap).toHaveBeenCalledTimes(3)
+  })
+
+  it('marks a 409 as a duplicate, not a failure', async () => {
+    mocked.uploadPcap.mockRejectedValue(httpError(409, { existingFileId: 'existing-1' }))
+
+    const { result } = renderHook(() => useFileUpload())
+    await act(async () => { await result.current.uploadFiles([pcap('dup.pcap')]) })
+
+    // Re-uploading a capture is a normal thing to do. Showing it as an error would send the
+    // analyst looking for a problem instead of to the file they already have.
+    expect(result.current.uploads[0]).toMatchObject({
+      isDuplicate: true,
+      duplicateOfFileId: 'existing-1',
+    })
+    // No error key at all — the duplicate branch never sets one, which is what keeps the entry
+    // out of the failure styling.
+    expect(result.current.uploads[0].error).toBeUndefined()
+  })
+
+  it('treats a 409 without an existing id as a plain error', async () => {
+    mocked.uploadPcap.mockRejectedValue(httpError(409, { message: 'conflict' }))
+
+    const { result } = renderHook(() => useFileUpload())
+    await act(async () => { await result.current.uploadFiles([pcap('x.pcap')]) })
+
+    // The duplicate affordance needs the id to link to; without one there is nothing to offer.
+    expect(result.current.uploads[0].isDuplicate).toBeUndefined()
+    expect(result.current.uploads[0].error).toBe('conflict')
+  })
+
+  it('prefers the backend message when an upload fails', async () => {
+    mocked.uploadPcap.mockRejectedValue(httpError(422, { message: 'Not a valid pcap' }))
+
+    const { result } = renderHook(() => useFileUpload())
+    await act(async () => { await result.current.uploadFiles([pcap('bad.pcap')]) })
+
+    // The backend knows why it rejected the file; "Upload failed" would discard that.
+    expect(result.current.uploads[0].error).toBe('Not a valid pcap')
+  })
+
+  it('falls back to a readable message when the failure carries none', async () => {
+    mocked.uploadPcap.mockRejectedValue({})
+
+    const { result } = renderHook(() => useFileUpload())
+    await act(async () => { await result.current.uploadFiles([pcap('bad.pcap')]) })
+
+    expect(result.current.uploads[0].error).toBe('Upload failed')
+  })
+
+  it('keeps going after one file fails', async () => {
+    mocked.uploadPcap
+      .mockRejectedValueOnce(httpError(422, { message: 'bad' }))
+      .mockResolvedValueOnce({ fileId: 'f2' } as never)
+
+    const { result } = renderHook(() => useFileUpload())
+    await act(async () => {
+      await result.current.uploadFiles([pcap('bad.pcap'), pcap('good.pcap')])
+    })
+
+    // One malformed capture in a drag-and-drop of twenty must not abandon the other nineteen.
+    expect(result.current.uploads[0].error).toBe('bad')
+    expect(result.current.uploads[1].fileId).toBe('f2')
+  })
+
+  it('reports progress from the service onto the matching entry', async () => {
+    mocked.uploadPcap.mockImplementation(async (_f, onProgress) => {
+      onProgress?.(42)
+      return { fileId: 'f1' } as never
+    })
+
+    const { result } = renderHook(() => useFileUpload())
+    const done = act(async () => { await result.current.uploadFiles([pcap('a.pcap')]) })
+    await done
+
+    await waitFor(() => expect(result.current.uploads[0].progress).toBe(100))
+  })
+
+  it('exposes isUploading only while work is outstanding', async () => {
+    mocked.uploadPcap.mockResolvedValue({ fileId: 'f1' } as never)
+
+    const { result } = renderHook(() => useFileUpload())
+    expect(result.current.isUploading).toBe(false)
+
+    await act(async () => { await result.current.uploadFiles([pcap('a.pcap')]) })
+
+    expect(result.current.isUploading).toBe(false)
+  })
+
+  it('clears the list on request', async () => {
+    mocked.uploadPcap.mockResolvedValue({ fileId: 'f1' } as never)
+
+    const { result } = renderHook(() => useFileUpload())
+    await act(async () => { await result.current.uploadFiles([pcap('a.pcap')]) })
+    expect(result.current.uploads).toHaveLength(1)
+
+    act(() => result.current.clearUploads())
+
+    expect(result.current.uploads).toEqual([])
+  })
+})

--- a/frontend/src/pages/Monitor/hooks/__tests__/useChangeEventFilters.test.tsx
+++ b/frontend/src/pages/Monitor/hooks/__tests__/useChangeEventFilters.test.tsx
@@ -88,16 +88,22 @@ describe('useChangeEventFilters', () => {
     expect(result.current.eventPage).toBe(1)
   })
 
-  it('clamps the page down when the list shrinks beneath it', () => {
-    const events = [...many(25, { severity: 'INFO' }), ...many(3, { severity: 'CRITICAL' })]
-    const { result } = renderHook(() => useChangeEventFilters(events))
+  it('clamps the page down when the event list itself shrinks', () => {
+    const { result, rerender } = renderHook(({ events }) => useChangeEventFilters(events), {
+      initialProps: { events: many(25) },
+    })
 
     act(() => result.current.setEventPage(3))
-    act(() => result.current.selectSeverity('CRITICAL'))
+    expect(result.current.eventPage).toBe(3)
 
-    // selectSeverity already resets to 1, so the clamp effect is what protects a page set
-    // directly — e.g. restored from a link — against a list that cannot reach it.
-    expect(result.current.eventPage).toBeLessThanOrEqual(result.current.totalEventPages)
+    // Shrink the input rather than changing a filter. selectSeverity resets the page to 1 on
+    // its own, so routing through it would pass even with the clamp effect deleted — the
+    // reset would do the work and the effect would never be exercised.
+    rerender({ events: many(5) })
+
+    // Page 3 of a one-page list renders nothing at all.
+    expect(result.current.totalEventPages).toBe(1)
+    expect(result.current.eventPage).toBe(1)
   })
 
   it('reports at least one page even with nothing to show', () => {

--- a/frontend/src/pages/Monitor/hooks/__tests__/useChangeEventFilters.test.tsx
+++ b/frontend/src/pages/Monitor/hooks/__tests__/useChangeEventFilters.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Change events are what monitor mode exists to surface: what altered between two snapshots of
+ * a network. This hook decides which of them an operator actually sees, so its defaults and its
+ * paging are the difference between noticing a change and not.
+ */
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { ChangeEvent } from '@/features/monitor/types/monitor.types'
+import { useChangeEventFilters } from '../useChangeEventFilters'
+
+function event(overrides: Partial<ChangeEvent> = {}): ChangeEvent {
+  return {
+    id: Math.random().toString(36).slice(2),
+    changeType: 'MAC_ADDED',
+    severity: 'INFO',
+    reviewed: false,
+    ...overrides,
+  } as ChangeEvent
+}
+
+/** n events sharing the given shape, for exercising pagination. */
+function many(n: number, overrides: Partial<ChangeEvent> = {}) {
+  return Array.from({ length: n }, () => event(overrides))
+}
+
+describe('useChangeEventFilters', () => {
+  it('defaults to showing only unreviewed events', () => {
+    const events = [event({ reviewed: true }), event({ reviewed: false })]
+
+    const { result } = renderHook(() => useChangeEventFilters(events))
+
+    // An opinionated default: monitor mode is a triage queue, so already-reviewed events are
+    // hidden until asked for. Defaulting to ALL would bury new changes under old ones.
+    expect(result.current.reviewedFilter).toBe('UNREVIEWED')
+    expect(result.current.filteredEvents).toHaveLength(1)
+  })
+
+  it('filters by severity', () => {
+    const events = [event({ severity: 'CRITICAL' }), event({ severity: 'INFO' })]
+    const { result } = renderHook(() => useChangeEventFilters(events))
+
+    act(() => result.current.selectSeverity('CRITICAL'))
+
+    expect(result.current.filteredEvents).toHaveLength(1)
+    expect(result.current.filteredEvents[0].severity).toBe('CRITICAL')
+  })
+
+  it('filters by change type', () => {
+    const events = [event({ changeType: 'MAC_ADDED' }), event({ changeType: 'ASN_CHANGE' })]
+    const { result } = renderHook(() => useChangeEventFilters(events))
+
+    act(() => result.current.selectChangeType('ASN_CHANGE'))
+
+    expect(result.current.filteredEvents).toHaveLength(1)
+  })
+
+  it('offers ALL plus each change type present in the data, without duplicates', () => {
+    const events = [
+      event({ changeType: 'MAC_ADDED' }),
+      event({ changeType: 'MAC_ADDED' }),
+      event({ changeType: 'ASN_CHANGE' }),
+    ]
+
+    const { result } = renderHook(() => useChangeEventFilters(events))
+
+    // Derived from the data rather than a fixed list, so a change type the backend adds shows
+    // up without a frontend release.
+    expect(result.current.changeTypes).toEqual(['ALL', 'MAC_ADDED', 'ASN_CHANGE'])
+  })
+
+  it('pages the filtered list ten at a time', () => {
+    const { result } = renderHook(() => useChangeEventFilters(many(25)))
+
+    expect(result.current.pagedEvents).toHaveLength(10)
+    expect(result.current.totalEventPages).toBe(3)
+  })
+
+  it('returns to page 1 when a filter changes', () => {
+    const { result } = renderHook(() => useChangeEventFilters(many(25)))
+
+    act(() => result.current.setEventPage(3))
+    expect(result.current.eventPage).toBe(3)
+
+    act(() => result.current.selectSeverity('INFO'))
+
+    // Staying on page 3 of a newly narrowed list usually shows an empty table.
+    expect(result.current.eventPage).toBe(1)
+  })
+
+  it('clamps the page down when the list shrinks beneath it', () => {
+    const events = [...many(25, { severity: 'INFO' }), ...many(3, { severity: 'CRITICAL' })]
+    const { result } = renderHook(() => useChangeEventFilters(events))
+
+    act(() => result.current.setEventPage(3))
+    act(() => result.current.selectSeverity('CRITICAL'))
+
+    // selectSeverity already resets to 1, so the clamp effect is what protects a page set
+    // directly — e.g. restored from a link — against a list that cannot reach it.
+    expect(result.current.eventPage).toBeLessThanOrEqual(result.current.totalEventPages)
+  })
+
+  it('reports at least one page even with nothing to show', () => {
+    const { result } = renderHook(() => useChangeEventFilters([]))
+
+    // Math.max(1, ...) — a zero page count would render "Page 1 of 0".
+    expect(result.current.totalEventPages).toBe(1)
+    expect(result.current.pagedEvents).toEqual([])
+  })
+})

--- a/frontend/src/pages/Monitor/hooks/__tests__/useNetworkDetailData.test.tsx
+++ b/frontend/src/pages/Monitor/hooks/__tests__/useNetworkDetailData.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * The monitor detail page loads eight endpoints and then polls them. The property that matters
+ * most is the one you only notice when it is wrong: a background refresh must not raise the
+ * loading flag, or the page blanks itself every thirty seconds while an operator is reading it.
+ */
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { monitorService } from '@/features/monitor/services/monitorService'
+import { insightsService } from '@/features/insights/services/insightsService'
+import { subnetService } from '@/features/subnets/services/subnetService'
+import { useNetworkDetailData } from '../useNetworkDetailData'
+
+vi.mock('@/features/monitor/services/monitorService', () => ({
+  monitorService: {
+    getNetwork: vi.fn(),
+    listSnapshots: vi.fn(),
+    listChanges: vi.fn(),
+    listDefinitions: vi.fn(),
+    addSnapshot: vi.fn(),
+    removeSnapshot: vi.fn(),
+  },
+}))
+vi.mock('@/features/insights/services/insightsService', () => ({
+  insightsService: {
+    listExternalEvents: vi.fn(),
+    listAnnotations: vi.fn(),
+    getLatestInsight: vi.fn(),
+  },
+}))
+vi.mock('@/features/subnets/services/subnetService', () => ({
+  subnetService: { list: vi.fn() },
+}))
+
+const monitor = vi.mocked(monitorService)
+const insights = vi.mocked(insightsService)
+const subnets = vi.mocked(subnetService)
+
+const NET = 'net-1'
+
+function serveAll() {
+  monitor.getNetwork.mockResolvedValue({ id: NET, name: 'HQ' } as never)
+  monitor.listSnapshots.mockResolvedValue([] as never)
+  monitor.listChanges.mockResolvedValue([] as never)
+  monitor.listDefinitions.mockResolvedValue([] as never)
+  insights.listExternalEvents.mockResolvedValue([] as never)
+  insights.listAnnotations.mockResolvedValue([] as never)
+  insights.getLatestInsight.mockResolvedValue(null as never)
+  subnets.list.mockResolvedValue([] as never)
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetAllMocks()
+})
+
+describe('useNetworkDetailData', () => {
+  it('loads the network on mount', async () => {
+    serveAll()
+
+    const { result } = renderHook(() => useNetworkDetailData(NET))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.network).toMatchObject({ id: NET })
+    expect(result.current.lastUpdated).toBeInstanceOf(Date)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('does not raise the loading flag on a background poll', async () => {
+    serveAll()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const { result } = renderHook(() => useNetworkDetailData(NET))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const firstLoad = monitor.getNetwork.mock.calls.length
+
+    // Hold the poll's first request open. Asserting after the poll settles proves nothing —
+    // loadAll(true) would set loading and clear it again before the assertion ran, so an
+    // earlier version of this test passed even with the spinner reinstated.
+    let releasePoll: () => void = () => {}
+    monitor.getNetwork.mockImplementationOnce(
+      () => new Promise(res => { releasePoll = () => res({ id: NET, name: 'HQ' } as never) })
+    )
+
+    await vi.advanceTimersByTimeAsync(30000)
+    await waitFor(() => expect(monitor.getNetwork.mock.calls.length).toBeGreaterThan(firstLoad))
+
+    // Mid-poll: if the interval used loadAll(true), the whole page would swap to a spinner
+    // every thirty seconds under an operator who is mid-read.
+    expect(result.current.loading).toBe(false)
+
+    releasePoll()
+  })
+
+  it('stops polling when the interval is set to zero', async () => {
+    serveAll()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const { result } = renderHook(() => useNetworkDetailData(NET))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    result.current.setPollInterval(0)
+    await waitFor(() => expect(result.current.pollInterval).toBe(0))
+    const afterDisable = monitor.getNetwork.mock.calls.length
+
+    await vi.advanceTimersByTimeAsync(120000)
+
+    expect(monitor.getNetwork.mock.calls.length).toBe(afterDisable)
+
+    // Caveat, stated rather than glossed: removing the `pollInterval === 0` guard does make
+    // this file fail, but by destabilising the run rather than by failing this assertion —
+    // setInterval(fn, 0) busy-loops. Spying on setInterval instead does not work either,
+    // because waitFor uses it internally. So the guard is covered, but the diagnosis on
+    // regression will be "this file died", not "polling was not disabled".
+  })
+
+  it('stops polling on unmount', async () => {
+    serveAll()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    const { result, unmount } = renderHook(() => useNetworkDetailData(NET))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    unmount()
+    const afterUnmount = monitor.getNetwork.mock.calls.length
+    await vi.advanceTimersByTimeAsync(90000)
+
+    expect(monitor.getNetwork.mock.calls.length).toBe(afterUnmount)
+  })
+
+  it('reports a load failure without leaving the spinner up', async () => {
+    serveAll()
+    monitor.getNetwork.mockRejectedValue(new Error('backend down'))
+
+    const { result } = renderHook(() => useNetworkDetailData(NET))
+
+    await waitFor(() => expect(result.current.error).toBe('Failed to load network data.'))
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('refreshes after adding a snapshot', async () => {
+    serveAll()
+    monitor.addSnapshot.mockResolvedValue({ id: 's1' } as never)
+
+    const { result } = renderHook(() => useNetworkDetailData(NET))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const before = monitor.listSnapshots.mock.calls.length
+
+    await result.current.handleAddSnapshot('file-1')
+
+    // A snapshot changes every panel on the page — change events, insights, definitions — so
+    // the reload is a full one rather than a local append.
+    expect(monitor.addSnapshot).toHaveBeenCalledWith(NET, 'file-1', undefined)
+    expect(monitor.listSnapshots.mock.calls.length).toBeGreaterThan(before)
+  })
+
+  it('patches a single snapshot in place without refetching', async () => {
+    serveAll()
+    monitor.listSnapshots.mockResolvedValue([
+      { id: 's1', label: 'old' },
+      { id: 's2', label: 'other' },
+    ] as never)
+
+    const { result } = renderHook(() => useNetworkDetailData(NET))
+    await waitFor(() => expect(result.current.snapshots).toHaveLength(2))
+    const before = monitor.listSnapshots.mock.calls.length
+
+    result.current.handleSnapshotUpdated({ id: 's1', label: 'renamed' } as never)
+
+    // Renaming a snapshot is a local edit; a full reload would discard scroll position and
+    // re-run eight requests for a label change.
+    await waitFor(() =>
+      expect(result.current.snapshots.find(s => s.id === 's1')).toMatchObject({ label: 'renamed' })
+    )
+    expect(result.current.snapshots.find(s => s.id === 's2')).toMatchObject({ label: 'other' })
+    expect(monitor.listSnapshots.mock.calls.length).toBe(before)
+  })
+
+  it('does nothing without a network id', async () => {
+    serveAll()
+
+    const { result } = renderHook(() => useNetworkDetailData(''))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(monitor.getNetwork).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/utils/__tests__/useClickOutside.test.tsx
+++ b/frontend/src/utils/__tests__/useClickOutside.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Every popup, filter panel and menu in the app closes through this hook. The interesting part
+ * is not that it fires — it is that it stops firing on unmount. A leaked document listener
+ * keeps a closed panel's `onClose` alive, so a later click elsewhere calls into a component
+ * that is gone.
+ */
+import { renderHook } from '@testing-library/react'
+import { useRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useClickOutside } from '../useClickOutside'
+
+/** Renders the hook against a real element attached to the document. */
+function renderWithElement(onClose: () => void) {
+  const el = document.createElement('div')
+  const child = document.createElement('button')
+  el.appendChild(child)
+  document.body.appendChild(el)
+
+  const view = renderHook(() => {
+    const ref = useRef<HTMLElement | null>(el)
+    useClickOutside(ref, onClose)
+  })
+
+  return { el, child, ...view }
+}
+
+function mousedownOn(target: Node) {
+  target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+}
+
+describe('useClickOutside', () => {
+  it('closes when the click lands outside the element', () => {
+    const onClose = vi.fn()
+    renderWithElement(onClose)
+
+    mousedownOn(document.body)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close when the click lands inside', () => {
+    const onClose = vi.fn()
+    const { el } = renderWithElement(onClose)
+
+    mousedownOn(el)
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not close when the click lands on a descendant', () => {
+    const onClose = vi.fn()
+    const { child } = renderWithElement(onClose)
+
+    // `contains` covers the subtree, which is what makes a panel with buttons inside usable —
+    // a strict identity check would close the panel on its own controls.
+    mousedownOn(child)
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('stops listening once unmounted', () => {
+    const onClose = vi.fn()
+    const { unmount } = renderWithElement(onClose)
+
+    unmount()
+    mousedownOn(document.body)
+
+    // The cleanup is the whole reason this is a hook rather than an inline effect. Without it
+    // every opened panel leaves a listener behind for the life of the page.
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('uses mousedown, not click', () => {
+    const onClose = vi.fn()
+    renderWithElement(onClose)
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    // mousedown fires before a button's own click handler, so a panel closes before the click
+    // reaches whatever is underneath. Switching to `click` reverses that ordering.
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/utils/__tests__/useResolvedDark.test.tsx
+++ b/frontend/src/utils/__tests__/useResolvedDark.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Anything that picks theme-aware colours in JS rather than CSS reads this hook — notably the
+ * network graph, which paints nodes and edges on a canvas the stylesheet cannot reach. Resolve
+ * it wrong and the graph is drawn in light colours on a dark page.
+ */
+import { renderHook, act } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useStore } from '@/store'
+import { useResolvedDark } from '../useResolvedDark'
+
+/** jsdom has no matchMedia, so stand one up whose value and listeners we control. */
+function stubMatchMedia(initialDark: boolean) {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>()
+  let matches = initialDark
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => listeners.add(cb),
+      removeEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => listeners.delete(cb),
+    }))
+  )
+
+  return {
+    listenerCount: () => listeners.size,
+    /** Simulates the OS theme flipping while the app is open. */
+    emit(nowDark: boolean) {
+      matches = nowDark
+      listeners.forEach(cb => cb({ matches: nowDark } as MediaQueryListEvent))
+    },
+  }
+}
+
+function setThemeMode(mode: 'light' | 'dark' | 'system') {
+  act(() => {
+    useStore.setState({ themeMode: mode } as Partial<ReturnType<typeof useStore.getState>>)
+  })
+}
+
+describe('useResolvedDark', () => {
+  beforeEach(() => setThemeMode('system'))
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns false when the user has chosen light, whatever the OS says', () => {
+    stubMatchMedia(true)
+    setThemeMode('light')
+
+    const { result } = renderHook(() => useResolvedDark())
+
+    // An explicit choice must win: following the OS here would override the user.
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true when the user has chosen dark, whatever the OS says', () => {
+    stubMatchMedia(false)
+    setThemeMode('dark')
+
+    const { result } = renderHook(() => useResolvedDark())
+
+    expect(result.current).toBe(true)
+  })
+
+  it.each([true, false])('follows the OS in system mode (dark=%s)', osDark => {
+    stubMatchMedia(osDark)
+    setThemeMode('system')
+
+    const { result } = renderHook(() => useResolvedDark())
+
+    expect(result.current).toBe(osDark)
+  })
+
+  it('re-renders when the OS theme flips while in system mode', () => {
+    const mq = stubMatchMedia(false)
+    setThemeMode('system')
+
+    const { result } = renderHook(() => useResolvedDark())
+    expect(result.current).toBe(false)
+
+    act(() => mq.emit(true))
+
+    // The point of subscribing at all: a static read would leave the graph in the old palette
+    // until the next navigation.
+    expect(result.current).toBe(true)
+  })
+
+  it('does not subscribe when the theme is pinned', () => {
+    const mq = stubMatchMedia(false)
+    setThemeMode('dark')
+
+    renderHook(() => useResolvedDark())
+
+    // No listener is needed when the answer cannot change, and adding one would re-render
+    // every consumer on an OS flip that must not affect them.
+    expect(mq.listenerCount()).toBe(0)
+  })
+
+  it('unsubscribes on unmount', () => {
+    const mq = stubMatchMedia(false)
+    setThemeMode('system')
+
+    const { unmount } = renderHook(() => useResolvedDark())
+    expect(mq.listenerCount()).toBe(1)
+
+    unmount()
+
+    expect(mq.listenerCount()).toBe(0)
+  })
+})


### PR DESCRIPTION
Completes **Phase 3** of #659 — the frontend test harness — and with it the last open phase of the epic.

Collected on `epic/659-phase3` rather than landing slice-by-slice on `main`, as requested.

## What this adds

**22 of 22 API services · 14 of 14 hooks · 10 of 10 components.**

Frontend goes from **246 tests across 9 files** to **596 across 53**. Every service now runs against MSW at the network layer, so the real `apiClient` — including its auth and 401 interceptors — is exercised rather than replaced by a stub.

## Bugs and inconsistencies found, pinned rather than fixed

Each is recorded by a passing test, so a fix produces a visible diff instead of a silent behaviour change:

| Finding | Where |
|---|---|
| A `204` never reaches the catch — axios resolves 2xx, so callers get `''` where `null` is declared | `adjudicationService` |
| `getNote` collapses **every** error to `null`, so an outage reads as "no note recorded" | `entityNotesService` |
| Polling interval created *after* the first poll is awaited, so every completed analysis costs one redundant fetch | `useAnalysisData` |
| `role="status"` and `aria-hidden="true"` set together — the spinner announces nothing to a screen reader | `Spinner` |
| Risk contributes at most 0.3 against traffic's 0.5, so a flagged host with low traffic is still hidden | `selectSignificantNodes` |
| `timeRange?.[0] \|\| Date.now()` treats a legitimate epoch-0 timestamp as missing | `analysisService` |

The "no record exists" family is now visible across three services: `getOverride` and `getNodeRole` rethrow real errors, `getNote` does not. Two of three are right, which makes the third the outlier rather than a defensible convention.

## Every assertion proven by mutation

Roughly 90 mutations across these commits — each test was watched failing before being trusted. **Five of my own assertions turned out vacuous and were fixed**, all sharing one shape: asserting something already true.

- `Exact<A,B>` resolving to `never`, which satisfies `T extends true`
- A `data` assertion comparing the backend array with itself
- `rejects.toThrow()` passing because MSW had no handler, not because validation rejected
- `loading` asserted *after* an async poll settled, so the flag was never observable
- A button checked by role, present whether or not the state reverted

Two fixtures also drifted behind `as` casts — inventing `NEW_HOST`/`NEW_PORT` change types and `totalPackets`/`roleLabel` fields that do not exist. `typecheck:test` caught both; vitest could not, because nothing constrains a string literal at runtime.

One flaky test was caught and fixed before commit: a sequential assertion racing a rejection that was still settling, failing about one run in five.

## Verification

Every gate checked by **captured exit code**, after an early `| tail && echo OK` reported success for a failing `tsc`:

- `npm run test` — 596 passed, run repeatedly for flakes
- `npx tsc --noEmit`, `npm run typecheck:test`, `npm run lint:contract` — all clean
- Full lint unchanged at its 61 pre-existing errors

## Where #659 stands after this

Phases 0, 1, 2, 4 and 5 already merged to `main`. This closes Phase 3.

Follow-ups remain tracked separately: #694 (three incompatible definitions of "private IP"), #701 (backend coverage 4 points lower in CI than locally), and the per-type migration of `src/types/` onto the generated schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for alerts, modals, pagination, uploads, network visualizations, monitoring, stories, and data tables.
  * Added validation for loading states, filtering, sorting, pagination, error handling, retries, stale responses, and asynchronous updates.
  * Improved coverage of note history, role suggestions, subnet management, analysis polling, tracing, and service interactions.
  * Added regression checks for accessibility attributes, dark-mode behavior, click handling, badges, and upload progress states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->