### PR TITLE
fix: one definition of MAC equality (#733)

### DIFF
--- a/backend/src/main/java/com/tracepcap/common/net/MacAddress.java
+++ b/backend/src/main/java/com/tracepcap/common/net/MacAddress.java
@@ -1,0 +1,78 @@
+package com.tracepcap.common.net;
+
+/**
+ * The one definition of "are these two MAC addresses the same" (#733).
+ *
+ * <p>Three normalisations existed before this: {@code PcapParserService} lowercased at parse time,
+ * {@code DeviceClassifierService.ouiKey} lowercased <em>and</em> mapped {@code -}/{@code .} to
+ * {@code :}, and {@code ChangeDetectionService} lowercased only. Whichever a comparison happened to
+ * use decided whether two spellings of one address matched.
+ *
+ * <p>That is not a cosmetic difference. An operator who typed {@code AA-BB-CC-DD-EE-FF} into the
+ * baseline panel had it stored verbatim and compared against a colon-form capture, so a device that
+ * was present in every snapshot was reported missing from every snapshot — and an alert that fires
+ * on a healthy network is how an operator learns to ignore the queue.
+ *
+ * <p>Deliberately not a validator. Callers hold operator-typed text and capture output, and
+ * rejecting an odd-looking address here would turn a comparison into a failure. Anything
+ * unrecognisable is returned trimmed and lowercased so it can still compare equal to itself.
+ */
+public final class MacAddress {
+
+  private MacAddress() {}
+
+  /**
+   * Canonical lower-case colon form, e.g. {@code "aa:bb:cc:dd:ee:ff"}.
+   *
+   * <p>Accepts colon, hyphen and dot separators, Cisco {@code aabb.ccdd.eeff} triplets, and bare
+   * hex. Returns {@code null} for null/blank input so callers can treat "no MAC" distinctly from
+   * "a MAC that normalises to nothing".
+   */
+  public static String normalise(String mac) {
+    if (mac == null) return null;
+    String trimmed = mac.trim();
+    if (trimmed.isEmpty()) return null;
+
+    String hex = trimmed.toLowerCase().replace("-", "").replace(":", "").replace(".", "");
+    // Only regroup when the result is exactly a 48-bit address in hex. Anything else keeps its
+    // separators rather than being silently reshaped into something that looks canonical.
+    if (hex.length() != 12 || !isHex(hex)) {
+      return trimmed.toLowerCase();
+    }
+
+    StringBuilder out = new StringBuilder(17);
+    for (int i = 0; i < 12; i += 2) {
+      if (i > 0) out.append(':');
+      out.append(hex, i, i + 2);
+    }
+    return out.toString();
+  }
+
+  /** Whether two addresses denote the same hardware, ignoring case and separator style. */
+  public static boolean sameAddress(String a, String b) {
+    String na = normalise(a);
+    String nb = normalise(b);
+    return na != null && na.equals(nb);
+  }
+
+  /**
+   * The vendor prefix as {@code "aa:bb:cc"}, or {@code null} if the address is too short to have
+   * one. Kept here rather than in the classifier so the OUI lookup and the comparison agree.
+   */
+  public static String oui(String mac) {
+    String normalised = normalise(mac);
+    if (normalised == null) return null;
+    String hex = normalised.replace(":", "");
+    if (hex.length() < 6 || !isHex(hex)) return null;
+    return hex.substring(0, 2) + ":" + hex.substring(2, 4) + ":" + hex.substring(4, 6);
+  }
+
+  private static boolean isHex(String s) {
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      boolean hexDigit = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+      if (!hexDigit) return false;
+    }
+    return true;
+  }
+}

