### PR TITLE
ci: gate shared vocabulary to one definition each (#733)

### DIFF
--- a/.github/workflows/shared-vocabulary.yml
+++ b/.github/workflows/shared-vocabulary.yml
@@ -1,0 +1,50 @@
+name: Shared Vocabulary
+
+# Some concepts are defined once or they drift. "Is this address local" had five
+# implementations that disagreed about fe80::/10 and about null (#694); "how big is this in
+# bytes" had nine, two of which rendered "1.0 undefined" past their last unit on captures the
+# production target reaches (#733). Each copy was individually reasonable — they were private
+# methods with different names, so the second author could not see the first, and could not
+# have found it by searching.
+#
+# You cannot mechanically detect "these two functions mean the same thing". But these concepts
+# are built from a small closed vocabulary of magic literals, and that is checkable. Two rounds
+# of manual searching missed the two formatters named formatFileSize rather than formatBytes;
+# this check found them on its first run.
+#
+# Static, so it runs in seconds. It asserts where a concept is *defined*; whether the
+# definition is correct is the unit tests' job.
+
+on:
+  pull_request:
+    paths:
+      - 'backend/src/main/java/**'
+      - 'frontend/src/**'
+      - 'scripts/check_shared_vocabulary.py'
+      - '.github/workflows/shared-vocabulary.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/src/main/java/**'
+      - 'frontend/src/**'
+      - 'scripts/check_shared_vocabulary.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Shared concepts have one definition
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        # Pinned and without a persisted token: this job only reads source files.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Check shared concepts are not redefined per-module
+        run: python3 scripts/check_shared_vocabulary.py

--- a/frontend/src/components/analysis/AnalysisSummary/AnalysisSummary.tsx
+++ b/frontend/src/components/analysis/AnalysisSummary/AnalysisSummary.tsx
@@ -1,5 +1,6 @@
 import type { AnalysisSummary as AnalysisSummaryType } from '@/types';
 import './AnalysisSummary.css';
+import { formatBytes } from '@/utils/formatters';
 
 interface AnalysisSummaryProps {
   summary: AnalysisSummaryType;
@@ -7,13 +8,6 @@ interface AnalysisSummaryProps {
 }
 
 export const AnalysisSummary = ({ summary, extractedFilesCount }: AnalysisSummaryProps) => {
-  const formatFileSize = (bytes: number | undefined | null): string => {
-    if (!bytes || bytes === 0) return '0 Bytes';
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
-  };
 
   const formatDuration = (
     start: number | undefined | null,
@@ -61,7 +55,7 @@ export const AnalysisSummary = ({ summary, extractedFilesCount }: AnalysisSummar
           </div>
           <div className="card-content">
             <div className="card-label">File Size</div>
-            <div className="card-value">{formatFileSize(summary.fileSize)}</div>
+            <div className="card-value">{formatBytes(summary.fileSize)}</div>
           </div>
         </div>
 

--- a/frontend/src/components/upload/FileList/FileList.tsx
+++ b/frontend/src/components/upload/FileList/FileList.tsx
@@ -10,6 +10,7 @@ import { API_ENDPOINTS } from '@/services/api/endpoints';
 import { Pagination } from '@components/common/Pagination/Pagination';
 import { parseDateTime } from '@/utils/dateUtils';
 import './FileList.css';
+import { formatBytes } from '@/utils/formatters';
 
 type MultiSelectAction = 'analyze' | 'merge';
 
@@ -165,13 +166,6 @@ export const FileList = () => {
     fetchFiles();
   }, [fetchFiles]);
 
-  const formatFileSize = (bytes: number): string => {
-    if (bytes === 0) return '0 Bytes';
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i];
-  };
 
   const formatDate = (timestamp: number): string => {
     const date = new Date(timestamp);
@@ -389,7 +383,7 @@ export const FileList = () => {
                                 })()}
                             </div>
                             <small className="text-muted">
-                              {formatFileSize(file.fileSize)} •{' '}
+                              {formatBytes(file.fileSize)} •{' '}
                               {formatDate(parseDateTime(file.uploadedAt))}
                               {!isCompleted && (
                                 <Badge

--- a/scripts/check_shared_vocabulary.py
+++ b/scripts/check_shared_vocabulary.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Shared vocabulary gate (#733, #734).
+
+Some concepts are defined once or they drift. "Is this address local" had five
+implementations that disagreed about link-local and about null; "how big is this in
+bytes" had nine, two of which rendered "1.0 undefined" past their last unit. Each was
+individually reasonable, and nothing compared them.
+
+You cannot mechanically detect "these two functions mean the same thing". But these
+concepts are built from a small closed vocabulary of magic literals, and *that* is
+checkable: the rule is not "do not duplicate logic", it is "these literals live in one
+file". Two rounds of manual searching missed the two formatters named formatFileSize
+rather than formatBytes; this check found them immediately.
+
+EXEMPTIONS MAY ONLY SHRINK. Each entry is a known duplicate with an issue attached, not
+a permanent carve-out. Adding one is how this check stops working.
+
+Usage: python3 scripts/check_shared_vocabulary.py [--root .]
+Exit 0 clean, 1 on a violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# --- rules -----------------------------------------------------------------
+
+RULES = [
+    {
+        "name": "private/link-local address ranges",
+        "why": "five implementations disagreed about fe80::/10 and about null (#694, #733)",
+        "owner": "backend common/net/IpLocality.java, frontend utils/ipClassification.ts",
+        # A *prefix constant* — the literal ends at the dot, which is what a range test
+        # looks like. A sample address such as '192.168.1.42' keeps going and is not a
+        # definition of anything.
+        "pattern": re.compile(
+            r"""(?x)
+            (?: ["'] (?: 10\. | 192\.168\. | 172\.(?:16|31)\. | 127\. | 169\.254\. ) ["'] )
+            | (?: ["'] (?: fe80 | fc00 | fd00 ) [:.]? ["'] )
+            | (?: 10\\\. \s*\| | 192\\\.168 | 169\\\.254 )   # the same list inside a regex literal
+            """
+        ),
+        "owners": {
+            "backend/src/main/java/com/tracepcap/common/net/IpLocality.java",
+            "frontend/src/utils/ipClassification.ts",
+        },
+        "exempt": {
+            # Finding 1 of #733: a fifth implementation, kept until the locality slice
+            # gives it somewhere to delegate to. It also answers a *different* question
+            # (should I skip the geo lookup) for null and for MAC addresses.
+            "backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java",
+            # NEVER_CLUSTER_PREFIXES — a genuinely different concept (loopback,
+            # link-local and multicast are not clusterable) built from the same
+            # vocabulary. Candidate for the locality slice; not a copy of it.
+            "frontend/src/features/network/services/clusterService.ts",
+        },
+    },
+    {
+        "name": "byte-size unit ladder",
+        "why": "nine implementations, two of which rendered '1.0 undefined' past GB (#733)",
+        "owner": "frontend utils/formatters",
+        # Two adjacent rungs, not one unit: 'GB' alone is also a country code, and
+        # matching it flagged a country-code map on the first run.
+        "pattern": re.compile(r"""["']KB["']\s*,\s*["']MB["']"""),
+        "owners": {"frontend/src/utils/formatters/index.ts"},
+        "exempt": set(),
+    },
+]
+
+SCAN_DIRS = ["backend/src/main/java", "frontend/src"]
+SCAN_SUFFIXES = {".java", ".ts", ".tsx"}
+
+# Comments carry these literals as examples ("e.g. 10.0.1.0/24") and are not definitions.
+COMMENT = re.compile(r"^\s*(//|/\*|\*|#)")
+
+
+def scan(root: Path) -> list[str]:
+    failures = []
+    for rule in RULES:
+        for scan_dir in SCAN_DIRS:
+            base = root / scan_dir
+            if not base.exists():
+                continue
+            for path in sorted(base.rglob("*")):
+                if path.suffix not in SCAN_SUFFIXES or not path.is_file():
+                    continue
+                rel = path.relative_to(root).as_posix()
+                if "__tests__" in rel or rel.endswith("Test.java") or ".test." in rel:
+                    continue
+                if rel in rule["owners"] or rel in rule["exempt"]:
+                    continue
+                try:
+                    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+                except OSError:
+                    continue
+                for n, line in enumerate(lines, 1):
+                    if COMMENT.match(line):
+                        continue
+                    if rule["pattern"].search(line):
+                        failures.append(
+                            f"{rel}:{n}: {rule['name']} outside {rule['owner']}\n"
+                            f"    {line.strip()[:100]}\n"
+                            f"    why this is gated: {rule['why']}"
+                        )
+    return failures
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    args = ap.parse_args()
+    root = Path(args.root).resolve()
+
+    failures = scan(root)
+    if failures:
+        print("Shared vocabulary defined outside its owning module:\n")
+        for f in failures:
+            print(f"  {f}\n")
+        print(
+            "Depend on the owning module instead of redefining the concept. If the\n"
+            "concept genuinely differs, say so at the call site and name it for the\n"
+            "question it answers, not the shape it tests."
+        )
+        return 1
+
+    exempt = sum(len(r["exempt"]) for r in RULES)
+    print(f"Shared vocabulary OK ({exempt} exemption(s) outstanding — these may only shrink).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Step 3 of #733, and the one that stops the next copy rather than cleaning up the last.

## The idea

You cannot mechanically detect "these two functions mean the same thing". But the concepts that drifted are built from a **small closed vocabulary of magic literals**, and that is checkable. The rule is not "do not duplicate logic", it is **"these literals live in one file"**.

Two rules today:

| concept | owner | why gated |
|---|---|---|
| private/link-local range prefixes | `common/net/IpLocality.java`, `utils/ipClassification.ts` | five implementations disagreed about `fe80::/10` and about `null` (#694) |
| byte-size unit ladder | `utils/formatters` | nine implementations, two rendering `"1.0 undefined"` past GB |

## It found two more on its first run

I searched for these by hand twice. The check immediately flagged `FileList.tsx` and `AnalysisSummary.tsx` — two more byte formatters, **named `formatFileSize` rather than `formatBytes`**, which is exactly why no grep for the latter ever showed them. Both capped at GB, unclamped, so an uploaded capture past 1TB rendered `"1.0 undefined"` in the file list.

So it was nine implementations, not the three I reported in #733 or the seven in #736. Both are now on the shared formatter. Two visual changes: they rendered the unit as `"Bytes"` and zero as `"0 Bytes"`; now `"B"` and `"0 B"`.

## Exemptions, which may only shrink

- `GeoIpService` — finding 1 of #733. A fifth locality implementation that also answers a *different* question (`null` and MAC addresses are "private" there because the method gates geo enrichment). It goes when the locality slice gives it something to delegate to.
- `clusterService.NEVER_CLUSTER_PREFIXES` — loopback, link-local and multicast are not clusterable. A genuinely different concept built from the same vocabulary, not a copy of the predicate.

Adding an exemption is how this check stops working, so each carries its reason inline.

## Two false positives shaped the patterns

The first run flagged a sample `'192.168.1.42'` in a settings preview and a country-code map where `'826'` maps to `'GB'`. So a range literal must now **end at the dot**, the way a prefix test does, and a unit ladder must show **two adjacent rungs**. Comment lines are skipped, since javadoc carries these as examples.

## Verification

Planted the regressions it exists to catch — a sixth locality copy in `StoryAggregatesService`, a tenth unit ladder in `FileList` — and confirmed each fails it and that it returns clean once reverted. Frontend suite green (611), both typechecks clean, `docker compose up -d --build` succeeds.

## Note on mechanism

#733 proposed ESLint `no-restricted-syntax` for the frontend half. I used one script for both languages instead: the frontend definition of `isRfc1918` is a **regex literal**, which ESLint's `Literal` selector handles awkwardly, and one script covering both is markedly less machinery for the same result. ESLint can be layered on later if the rules grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)