### PR TITLE
fix: make the capture bucket private (#637)

### DIFF
--- a/.github/workflows/minio-policy.yml
+++ b/.github/workflows/minio-policy.yml
@@ -1,0 +1,39 @@
+name: MinIO Bucket Policy
+
+# Catches a compose file making the capture bucket anonymously readable. Raw PCAPs are the most
+# sensitive artefact the system holds — credentials from cleartext protocols, session tokens,
+# internal topology — and they were downloadable with no credentials at all (#637). Object names
+# being UUIDs is obscurity, not access control: the bucket was listable, so they were enumerable
+# in one request.
+#
+# Static, so it runs in seconds without standing up a stack. It asserts the declaration; the live
+# policy is exercised by the system tests against a real MinIO.
+
+on:
+  pull_request:
+    paths:
+      - 'docker-compose*.yml'
+      - 'scripts/check_minio_policy.py'
+      - '.github/workflows/minio-policy.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker-compose*.yml'
+      - 'scripts/check_minio_policy.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Capture bucket is private
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check no compose file grants anonymous access
+        run: python3 scripts/check_minio_policy.py

--- a/.github/workflows/minio-policy.yml
+++ b/.github/workflows/minio-policy.yml
@@ -33,7 +33,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        # Pinned to a commit and without a persisted token: this job reads compose files and
+        # needs no credentials, so leaving one in .git/config only widens what a compromised
+        # action could reach.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Check no compose file grants anonymous access
         run: python3 scripts/check_minio_policy.py

--- a/docker-compose.offline.yml
+++ b/docker-compose.offline.yml
@@ -65,8 +65,10 @@ services:
       TZ: Asia/Singapore
     ports:
       # 9000 (the S3 API) is deliberately NOT published. The backend reaches MinIO over the
-      # compose network, so a host mapping only widens who can reach object storage. Publish it
-      # locally with `docker compose port` or an override file if you need mc/s3 tooling (#637).
+      # compose network, so a host mapping only widens who can reach object storage. If you need
+      # mc/s3 tooling against it locally, add a compose override binding to loopback only:
+      #   services: {minio: {ports: ["127.0.0.1:9000:9000"]}}
+      # `docker compose port` only reports an existing binding; it cannot create one (#637).
       - "9001:9001"  # Console
     volumes:
       - minio_data:/data

--- a/docker-compose.offline.yml
+++ b/docker-compose.offline.yml
@@ -64,7 +64,9 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       TZ: Asia/Singapore
     ports:
-      - "9000:9000"  # API
+      # 9000 (the S3 API) is deliberately NOT published. The backend reaches MinIO over the
+      # compose network, so a host mapping only widens who can reach object storage. Publish it
+      # locally with `docker compose port` or an override file if you need mc/s3 tooling (#637).
       - "9001:9001"  # Console
     volumes:
       - minio_data:/data
@@ -95,12 +97,19 @@ services:
       # `$$VAR` escapes the `$` so the container's shell does the expansion, not Compose.
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    # `entrypoint` below is a FOLDED block (`>`): every newline becomes a space, so the whole
+    # thing runs as one `sh -c` line. A `#` comment inside it would therefore swallow the rest of
+    # the command — do not put comments in there.
+    #
+    # `mc anonymous set none` rather than deleting the old `set public` line: `none` also revokes
+    # an existing anonymous policy, so redeploying over a stack created before this change closes
+    # the hole. Deleting the line would leave an already-public bucket public (#637).
     entrypoint: >
       /bin/sh -c "
       sleep 5;
       /usr/bin/mc alias set myminio http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\";
       /usr/bin/mc mb myminio/tracepcap-files --ignore-existing;
-      /usr/bin/mc anonymous set public myminio/tracepcap-files;
+      /usr/bin/mc anonymous set none myminio/tracepcap-files;
       exit 0;
       "
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,9 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       TZ: Asia/Singapore
     ports:
-      - "9000:9000"  # API
+      # 9000 (the S3 API) is deliberately NOT published. The backend reaches MinIO over the
+      # compose network, so a host mapping only widens who can reach object storage. Publish it
+      # locally with `docker compose port` or an override file if you need mc/s3 tooling (#637).
       - "9001:9001"  # Console
     volumes:
       - minio_data:/data
@@ -93,12 +95,19 @@ services:
       # `$$VAR` escapes the `$` so the container's shell does the expansion, not Compose.
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    # `entrypoint` below is a FOLDED block (`>`): every newline becomes a space, so the whole
+    # thing runs as one `sh -c` line. A `#` comment inside it would therefore swallow the rest of
+    # the command — do not put comments in there.
+    #
+    # `mc anonymous set none` rather than deleting the old `set public` line: `none` also revokes
+    # an existing anonymous policy, so redeploying over a stack created before this change closes
+    # the hole. Deleting the line would leave an already-public bucket public (#637).
     entrypoint: >
       /bin/sh -c "
       sleep 5;
       /usr/bin/mc alias set myminio http://minio:9000 \"$$MINIO_ROOT_USER\" \"$$MINIO_ROOT_PASSWORD\";
       /usr/bin/mc mb myminio/tracepcap-files --ignore-existing;
-      /usr/bin/mc anonymous set public myminio/tracepcap-files;
+      /usr/bin/mc anonymous set none myminio/tracepcap-files;
       exit 0;
       "
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,10 @@ services:
       TZ: Asia/Singapore
     ports:
       # 9000 (the S3 API) is deliberately NOT published. The backend reaches MinIO over the
-      # compose network, so a host mapping only widens who can reach object storage. Publish it
-      # locally with `docker compose port` or an override file if you need mc/s3 tooling (#637).
+      # compose network, so a host mapping only widens who can reach object storage. If you need
+      # mc/s3 tooling against it locally, add a compose override binding to loopback only:
+      #   services: {minio: {ports: ["127.0.0.1:9000:9000"]}}
+      # `docker compose port` only reports an existing binding; it cannot create one (#637).
       - "9001:9001"  # Console
     volumes:
       - minio_data:/data

--- a/scripts/check_minio_policy.py
+++ b/scripts/check_minio_policy.py
@@ -16,11 +16,16 @@ import sys
 REPO = pathlib.Path(__file__).resolve().parent.parent
 COMPOSE = sorted(REPO.glob("docker-compose*.yml"))
 
-# `mc anonymous set <policy>` — anything other than `none` grants some anonymous access.
-ANON = re.compile(r"mc\s+anonymous\s+set\s+(\w+)")
-# Publishing the S3 API on the host widens who can reach object storage; the backend uses the
-# compose network. The console (9001) is fine.
-PORT_9000 = re.compile(r'^\s*-\s*"9000:9000"')
+# Any mc subcommand that can grant anonymous access, not just the one this repo used. `policy
+# set` is the older spelling and `anonymous set-json` takes a policy document — a guard that only
+# knew `anonymous set` would wave both through, which is the failure mode it exists to prevent.
+ANON = re.compile(r"mc\s+(?:anonymous|policy)\s+set(?:-json)?\s+(\S+)")
+ANON_SAFE = {"none"}
+
+# Any published mapping whose *target* is 9000, in either short or long syntax. Matching the
+# literal "9000:9000" would miss "127.0.0.1:9000:9000", "9000:9000/tcp" and the long form.
+PORT_SHORT = re.compile(r'^\s*-\s*["\']?(?:[\d.]+:)?(\d+):9000(?:/\w+)?["\']?\s*$')
+PORT_LONG_TARGET = re.compile(r'^\s*target:\s*9000\s*$')
 
 failures = []
 
@@ -30,13 +35,13 @@ for path in COMPOSE:
         if line.lstrip().startswith("#"):
             continue
         m = ANON.search(line)
-        if m and m.group(1) != "none":
+        if m and m.group(1) not in ANON_SAFE:
             failures.append(
                 f"{path.name}:{lineno} grants anonymous '{m.group(1)}' on the capture bucket."
                 f"\n    Use `mc anonymous set none` — it also revokes a policy set by an earlier"
                 f"\n    deploy, which simply deleting the line would not."
             )
-        if PORT_9000.match(line):
+        if PORT_SHORT.match(line) or PORT_LONG_TARGET.match(line):
             failures.append(
                 f"{path.name}:{lineno} publishes the MinIO S3 API on the host."
                 f"\n    The backend reaches MinIO over the compose network; a host mapping only"

--- a/scripts/check_minio_policy.py
+++ b/scripts/check_minio_policy.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Fail if any compose file makes the capture bucket anonymously readable.
+
+Raw PCAPs are the most sensitive artefact the system holds: they carry credentials from
+cleartext protocols, session tokens and internal topology. `mc anonymous set public` put them
+behind no authentication at all (#637), and object names being UUIDs is obscurity rather than
+access control — the bucket was listable, so the UUIDs were enumerable in one request.
+
+Static, so it runs in CI without standing up a stack. It checks the declaration rather than a
+live bucket; the live policy is asserted once by the system test.
+"""
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+COMPOSE = sorted(REPO.glob("docker-compose*.yml"))
+
+# `mc anonymous set <policy>` — anything other than `none` grants some anonymous access.
+ANON = re.compile(r"mc\s+anonymous\s+set\s+(\w+)")
+# Publishing the S3 API on the host widens who can reach object storage; the backend uses the
+# compose network. The console (9001) is fine.
+PORT_9000 = re.compile(r'^\s*-\s*"9000:9000"')
+
+failures = []
+
+for path in COMPOSE:
+    text = path.read_text()
+    for lineno, line in enumerate(text.splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        m = ANON.search(line)
+        if m and m.group(1) != "none":
+            failures.append(
+                f"{path.name}:{lineno} grants anonymous '{m.group(1)}' on the capture bucket."
+                f"\n    Use `mc anonymous set none` — it also revokes a policy set by an earlier"
+                f"\n    deploy, which simply deleting the line would not."
+            )
+        if PORT_9000.match(line):
+            failures.append(
+                f"{path.name}:{lineno} publishes the MinIO S3 API on the host."
+                f"\n    The backend reaches MinIO over the compose network; a host mapping only"
+                f"\n    widens who can reach object storage. Publish 9001 (console) instead."
+            )
+
+if failures:
+    print("FAIL — object storage would be reachable without credentials:\n")
+    for f in failures:
+        print(f"  {f}\n")
+    print("See #637. Captures must not be downloadable without authenticating.")
+    sys.exit(1)
+
+print(f"OK — {len(COMPOSE)} compose file(s): bucket is private, S3 API not published.")


### PR DESCRIPTION
Closes #637.

Raw PCAPs were downloadable **with no credentials**. They carry credentials from cleartext protocols, session tokens and internal topology, and the bucket was listable — so the UUID object names were enumerable in one request. Obscurity, not access control.

## The fix

**`mc anonymous set none`, not deleting the `set public` line.** `none` *revokes* an existing policy, so redeploying over a stack created before this change actually closes the hole. Deleting the line would leave an already-public bucket public — the failure mode that matters for every deployment already out there.

**Stops publishing 9000 on the host.** The backend reaches MinIO over the compose network, so the mapping only widened who could reach object storage. The console (9001) is unchanged.

`getPresignedUrl` exists on `StorageService` but has no callers, so nothing depended on public or presigned object URLs.

## A first attempt looked correct and changed nothing

Worth recording, because the static check passed while the live bucket stayed public.

`entrypoint: >` is a YAML **folded** block — every newline becomes a space, so the whole thing runs as one `sh -c` line. Explanatory `#` comments placed inside it ended up mid-line and **commented out the rest of the command**, including the `anonymous set none` itself:

```
sh -c " … mc mb …; # Explicitly private, not merely … mc anonymous set none …; exit 0; "
                   ^ everything from here is a comment
```

The comments now sit above the block with a note saying why they cannot go inside it. This is the reason the verification below is against a running stack rather than a diff.

## Verified — the issue's own repro, reversed

```
policy:          Access permission is `private`     (was `public`)
anonymous LIST   HTTP 403                            (was 200)
backend read     HTTP 200, 15,146,916 bytes          (unchanged)
```

The backend still reads and writes objects; it authenticates with the root credentials.

## Regression guard

`scripts/check_minio_policy.py` fails on any compose file that grants anonymous access or publishes 9000, wired into CI on pull requests **and on merge to `main`**. Static, so it runs in seconds without a stack — the live policy is exercised by the system tests. Confirmed it fails when the old policy is reinstated:

```
FAIL — object storage would be reachable without credentials:
  docker-compose.yml:106 grants anonymous 'public' on the capture bucket.
```

## Acceptance criteria

- [x] Bucket is private; anonymous GET/LIST return 403
- [x] Backend still reads and writes objects
- [x] No UI path relied on direct object URLs (`getPresignedUrl` has no callers)
- [x] Port 9000 no longer published
- [x] A check that the policy has not regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * MinIO’s S3 API is no longer exposed to the host; console access remains available.
  * Anonymous bucket access is disabled by default.
* **New Features**
  * Added automated checks to prevent insecure MinIO policies and port exposure in future changes.
  * Security validation runs for relevant pull requests, updates to `main`, and manual requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->