--- a/backend/src/main/java/com/tracepcap/common/net/MacAddress.java
+++ b/backend/src/main/java/com/tracepcap/common/net/MacAddress.java
@@ -62,7 +62,9 @@ public final class MacAddress {
   public static String oui(String mac) {
     String normalised = normalise(mac);
     if (normalised == null) return null;
-    String hex = normalised.replace(":", "");
+    // Strip every separator, not just colons: normalise() only regroups a full 48-bit address,
+    // so a bare vendor prefix such as "AA-BB-CC" still carries the operator's separators here.
+    String hex = normalised.replace(":", "").replace("-", "").replace(".", "");
     if (hex.length() < 6 || !isHex(hex)) return null;
     return hex.substring(0, 2) + ":" + hex.substring(2, 4) + ":" + hex.substring(4, 6);
   }

--- a/backend/src/main/java/com/tracepcap/hostclassification/service/DeviceClassifierService.java
+++ b/backend/src/main/java/com/tracepcap/hostclassification/service/DeviceClassifierService.java
@@ -1,5 +1,7 @@
 package com.tracepcap.hostclassification.service;
 
+import com.tracepcap.common.net.MacAddress;
+
 import com.tracepcap.analysis.entity.HostClassificationEntity;
 import com.tracepcap.analysis.service.HostnameResolverService;
 import com.tracepcap.analysis.service.PcapParserService;
@@ -300,18 +302,11 @@ public class DeviceClassifierService implements HostClassifier {
   }
 
   private String ouiKey(String mac) {
-    if (mac == null || mac.length() < 6) return null;
-    // Normalise to lower-case colon form "aa:bb:cc"
-    String norm = mac.toLowerCase().replace("-", ":").replace(".", ":");
-    // Accept "aa:bb:cc:dd:ee:ff" or "aabbccddeeff" etc.
-    if (norm.contains(":")) {
-      String[] parts = norm.split(":");
-      if (parts.length >= 3) return parts[0] + ":" + parts[1] + ":" + parts[2];
-    } else if (norm.length() >= 6) {
-      return norm.substring(0, 2) + ":" + norm.substring(2, 4) + ":" + norm.substring(4, 6);
-    }
-    return null;
+    // Shared with the baseline comparison (#733) so the OUI lookup and "is this the same device"
+    // cannot disagree about what an address spelling means.
+    return MacAddress.oui(mac);
   }
+
 
   /** Joins detected service roles into the comma-separated form stored on the host (null if none). */
   private String joinRoles(Set<String> roles) {

--- a/backend/src/main/java/com/tracepcap/monitor/service/BaselineService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/BaselineService.java
@@ -1,5 +1,7 @@
 package com.tracepcap.monitor.service;
 
+import com.tracepcap.common.net.MacAddress;
+
 import com.tracepcap.common.exception.ResourceNotFoundException;
 import com.tracepcap.monitor.dto.BaselineDefinitionDto;
 import com.tracepcap.monitor.dto.CreateBaselineDefinitionRequest;
@@ -49,12 +51,27 @@ public class BaselineService {
         BaselineDefinitionEntity.builder()
             .network(network)
             .entryType(entryType)
-            .entityKey(request.getEntityKey().trim())
+            // Canonical form on write. Comparison normalises too, so rows predating this still
+            // match; this only stops new rows from being stored in a shape they were never
+            // compared in.
+            .entityKey(canonicalKey(entryType, request.getEntityKey()))
             .entityValue(request.getEntityValue())
             .notes(request.getNotes())
             .build();
 
     return toDto(baselineDefinitionRepository.save(entity));
+  }
+
+  /** MAC-keyed entries are stored canonically; everything else keeps the operator's text. */
+  private static String canonicalKey(BaselineEntryType entryType, String rawKey) {
+    String trimmed = rawKey.trim();
+    return switch (entryType) {
+      case DEVICE, IP_MAC_BINDING -> {
+        String normalised = MacAddress.normalise(trimmed);
+        yield normalised != null ? normalised : trimmed;
+      }
+      default -> trimmed;
+    };
   }
 
   public void deleteDefinition(UUID networkId, UUID definitionId) {

--- a/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
+++ b/backend/src/main/java/com/tracepcap/monitor/service/ChangeDetectionService.java
@@ -1,6 +1,7 @@
 package com.tracepcap.monitor.service;
 
 import com.tracepcap.common.net.IpLocality;
+import com.tracepcap.common.net.MacAddress;
 import com.tracepcap.analysis.spi.ConversationLookup;
 import com.tracepcap.analysis.spi.ConversationLookup.ConversationFacts;
 import com.tracepcap.analysis.spi.ConversationLookup.Facet;
@@ -178,11 +179,11 @@ public class ChangeDetectionService {
         baselineDefinitionRepository.findByNetworkIdOrderByCreatedAtAsc(networkId);
     if (definitions.isEmpty()) return List.of();
 
-    // Lowercase both sides. macMap keys by the raw MAC as captured, and captures and the UI
-    // disagree on MAC casing routinely — comparing them as-is would report a baselined device as
-    // absent from every snapshot it is actually in.
-    Map<String, HostFacts> byMac = lowerKeys(macMap(toFileId));
-    Map<String, String> macToIp = lowerKeys(macToIpMap(toFileId));
+    // Normalise both sides. Captures and the operator's typing disagree on both casing and
+    // separator style, and comparing them as-is reports a baselined device as absent from every
+    // snapshot it is actually in.
+    Map<String, HostFacts> byMac = normaliseKeys(macMap(toFileId));
+    Map<String, String> macToIp = normaliseKeys(macToIpMap(toFileId));
     // Every observed IP, not just those from macToIp: that map drops hosts with no MAC, and a
     // gateway seen by IP alone would otherwise be reported missing from a snapshot it is in.
     Set<String> seenIps =
@@ -199,8 +200,8 @@ public class ChangeDetectionService {
 
       switch (def.getEntryType()) {
         case DEVICE, IP_MAC_BINDING -> {
-          // Keyed by MAC. Casing varies between captures and the UI, so compare lowercased.
-          String mac = key.toLowerCase();
+          // Keyed by MAC; spelling varies between captures and the UI, so compare canonically.
+          String mac = MacAddress.normalise(key);
           HostFacts observed = byMac.get(mac);
           if (observed == null) {
             events.add(
@@ -238,9 +239,9 @@ public class ChangeDetectionService {
     return events;
   }
 
-  private static <V> Map<String, V> lowerKeys(Map<String, V> source) {
+  private static <V> Map<String, V> normaliseKeys(Map<String, V> source) {
     Map<String, V> result = new HashMap<>();
-    source.forEach((k, v) -> result.put(k == null ? null : k.toLowerCase(), v));
+    source.forEach((k, v) -> result.put(MacAddress.normalise(k), v));
     return result;
   }
 

--- a/backend/src/test/java/com/tracepcap/common/net/MacAddressTest.java
+++ b/backend/src/test/java/com/tracepcap/common/net/MacAddressTest.java
@@ -73,6 +73,15 @@ class MacAddressTest {
     assertThat(MacAddress.oui(mac)).isEqualTo(oui);
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"AA-BB-CC", "aa:bb:cc", "AABBCC", "aabb.cc"})
+  void aBareVendorPrefixResolvesWhateverSeparatorItWasWrittenWith(String prefix) {
+    // normalise() only regroups a full 48-bit address, so a 3-octet prefix arrives here still
+    // carrying its separators. Wireshark's manuf file is colon-form, but an OUI table in any
+    // other spelling would have silently loaded zero vendors.
+    assertThat(MacAddress.oui(prefix)).isEqualTo("aa:bb:cc");
+  }
+
   @Test
   void ouiIsNullWhenThereIsNotEnoughAddressToHaveOne() {
     assertThat(MacAddress.oui("aa:bb")).isNull();

--- a/backend/src/test/java/com/tracepcap/common/net/MacAddressTest.java
+++ b/backend/src/test/java/com/tracepcap/common/net/MacAddressTest.java
@@ -1,0 +1,81 @@
+package com.tracepcap.common.net;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** The single definition of MAC equality (#733). */
+class MacAddressTest {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "aa:bb:cc:dd:ee:ff",
+        "AA:BB:CC:DD:EE:FF",
+        "aa-bb-cc-dd-ee-ff",
+        "AA-BB-CC-DD-EE-FF",
+        "aabb.ccdd.eeff",
+        "aabbccddeeff",
+        "  AA:BB:cc:DD:ee:FF  "
+      })
+  void everySpellingOfOneAddressNormalisesToTheSameForm(String spelling) {
+    // The whole point: a capture, a Cisco config paste and an operator typing by hand produce
+    // three different strings for one device.
+    assertThat(MacAddress.normalise(spelling)).isEqualTo("aa:bb:cc:dd:ee:ff");
+  }
+
+  @Test
+  void differentAddressesStayDifferent() {
+    assertThat(MacAddress.sameAddress("aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:00")).isFalse();
+  }
+
+  @Test
+  void hyphenAndColonSpellingsCompareEqual() {
+    // The exact case that reported a present device as missing from every snapshot.
+    assertThat(MacAddress.sameAddress("AA-BB-CC-DD-EE-FF", "aa:bb:cc:dd:ee:ff")).isTrue();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"   "})
+  void absentInputIsNullRatherThanAnEmptyKey(String input) {
+    // Distinguishable from "an address that normalises to nothing", so a host with no MAC does
+    // not collide with another host with no MAC when used as a map key.
+    assertThat(MacAddress.normalise(input)).isNull();
+  }
+
+  @Test
+  void twoAbsentAddressesAreNotTheSameDevice() {
+    assertThat(MacAddress.sameAddress(null, null)).isFalse();
+  }
+
+  @Test
+  void somethingThatIsNotAnAddressIsLeftAloneRatherThanReshaped() {
+    // Callers hold operator-typed text. Reshaping "not-a-mac" into a canonical-looking string
+    // would invent an address; it only needs to compare equal to itself.
+    assertThat(MacAddress.normalise("not-a-mac")).isEqualTo("not-a-mac");
+    assertThat(MacAddress.normalise("zz:zz:zz:zz:zz:zz")).isEqualTo("zz:zz:zz:zz:zz:zz");
+    assertThat(MacAddress.sameAddress("ZZ:ZZ:ZZ:ZZ:ZZ:ZZ", "zz:zz:zz:zz:zz:zz")).isTrue();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "aa:bb:cc:dd:ee:ff, aa:bb:cc",
+    "AA-BB-CC-DD-EE-FF, aa:bb:cc",
+    "aabb.ccdd.eeff,    aa:bb:cc",
+    "aabbccddeeff,      aa:bb:cc"
+  })
+  void ouiIsTakenFromTheCanonicalFormSoEverySpellingResolvesTheSameVendor(String mac, String oui) {
+    assertThat(MacAddress.oui(mac)).isEqualTo(oui);
+  }
+
+  @Test
+  void ouiIsNullWhenThereIsNotEnoughAddressToHaveOne() {
+    assertThat(MacAddress.oui("aa:bb")).isNull();
+    assertThat(MacAddress.oui(null)).isNull();
+  }
+}

--- a/backend/src/test/java/com/tracepcap/monitor/service/BaselineDeviationDetectionTest.java
+++ b/backend/src/test/java/com/tracepcap/monitor/service/BaselineDeviationDetectionTest.java
@@ -162,6 +162,16 @@ class BaselineDeviationDetectionTest {
   }
 
   @Test
+  void aHyphenSeparatedDeclarationMatchesAColonSeparatedCapture() {
+    // #733: the panel accepts whatever the operator types. Comparing on casing alone meant a
+    // device present in every snapshot was reported missing from every snapshot.
+    declared(def(BaselineEntryType.DEVICE, "AA-BB-CC-DD-EE-FF", "10.0.0.1"));
+    observed(host("10.0.0.1", "aa:bb:cc:dd:ee:ff"));
+
+    assertThat(detect()).isEmpty();
+  }
+
+  @Test
   void macCasingDoesNotMakeADeclaredDeviceLookAbsent() {
     // Captures and the UI disagree on MAC casing routinely. Comparing as-is would report a
     // baselined device as missing from every snapshot it is actually in — a false alarm on


### PR DESCRIPTION
First of the two live bugs in #733.

## The bug

Three MAC normalisations existed, and which one a comparison reached decided whether two spellings of one address matched:

| where | does what |
|---|---|
| `PcapParserService` | lowercases at parse time |
| `DeviceClassifierService.ouiKey` | lowercases **and** maps `-`/`.` → `:` |
| `ChangeDetectionService` | lowercases only |
| `BaselineService` | bare `.trim()` on write |

So a device declared in the baseline panel as `AA-BB-CC-DD-EE-FF` never matched its colon-form capture, and #650's check reported it `BASELINE_MISSING` on **every** snapshot. That is the same class of false alarm as the casing bug fixed during #650 — and an alert that fires on a healthy network is how an operator learns to ignore the queue.

## The fix

`common/net/MacAddress`, alongside `IpLocality` — the same shape as the predicate #694 consolidated, for the same reason. Three deliberate choices:

- **Accepts every spelling that actually occurs**: colon, hyphen, dot, Cisco `aabb.ccdd.eeff` triplets, bare hex.
- **`null` for absent input**, not `""`, so two hosts with no MAC do not collide as map keys. `sameAddress(null, null)` is `false` — absence is not identity.
- **Not a validator.** Callers hold operator-typed text; rejecting an odd address would turn a comparison into a failure. Anything that is not a 48-bit address is returned trimmed and lowercased so it still compares equal to itself, rather than being reshaped into something that looks canonical.

`BaselineService` now stores the canonical form. Comparison normalises too, so rows written before this still match — the write-side change only stops new rows being stored in a shape they were never compared in.

## Verification

- 19 new tests on `MacAddress`, 1 added to the baseline detector for the hyphen case; full suite green (414)
- `docker compose up -d --build` succeeds
- Verified by mutation: reverting to lowercase-only fails **8** tests across the two suites; making two absent MACs compare equal fails **1**; reshaping non-addresses errors **2**

One process note: my first mutation run used `-Dtest=A+B`, which is not valid surefire syntax — it ran nothing and I read stale reports showing false green. Re-run with `,` and with the report files deleted first. The `Errors:` column also has to be read, not just `Failures:` — M3 shows up only there.

Retires finding 4 of #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)