### PR TITLE
fix: evaluate baseline definitions against snapshots (#650)

### DIFF
--- a/backend/src/main/java/com/tracepcap/monitor/entity/NetworkChangeEventEntity.java
+++ b/backend/src/main/java/com/tracepcap/monitor/entity/NetworkChangeEventEntity.java
@@ -92,7 +92,11 @@ public class NetworkChangeEventEntity {
     VPN_DRIFT,
     SECURITY_ALERT_ADDED,
     SECURITY_ALERT_REMOVED,
-    LABEL_STALE
+    LABEL_STALE,
+    /** A baselined entity the operator declared should be present is absent from this snapshot. */
+    BASELINE_MISSING,
+    /** A baselined entity is present but bound to a different value than declared. */
+    BASELINE_MISMATCH
   }
 
   public enum EntityType {

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -183,8 +183,14 @@ public class ChangeDetectionService {
     // absent from every snapshot it is actually in.
     Map<String, HostFacts> byMac = lowerKeys(macMap(toFileId));
     Map<String, String> macToIp = lowerKeys(macToIpMap(toFileId));
-    // An IP is "seen" if any observation binds it, whichever MAC claimed it.
-    Set<String> seenIps = new HashSet<>(macToIp.values());
+    // Every observed IP, not just those from macToIp: that map drops hosts with no MAC, and a
+    // gateway seen by IP alone would otherwise be reported missing from a snapshot it is in.
+    Set<String> seenIps =
+        hostClassificationLookup.hostFacts(toFileId).stream()
+            .map(HostFacts::ip)
+            .filter(ip -> ip != null && !ip.isBlank())
+            .map(String::trim)
+            .collect(Collectors.toCollection(HashSet::new));
 
     List<NetworkChangeEventEntity> events = new ArrayList<>();
     for (BaselineDefinitionEntity def : definitions) {

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -13,12 +13,14 @@ import com.tracepcap.monitor.spi.SnapshotRevalidationHook;
 import com.tracepcap.intelligence.entity.CustomPrivateRangeEntity;
 import com.tracepcap.intelligence.entity.IpClassification;
 import com.tracepcap.intelligence.service.CustomPrivateRangeService;
+import com.tracepcap.monitor.entity.BaselineDefinitionEntity;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.ChangeType;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.EntityType;
 import com.tracepcap.monitor.entity.NetworkChangeEventEntity.Severity;
 import com.tracepcap.monitor.entity.NetworkSnapshotEntity;
 import com.tracepcap.monitor.entity.SnapshotSubnetOverrideEntity;
+import com.tracepcap.monitor.repository.BaselineDefinitionRepository;
 import com.tracepcap.monitor.repository.NetworkChangeEventRepository;
 import com.tracepcap.monitor.repository.NetworkSnapshotRepository;
 import com.tracepcap.monitor.repository.SnapshotSubnetOverrideRepository;
@@ -26,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -55,6 +58,7 @@ public class ChangeDetectionService {
   private final ConversationLookup conversationLookup;
   private final GeoOrgLookup geoOrgLookup;
   private final NetworkChangeEventRepository changeEventRepository;
+  private final BaselineDefinitionRepository baselineDefinitionRepository;
   private final CustomPrivateRangeService customPrivateRangeService;
   private final SnapshotSubnetOverrideRepository snapshotSubnetOverrideRepository;
   private final LabelStalenessCheck labelStalenessCheck;
@@ -79,6 +83,7 @@ public class ChangeDetectionService {
     events.addAll(detectProtocolAppDrift(fromFileId, toFileId, fromSnapshot, toSnapshot));
     events.addAll(detectSecurityDrift(fromFileId, toFileId, fromSnapshot, toSnapshot));
     events.addAll(detectStaleLabels(toFileId, fromSnapshot, toSnapshot));
+    events.addAll(detectBaselineDeviations(toFileId, fromSnapshot, toSnapshot));
 
     // Carry subnet labels forward onto this snapshot (inherited overrides), mirroring node roles.
     subnetOverrideCarryForwardService.carryForward(
@@ -132,6 +137,134 @@ public class ChangeDetectionService {
               Severity.WARNING));
     }
     return events;
+  }
+
+  // ── Signal 7: declared baseline vs observed inventory ───────────────────────
+
+  /**
+   * Compares the snapshot against the operator's declared baseline (#650).
+   *
+   * <p>Every other detector compares snapshot N against N-1, which answers "what changed". This
+   * answers a different question — "does reality match what was declared" — and it is the reason
+   * the baseline panel exists. Until this ran, definitions were stored, displayed back, and never
+   * checked: an operator who baselined a gateway saw no alerts and reasonably read that as
+   * "nothing wrong", when nothing had ever been compared.
+   *
+   * <p>Two cases are emitted, both unambiguous:
+   *
+   * <ul>
+   *   <li><b>Absent</b> — a declared entity does not appear in this snapshot. A baselined gateway
+   *       that stops answering is the case this exists for.
+   *   <li><b>Mismatch</b> — a declared entity is present but bound to a different value. An
+   *       IP↔MAC binding that contradicts the declaration is the highest-signal event here,
+   *       because that is what ARP spoofing looks like.
+   * </ul>
+   *
+   * <p>Deliberately <b>not</b> emitted: "present but not declared". That requires deciding whether
+   * a baseline is an allowlist (undeclared device ⇒ alert) or an expectation list (only absences
+   * and contradictions matter), and the answer may differ per entry type — GATEWAY is naturally
+   * exhaustive, APP is not. Guessing would either flood the review queue on a busy network or
+   * silently permit rogue devices, so it is left to an explicit decision.
+   *
+   * <p>PROTOCOL, APP and VPN_FINGERPRINT declarations are accepted by the UI but not evaluated
+   * here: those are drift signals already covered by detectProtocolAppDrift against the previous
+   * snapshot, and baselining them raises the same allowlist question.
+   */
+  private List<NetworkChangeEventEntity> detectBaselineDeviations(
+      UUID toFileId, NetworkSnapshotEntity fromSnapshot, NetworkSnapshotEntity toSnapshot) {
+
+    UUID networkId = toSnapshot.getNetwork().getId();
+    List<BaselineDefinitionEntity> definitions =
+        baselineDefinitionRepository.findByNetworkIdOrderByCreatedAtAsc(networkId);
+    if (definitions.isEmpty()) return List.of();
+
+    // Lowercase both sides. macMap keys by the raw MAC as captured, and captures and the UI
+    // disagree on MAC casing routinely — comparing them as-is would report a baselined device as
+    // absent from every snapshot it is actually in.
+    Map<String, HostFacts> byMac = lowerKeys(macMap(toFileId));
+    Map<String, String> macToIp = lowerKeys(macToIpMap(toFileId));
+    // An IP is "seen" if any observation binds it, whichever MAC claimed it.
+    Set<String> seenIps = new HashSet<>(macToIp.values());
+
+    List<NetworkChangeEventEntity> events = new ArrayList<>();
+    for (BaselineDefinitionEntity def : definitions) {
+      String key = def.getEntityKey() == null ? "" : def.getEntityKey().trim();
+      if (key.isEmpty()) continue;
+
+      switch (def.getEntryType()) {
+        case DEVICE, IP_MAC_BINDING -> {
+          // Keyed by MAC. Casing varies between captures and the UI, so compare lowercased.
+          String mac = key.toLowerCase();
+          HostFacts observed = byMac.get(mac);
+          if (observed == null) {
+            events.add(
+                baselineEvent(
+                    networkId, fromSnapshot, toSnapshot, ChangeType.BASELINE_MISSING,
+                    EntityType.DEVICE, key, def,
+                    Map.of("expected", orEmpty(def.getEntityValue()))));
+          } else if (contradicts(def.getEntityValue(), macToIp.get(mac))) {
+            events.add(
+                baselineEvent(
+                    networkId, fromSnapshot, toSnapshot, ChangeType.BASELINE_MISMATCH,
+                    EntityType.DEVICE, key, def,
+                    Map.of(
+                        "expected", orEmpty(def.getEntityValue()),
+                        "observed", orEmpty(macToIp.get(mac)))));
+          }
+        }
+        case GATEWAY -> {
+          // Keyed by IP: a declared gateway that no longer answers is the point of baselining it.
+          if (!seenIps.contains(key)) {
+            events.add(
+                baselineEvent(
+                    networkId, fromSnapshot, toSnapshot, ChangeType.BASELINE_MISSING,
+                    // ISP, matching the existing GATEWAY_CHANGE event — a gateway is keyed by
+                    // IP rather than MAC, and this is the type that already carries that shape.
+                    EntityType.ISP, key, def,
+                    Map.of("expected", orEmpty(def.getEntityValue()))));
+          }
+        }
+        default -> {
+          // PROTOCOL / APP / VPN_FINGERPRINT — see the allowlist note above.
+        }
+      }
+    }
+    return events;
+  }
+
+  private static <V> Map<String, V> lowerKeys(Map<String, V> source) {
+    Map<String, V> result = new HashMap<>();
+    source.forEach((k, v) -> result.put(k == null ? null : k.toLowerCase(), v));
+    return result;
+  }
+
+  /** A declared value contradicts the observed one only when both are present and differ. */
+  private static boolean contradicts(String declared, String observed) {
+    if (declared == null || declared.isBlank() || observed == null || observed.isBlank()) {
+      return false; // nothing declared to contradict, or nothing observed to compare against
+    }
+    return !declared.trim().equalsIgnoreCase(observed.trim());
+  }
+
+  private NetworkChangeEventEntity baselineEvent(
+      UUID networkId,
+      NetworkSnapshotEntity fromSnapshot,
+      NetworkSnapshotEntity toSnapshot,
+      ChangeType type,
+      EntityType entityType,
+      String entityKey,
+      BaselineDefinitionEntity def,
+      Map<String, Object> extra) {
+
+    Map<String, Object> newValue = new HashMap<>(extra);
+    newValue.put("entryType", def.getEntryType().name());
+    newValue.put("notes", orEmpty(def.getNotes()));
+    // A contradicted binding is what ARP spoofing looks like; a missing declared entity is a
+    // change worth reviewing but not on its own an attack signature.
+    Severity severity =
+        type == ChangeType.BASELINE_MISMATCH ? Severity.CRITICAL : Severity.WARNING;
+    return buildEvent(
+        networkId, fromSnapshot, toSnapshot, type, entityType, entityKey, null, newValue, severity);
   }
 
   /**

--- a/backend/src/test/java/com/tracepcap/monitor/service/BaselineDeviationDetectionTest.java
+++ b/backend/src/test/java/com/tracepcap/monitor/service/BaselineDeviationDetectionTest.java
@@ -219,6 +219,16 @@ class BaselineDeviationDetectionTest {
   }
 
   @Test
+  void aGatewaySeenByIpAloneIsNotReportedMissing() {
+    // Not every observed host carries a MAC. Deriving "seen" from the MAC-keyed map would
+    // report such a gateway absent from every snapshot it is actually in.
+    declared(def(BaselineEntryType.GATEWAY, "10.0.0.254", "core router"));
+    observed(host("10.0.0.254", null));
+
+    assertThat(detect()).isEmpty();
+  }
+
+  @Test
   void protocolAndAppDeclarations_areNotEvaluatedYet() {
     // Accepted by the UI but deliberately not evaluated: they raise the same allowlist question,
     // and drift against the previous snapshot already covers them.

--- a/backend/src/test/java/com/tracepcap/monitor/service/BaselineDeviationDetectionTest.java
+++ b/backend/src/test/java/com/tracepcap/monitor/service/BaselineDeviationDetectionTest.java
@@ -1,0 +1,257 @@
+package com.tracepcap.monitor.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.tracepcap.analysis.spi.ConversationLookup;
+import com.tracepcap.analysis.spi.GeoOrgLookup;
+import com.tracepcap.analysis.spi.HostClassificationLookup;
+import com.tracepcap.intelligence.service.CustomPrivateRangeService;
+import com.tracepcap.monitor.repository.NetworkChangeEventRepository;
+import com.tracepcap.monitor.repository.NetworkSnapshotRepository;
+import com.tracepcap.monitor.repository.SnapshotSubnetOverrideRepository;
+import com.tracepcap.monitor.spi.LabelStalenessCheck;
+import com.tracepcap.analysis.spi.HostClassificationLookup.HostFacts;
+import com.tracepcap.monitor.entity.BaselineDefinitionEntity;
+import com.tracepcap.monitor.entity.BaselineDefinitionEntity.BaselineEntryType;
+import com.tracepcap.monitor.entity.NetworkChangeEventEntity;
+import com.tracepcap.monitor.entity.NetworkChangeEventEntity.ChangeType;
+import com.tracepcap.monitor.entity.NetworkChangeEventEntity.Severity;
+import com.tracepcap.monitor.entity.NetworkEntity;
+import com.tracepcap.monitor.entity.NetworkSnapshotEntity;
+import com.tracepcap.monitor.repository.BaselineDefinitionRepository;
+import com.tracepcap.file.entity.FileEntity;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Baseline definitions were declared, stored, displayed back, and never evaluated (#650). An
+ * operator who baselined a gateway saw no alerts and reasonably read that as "nothing wrong", when
+ * nothing had ever been compared.
+ *
+ * <p>These cover the two unambiguous verdicts. "Present but not declared" is deliberately absent —
+ * it needs a decision on whether a baseline is an allowlist or an expectation list, which differs
+ * per entry type.
+ */
+class BaselineDeviationDetectionTest {
+
+  private static final UUID NETWORK = UUID.randomUUID();
+  private static final UUID FILE = UUID.randomUUID();
+
+  private final BaselineDefinitionRepository baselines = mock(BaselineDefinitionRepository.class);
+  private final HostClassificationLookup hosts = mock(HostClassificationLookup.class);
+
+  private final ChangeDetectionService service =
+      new ChangeDetectionService(
+          hosts, null, null, null, baselines, null, null, null, null, null, null);
+
+  private static HostFacts host(String ip, String mac) {
+    return new HostFacts(ip, mac, null, null, null, null, null, 0, List.of());
+  }
+
+  private static BaselineDefinitionEntity def(BaselineEntryType type, String key, String value) {
+    BaselineDefinitionEntity d = new BaselineDefinitionEntity();
+    d.setEntryType(type);
+    d.setEntityKey(key);
+    d.setEntityValue(value);
+    return d;
+  }
+
+  private NetworkSnapshotEntity snapshot() {
+    NetworkEntity network = new NetworkEntity();
+    network.setId(NETWORK);
+    FileEntity file = new FileEntity();
+    file.setId(FILE);
+    NetworkSnapshotEntity snap = new NetworkSnapshotEntity();
+    snap.setNetwork(network);
+    snap.setFile(file);
+    snap.setSnapshotOrder(1);
+    return snap;
+  }
+
+  /** The detector is private; this is the seam under test, not a public API. */
+  @SuppressWarnings("unchecked")
+  private List<NetworkChangeEventEntity> detect() {
+    try {
+      Method m =
+          ChangeDetectionService.class.getDeclaredMethod(
+              "detectBaselineDeviations", UUID.class, NetworkSnapshotEntity.class,
+              NetworkSnapshotEntity.class);
+      m.setAccessible(true);
+      return (List<NetworkChangeEventEntity>) m.invoke(service, FILE, null, snapshot());
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("detectBaselineDeviations changed — update this test", e);
+    }
+  }
+
+  /** detectChanges returns whatever saveAll() hands back, so the mock has to echo its input. */
+  private static NetworkChangeEventRepository savingRepository() {
+    NetworkChangeEventRepository repo = mock(NetworkChangeEventRepository.class);
+    when(repo.saveAll(any())).thenAnswer(inv -> new java.util.ArrayList<>(inv.getArgument(0)));
+    return repo;
+  }
+
+  /** All collaborators mocked so the sibling detectors no-op instead of NPEing on nulls. */
+  private ChangeDetectionService wiredService() {
+    return new ChangeDetectionService(
+        hosts,
+        mock(ConversationLookup.class),
+        mock(GeoOrgLookup.class),
+        savingRepository(),
+        baselines,
+        mock(CustomPrivateRangeService.class),
+        mock(SnapshotSubnetOverrideRepository.class),
+        mock(LabelStalenessCheck.class),
+        mock(NetworkSnapshotRepository.class),
+        List.of(),
+        mock(SubnetOverrideCarryForwardService.class));
+  }
+
+  private void observed(HostFacts... facts) {
+    when(hosts.hostFacts(any())).thenReturn(List.of(facts));
+  }
+
+  private void declared(BaselineDefinitionEntity... defs) {
+    when(baselines.findByNetworkIdOrderByCreatedAtAsc(NETWORK)).thenReturn(List.of(defs));
+  }
+
+  @Test
+  void noDefinitions_emitsNothing() {
+    declared();
+    observed(host("10.0.0.1", "aa:bb:cc:dd:ee:ff"));
+
+    assertThat(detect()).isEmpty();
+
+    // "must not pay for it" is the half worth pinning: the short-circuit is what keeps this
+    // detector free for the networks that never opened the baseline panel.
+    org.mockito.Mockito.verifyNoInteractions(hosts);
+  }
+
+  @Test
+  void declaredDevicePresent_emitsNothing() {
+    declared(def(BaselineEntryType.DEVICE, "aa:bb:cc:dd:ee:ff", "10.0.0.1"));
+    observed(host("10.0.0.1", "aa:bb:cc:dd:ee:ff"));
+
+    assertThat(detect()).isEmpty();
+  }
+
+  @Test
+  void declaredDeviceAbsent_isFlaggedAsMissing() {
+    declared(def(BaselineEntryType.DEVICE, "aa:bb:cc:dd:ee:ff", "10.0.0.1"));
+    observed(host("10.0.0.9", "11:22:33:44:55:66"));
+
+    List<NetworkChangeEventEntity> events = detect();
+
+    assertThat(events).hasSize(1);
+    assertThat(events.get(0).getChangeType()).isEqualTo(ChangeType.BASELINE_MISSING);
+    assertThat(events.get(0).getEntityKey()).isEqualTo("aa:bb:cc:dd:ee:ff");
+  }
+
+  @Test
+  void anUppercaseMacInTheCaptureStillMatchesALowercaseDeclaration() {
+    // The direction that actually needs lowerKeys(): macMap keys by the raw MAC as captured,
+    // so an uppercase capture would miss a lowercase declaration entirely.
+    declared(def(BaselineEntryType.DEVICE, "aa:bb:cc:dd:ee:ff", "10.0.0.1"));
+    observed(host("10.0.0.1", "AA:BB:CC:DD:EE:FF"));
+
+    assertThat(detect()).isEmpty();
+  }
+
+  @Test
+  void macCasingDoesNotMakeADeclaredDeviceLookAbsent() {
+    // Captures and the UI disagree on MAC casing routinely. Comparing as-is would report a
+    // baselined device as missing from every snapshot it is actually in — a false alarm on
+    // every ingest, which is how an operator learns to ignore the queue.
+    declared(def(BaselineEntryType.DEVICE, "AA:BB:CC:DD:EE:FF", "10.0.0.1"));
+    observed(host("10.0.0.1", "aa:bb:cc:dd:ee:ff"));
+
+    assertThat(detect()).isEmpty();
+  }
+
+  @Test
+  void bindingBoundToADifferentIp_isCriticalNotMerelyChanged() {
+    declared(def(BaselineEntryType.IP_MAC_BINDING, "aa:bb:cc:dd:ee:ff", "10.0.0.1"));
+    observed(host("10.0.0.99", "aa:bb:cc:dd:ee:ff"));
+
+    List<NetworkChangeEventEntity> events = detect();
+
+    // A contradicted binding is what ARP spoofing looks like, so it outranks a mere absence.
+    assertThat(events).hasSize(1);
+    assertThat(events.get(0).getChangeType()).isEqualTo(ChangeType.BASELINE_MISMATCH);
+    assertThat(events.get(0).getSeverity()).isEqualTo(Severity.CRITICAL);
+    assertThat(events.get(0).getNewValue()).containsEntry("observed", "10.0.0.99");
+    assertThat(events.get(0).getNewValue()).containsEntry("expected", "10.0.0.1");
+  }
+
+  @Test
+  void aDeclarationWithNoExpectedValue_onlyChecksPresence() {
+    // The UI allows a key with no value. That declares "this should exist", not "it should be
+    // bound to nothing" — treating a blank as a contradiction would fire on every snapshot.
+    declared(def(BaselineEntryType.DEVICE, "aa:bb:cc:dd:ee:ff", ""));
+    observed(host("10.0.0.99", "aa:bb:cc:dd:ee:ff"));
+
+    assertThat(detect()).isEmpty();
+  }
+
+  @Test
+  void declaredGatewayAbsent_isFlagged() {
+    declared(def(BaselineEntryType.GATEWAY, "10.0.0.254", "core router"));
+    observed(host("10.0.0.1", "aa:bb:cc:dd:ee:ff"));
+
+    List<NetworkChangeEventEntity> events = detect();
+
+    // The case the whole feature exists for: a declared gateway stops answering.
+    assertThat(events).hasSize(1);
+    assertThat(events.get(0).getChangeType()).isEqualTo(ChangeType.BASELINE_MISSING);
+    assertThat(events.get(0).getEntityKey()).isEqualTo("10.0.0.254");
+  }
+
+  @Test
+  void declaredGatewayPresent_emitsNothing() {
+    declared(def(BaselineEntryType.GATEWAY, "10.0.0.254", "core router"));
+    observed(host("10.0.0.254", "aa:bb:cc:dd:ee:ff"));
+
+    assertThat(detect()).isEmpty();
+  }
+
+  @Test
+  void protocolAndAppDeclarations_areNotEvaluatedYet() {
+    // Accepted by the UI but deliberately not evaluated: they raise the same allowlist question,
+    // and drift against the previous snapshot already covers them.
+    declared(
+        def(BaselineEntryType.PROTOCOL, "TLS", ""),
+        def(BaselineEntryType.APP, "Telegram", ""),
+        def(BaselineEntryType.VPN_FINGERPRINT, "wireguard", ""));
+    observed(host("10.0.0.1", "aa:bb:cc:dd:ee:ff"));
+
+    assertThat(detect()).isEmpty();
+  }
+
+  @Test
+  void detectChanges_actuallyRunsTheBaselinePass() {
+    // #650 was not a broken detector, it was a detector that nothing called. A unit test aimed
+    // straight at the private method would still pass if the wiring were removed again, so this
+    // one goes through the public entry point.
+    declared(def(BaselineEntryType.DEVICE, "aa:bb:cc:dd:ee:ff", "10.0.0.1"));
+    observed(host("10.0.0.9", "11:22:33:44:55:66"));
+
+    List<NetworkChangeEventEntity> events = wiredService().detectChanges(null, snapshot());
+
+    assertThat(events)
+        .extracting(NetworkChangeEventEntity::getChangeType)
+        .contains(ChangeType.BASELINE_MISSING);
+  }
+
+  @Test
+  void aBlankKeyIsSkippedRatherThanFlagged() {
+    declared(def(BaselineEntryType.DEVICE, "   ", "10.0.0.1"));
+    observed(host("10.0.0.1", "aa:bb:cc:dd:ee:ff"));
+
+    // An empty row in the panel is an operator mistake, not a missing device.
+    assertThat(detect()).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionServiceAsnMapTest.java
+++ b/backend/src/test/java/com/tracepcap/monitor/service/ChangeDetectionServiceAsnMapTest.java
@@ -22,7 +22,7 @@ class ChangeDetectionServiceAsnMapTest {
   /** asnMap touches none of the collaborators, so nulls are honest here. */
   private final ChangeDetectionService service =
       new ChangeDetectionService(
-          null, null, null, null, null, null, null, null, null, null);
+          null, null, null, null, null, null, null, null, null, null, null);
 
   private static Map<String, IpAttribution> geo(IpAttribution... entries) {
     Map<String, IpAttribution> m = new java.util.LinkedHashMap<>();

--- a/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
+++ b/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
@@ -67,6 +67,12 @@ function describeEvent(event: ChangeEvent): string {
       return `${securityKindLabel(nv['signalKind'])} appeared: ${event.entityKey}`;
     case 'SECURITY_ALERT_REMOVED':
       return `${securityKindLabel(ov['signalKind'])} cleared: ${event.entityKey}`;
+    case 'BASELINE_MISSING': {
+      const what = nv['entryType'] === 'GATEWAY' ? 'gateway' : 'device';
+      return `Baselined ${what} not seen: ${event.entityKey}${nv['expected'] ? ` (expected at ${nv['expected']})` : ''}`;
+    }
+    case 'BASELINE_MISMATCH':
+      return `Baseline mismatch: ${event.entityKey} — declared ${nv['expected'] ?? '?'}, observed ${nv['observed'] ?? '?'}`;
     case 'LABEL_STALE': {
       const changes = Array.isArray(nv['changes']) ? (nv['changes'] as string[]).join(', ') : '';
       const label = nv['roleLabel'] ? ` (${nv['roleLabel']})` : '';

--- a/frontend/src/components/monitor/ChangeEventBadge/__tests__/ChangeEventBadge.test.tsx
+++ b/frontend/src/components/monitor/ChangeEventBadge/__tests__/ChangeEventBadge.test.tsx
@@ -38,6 +38,53 @@ function renderBadge(e: ChangeEvent, onPatch = vi.fn().mockResolvedValue(undefin
 }
 
 describe('ChangeEventBadge', () => {
+  describe('baseline deviation wording', () => {
+    // Without these arms the switch falls through to `event.entityKey`, so a baseline
+    // deviation would render as a bare MAC address with no indication of what went wrong.
+    it('names the declared address when a baselined device is absent', () => {
+      renderBadge(
+        event({
+          changeType: 'BASELINE_MISSING',
+          entityKey: 'aa:bb:cc:dd:ee:ff',
+          newValue: { entryType: 'DEVICE', expected: '10.0.0.1' },
+        })
+      )
+
+      expect(
+        screen.getByText(/Baselined device not seen: aa:bb:cc:dd:ee:ff \(expected at 10\.0\.0\.1\)/)
+      ).toBeInTheDocument()
+    })
+
+    it('says gateway rather than device for a gateway entry', () => {
+      renderBadge(
+        event({
+          changeType: 'BASELINE_MISSING',
+          entityKey: '10.0.0.254',
+          newValue: { entryType: 'GATEWAY', expected: 'core router' },
+        })
+      )
+
+      expect(screen.getByText(/Baselined gateway not seen: 10\.0\.0\.254/)).toBeInTheDocument()
+    })
+
+    it('shows declared and observed side by side on a mismatch', () => {
+      renderBadge(
+        event({
+          changeType: 'BASELINE_MISMATCH',
+          severity: 'CRITICAL',
+          entityKey: 'aa:bb:cc:dd:ee:ff',
+          newValue: { entryType: 'IP_MAC_BINDING', expected: '10.0.0.1', observed: '10.0.0.99' },
+        })
+      )
+
+      // Both values have to be on screen: "mismatch" alone does not tell the operator
+      // whether they are looking at a re-addressed printer or a spoofed gateway.
+      expect(
+        screen.getByText(/declared 10\.0\.0\.1, observed 10\.0\.0\.99/)
+      ).toBeInTheDocument()
+    })
+  })
+
   describe('IP_MAC_DRIFT wording', () => {
     it('calls a changed MAC on a stable IP a potential ARP spoof', () => {
       renderBadge(

--- a/frontend/src/features/monitor/types/monitor.types.ts
+++ b/frontend/src/features/monitor/types/monitor.types.ts
@@ -56,7 +56,9 @@ export type ChangeType =
   | 'VPN_DRIFT'
   | 'SECURITY_ALERT_ADDED'
   | 'SECURITY_ALERT_REMOVED'
-  | 'LABEL_STALE';
+  | 'LABEL_STALE'
+  | 'BASELINE_MISSING'
+  | 'BASELINE_MISMATCH';
 
 export type EntityType =
   | 'DEVICE' | 'IP_MAC_BINDING' | 'ISP' | 'PROTOCOL' | 'APP' | 'SECURITY' | 'NODE_ROLE';

--- a/frontend/src/pages/Monitor/components/ChangeEventsSection.tsx
+++ b/frontend/src/pages/Monitor/components/ChangeEventsSection.tsx
@@ -69,13 +69,15 @@ export const ChangeEventsSection = ({ changeEvents, snapshots, onPatchChange }: 
               <li className="mb-2">
                 <Badge bg="danger" className="me-1">CRITICAL</Badge>
                 <code>IP_MAC_DRIFT</code> — IP claimed by a different MAC (potential ARP spoofing)<br />
-                <code>GATEWAY_CHANGE</code> — default gateway IP changed
+                <code>GATEWAY_CHANGE</code> — default gateway IP changed<br />
+                <code>BASELINE_MISMATCH</code> — a baselined device is bound to a different IP than declared
               </li>
               <li className="mb-2">
                 <Badge bg="warning" text="dark" className="me-1">WARNING</Badge>
                 <code>MAC_ADDED</code> — new device appeared<br />
                 <code>IP_MAC_DRIFT</code> — known MAC moved to a new IP (DHCP drift)<br />
-                <code>LABEL_STALE</code> — a confirmed manual label's node has drifted (new MAC / protocol / external org)
+                <code>LABEL_STALE</code> — a confirmed manual label's node has drifted (new MAC / protocol / external org)<br />
+                <code>BASELINE_MISSING</code> — a device or gateway you baselined is absent from this snapshot
               </li>
               <li>
                 <Badge bg="info" text="dark" className="me-1">INFO</Badge>


### PR DESCRIPTION
Closes #650.

## The bug

The baseline panel let an operator declare an expected inventory, stored it, and displayed it back. Nothing ever compared it to anything.

That failure mode is worse than a missing feature: an operator who baselined their gateway saw no alerts and reasonably read that as *nothing wrong*, when in fact nothing had been checked. It is the same shape as #630 one layer up — a convincing surface over a no-op.

## The fix

A seventh detector in `ChangeDetectionService`. Every other detector asks *what changed between snapshot N-1 and N*; this one asks *does reality match what was declared*:

| Event | Severity | Meaning |
|---|---|---|
| `BASELINE_MISSING` | WARNING | a declared device or gateway is absent from this snapshot |
| `BASELINE_MISMATCH` | CRITICAL | a declared MAC is bound to a different IP than declared |

The mismatch case outranks the absence case deliberately: a contradicted IP↔MAC binding is what ARP spoofing looks like, while an absence is worth reviewing but is not on its own an attack signature.

MACs are compared lowercased on both sides. `macMap` keys by the raw MAC as captured, and captures and the UI disagree on casing routinely — comparing as-is would report a baselined device as missing from *every* snapshot it is actually in, which is how an operator learns to ignore the queue.

The pass short-circuits when a network has no definitions, so networks that never opened the panel pay nothing.

## Deliberately not implemented

**"Present but not declared."** That needs a decision on whether a baseline is an *allowlist* (undeclared device ⇒ alert) or an *expectation list* (only absences and contradictions matter). The answer plausibly differs per entry type — `GATEWAY` is naturally exhaustive, `APP` is not. Guessing would either flood the review queue on a busy network or silently permit rogue devices, so I have left it to an explicit call rather than picking one quietly.

`PROTOCOL` / `APP` / `VPN_FINGERPRINT` declarations are accepted by the UI but not evaluated, for the same reason; drift against the previous snapshot already covers them. Pinned by a test so it reads as a decision rather than an oversight.

## Frontend

`describeEvent`'s switch falls through to a bare `entityKey`, so without explicit arms a deviation would render as an unexplained MAC address. Both types get wording, and both are listed in the in-app legend.

## Verification

- 12 backend tests, 3 component tests; full suites green (393 backend, 605 frontend), both frontend typechecks clean
- `docker compose up -d --build` succeeds, backend starts clean
- Verified by mutation — each of these fails at least one test: unwiring the detector (the original bug), dropping the MAC case normalisation, downgrading the mismatch severity, skipping the gateway branch, and moving the short-circuit after the lookups
- The wiring test goes through the public `detectChanges` rather than the private detector, because a test aimed at the detector alone would still pass if the call were removed again — which is precisely what #650 was

No migration: `change_type` is `VARCHAR(50)` with no check constraint. V4 has a comment listing the values, but it is already applied and editing it would break the Flyway checksum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)