### PR TITLE
fix: retire the fifth locality implementation (#733)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java
@@ -6,6 +6,7 @@ import com.maxmind.db.CHMCache;
 import com.maxmind.geoip2.DatabaseReader;
 import com.maxmind.geoip2.model.CityResponse;
 import com.tracepcap.analysis.entity.IpGeoInfoEntity;
+import com.tracepcap.common.net.IpLocality;
 import com.tracepcap.analysis.repository.IpGeoInfoRepository;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -125,7 +126,7 @@ public class GeoIpService {
   public Map<String, GeoResult> lookupExternal(Set<String> ips) {
     if (!geoEnabled || ips == null || ips.isEmpty()) return Map.of();
 
-    List<String> external = ips.stream().filter(ip -> !isPrivate(ip)).collect(Collectors.toList());
+    List<String> external = ips.stream().filter(ip -> !shouldSkipLookup(ip)).collect(Collectors.toList());
     if (external.isEmpty()) return Map.of();
 
     Map<String, GeoResult> result = new HashMap<>();
@@ -367,25 +368,28 @@ public class GeoIpService {
     }
   }
 
-  /** Returns true if the IP is RFC1918, loopback, link-local, IPv6 ULA/loopback, or a MAC address. */
-  static boolean isPrivate(String ip) {
+  /**
+   * Whether to skip geo enrichment for this token (#733).
+   *
+   * <p>Named for the question it answers, not the shape it tests. It was called {@code isPrivate}
+   * and was the fifth implementation of "is this address local" — but it never was that predicate:
+   * it answers {@code true} for {@code null} and for MAC addresses, which are not private
+   * addresses, they are things there is no point looking up. Sharing a name with the range test
+   * while disagreeing with it on those inputs is what made the duplication invisible.
+   *
+   * <p>The range test now delegates to {@link IpLocality}, which fixes two defects the local copy
+   * had: {@code startsWith("fe80")} matched only that one hextet rather than {@code fe80::/10}, so
+   * {@code feb0::1} was sent to an external lookup; and nothing was lowercased, so {@code FC00::1}
+   * was too. Both leaked internal addressing to a third party when online, which is the failure
+   * mode that matters here rather than the wasted call.
+   */
+  static boolean shouldSkipLookup(String ip) {
+    // Not "private" — just nothing to look up. Kept here rather than pushed into IpLocality,
+    // which answers a question about addresses and should not grow opinions about placeholders.
     if (ip == null || ip.isBlank()) return true;
-    // MAC addresses (e.g. "00:11:22:33:44:55") — used as fallback IPs for non-IP packets
-    if (MAC_PATTERN.matcher(ip).matches()) return true;
-    String t = ip.trim();
-    if (t.equals("::1") || t.startsWith("fc") || t.startsWith("fd") || t.startsWith("fe80"))
-      return true;
-    if (t.startsWith("10.") || t.startsWith("127.") || t.startsWith("169.254.")
-        || t.startsWith("192.168.")) return true;
-    if (t.startsWith("172.")) {
-      String[] parts = t.split("\\.");
-      if (parts.length >= 2) {
-        try {
-          int second = Integer.parseInt(parts[1]);
-          if (second >= 16 && second <= 31) return true;
-        } catch (NumberFormatException ignored) {}
-      }
-    }
-    return false;
+    // MAC addresses stand in as IPs for non-IP packets.
+    if (MAC_PATTERN.matcher(ip.trim()).matches()) return true;
+    return IpLocality.isLocal(ip);
   }
+
 }

--- a/backend/src/test/java/com/tracepcap/analysis/service/GeoIpLocalityTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/service/GeoIpLocalityTest.java
@@ -1,0 +1,65 @@
+package com.tracepcap.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The fifth "is this address local" implementation (#733 finding 1), now delegating to
+ * {@link com.tracepcap.common.net.IpLocality} for the range test.
+ *
+ * <p>It keeps two answers the shared predicate deliberately does not give — {@code null} and MAC
+ * addresses are skipped — because this method never answered "is this private". It answers "is
+ * there any point looking this up", and sharing a name with the range test while disagreeing with
+ * it on those inputs is what kept the duplication invisible.
+ */
+class GeoIpLocalityTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"10.0.0.1", "192.168.1.1", "172.16.0.1", "127.0.0.1", "169.254.1.1"})
+  void rfc1918AndFriendsAreSkipped(String ip) {
+    assertThat(GeoIpService.shouldSkipLookup(ip)).isTrue();
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void absentAddressesAreSkipped(String ip) {
+    assertThat(GeoIpService.shouldSkipLookup(ip)).isTrue();
+  }
+
+  @Test
+  void macAddressesAreSkipped() {
+    assertThat(GeoIpService.shouldSkipLookup("00:11:22:33:44:55")).isTrue();
+  }
+
+  @Test
+  void publicAddressesAreLookedUp() {
+    assertThat(GeoIpService.shouldSkipLookup("8.8.8.8")).isFalse();
+  }
+
+  // --- two defects the local copy had, fixed by delegating -------------------
+
+  @ParameterizedTest
+  @ValueSource(strings = {"fe80::1", "feb0::1", "febf::1"})
+  void allOfTheLinkLocalRangeIsSkipped(String ip) {
+    // Was startsWith("fe80"), which matched one hextet of fe80::/10, so feb0::1 was sent to an
+    // external lookup. The wasted call is not the problem — leaking internal addressing to a
+    // third party is.
+    assertThat(GeoIpService.shouldSkipLookup(ip)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"fc00::1", "FC00::1", "fd12:3456::1", "FD12:3456::1"})
+  void uniqueLocalIsSkippedWhateverTheCase(String ip) {
+    // The local copy never lowercased, so an uppercase ULA was treated as public.
+    assertThat(GeoIpService.shouldSkipLookup(ip)).isTrue();
+  }
+
+  @Test
+  void aGenuinelyExternalIpv6AddressIsStillLookedUp() {
+    assertThat(GeoIpService.shouldSkipLookup("2001:db8::1")).isFalse();
+  }
+}

--- a/frontend/src/utils/__tests__/ipClassification.test.ts
+++ b/frontend/src/utils/__tests__/ipClassification.test.ts
@@ -23,6 +23,19 @@ describe('isRfc1918', () => {
   });
 });
 
+describe('link-local matches the backend', () => {
+  // fe80::/10 spans fe80–febf. The regex used to test `fe80:`, one hextet of it, so feb0::1
+  // read as public here and internal in IpLocality — the same host classified differently
+  // depending on which side of the wire answered.
+  it.each(['fe80::1', 'fe90::1', 'fea0::1', 'febf::1', 'FEB0::1'])('treats %s as internal', ip => {
+    expect(isRfc1918(ip)).toBe(true)
+  })
+
+  it.each(['fec0::1', 'ff02::1', '2001:db8::1'])('leaves %s external', ip => {
+    expect(isRfc1918(ip)).toBe(false)
+  })
+})
+
 describe('ipInCidr', () => {
   it('matches inside an IPv4 CIDR and rejects outside', () => {
     expect(ipInCidr('10.0.1.5', '10.0.0.0/16')).toBe(true);

--- a/frontend/src/utils/ipClassification.ts
+++ b/frontend/src/utils/ipClassification.ts
@@ -9,9 +9,15 @@ import type { CustomPrivateRange } from '@/features/intelligence/types/customPri
  *   - {@link isPrivateIp} — the heuristic, but a user's custom range override wins in either direction.
  */
 
-/** RFC 1918 / loopback / link-local / IPv6 ULA (fc00::/7) + link-local (fe80::) + loopback (::1). */
+/**
+ * RFC 1918 / loopback / link-local / IPv6 ULA (fc00::/7) + link-local (fe80::/10) + loopback (::1).
+ *
+ * Kept in step with the backend's IpLocality (#733 finding 3). The link-local alternative was
+ * `fe80:`, which is one hextet of a /10 — so feb0::1 read as public here and internal on the
+ * server, and the same host was classified differently depending on which side answered.
+ */
 export function isRfc1918(ip: string): boolean {
-  return /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|169\.254\.|f[cd][0-9a-f]{2}:|fe80:|::1$)/i.test(ip);
+  return /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|169\.254\.|f[cd][0-9a-f]{2}:|fe[89ab][0-9a-f]:|::1$)/i.test(ip);
 }
 
 /** IPv4 dotted-quad → uint32. IPv4 only; callers guard IPv6 before calling. */

--- a/scripts/check_shared_vocabulary.py
+++ b/scripts/check_shared_vocabulary.py
@@ -48,10 +48,6 @@ RULES = [
             "frontend/src/utils/ipClassification.ts",
         },
         "exempt": {
-            # Finding 1 of #733: a fifth implementation, kept until the locality slice
-            # gives it somewhere to delegate to. It also answers a *different* question
-            # (should I skip the geo lookup) for null and for MAC addresses.
-            "backend/src/main/java/com/tracepcap/analysis/service/GeoIpService.java",
             # NEVER_CLUSTER_PREFIXES — a genuinely different concept (loopback,
             # link-local and multicast are not clusterable) built from the same
             # vocabulary. Candidate for the locality slice; not a copy of it.


### PR DESCRIPTION
Findings 1 and 3 of #733. Removes one of the gate's two exemptions.

## The fifth implementation

`GeoIpService` kept its own string-prefix range test — the one #694 missed when it consolidated the other four. Two defects:

- `startsWith("fe80")` matched **one hextet of `fe80::/10`**, so `feb0::1` was classified public
- nothing was lowercased, so `FC00::1` was too

Both meant internal addressing was sent to an external geo lookup when online. The wasted call is not the problem; the leak is.

## Naming was the actual bug

It was never "is this address private". It returns `true` for `null` and for MAC addresses — neither is a private address; they are things there is no point looking up. **Sharing a name with the range test while disagreeing with it on those inputs is what kept the duplication invisible**, so the name changes along with the delegation: `shouldSkipLookup`.

Both guards stay at the call site rather than moving into `IpLocality`, which answers a question about addresses and should not grow opinions about placeholders. That distinction is what makes this a delegation rather than a merge — and it is why a naive "just call `IpLocality`" would have started sending nulls and MAC addresses to the lookup.

## Same gap in the frontend

`isRfc1918` tested `fe80:` — again one hextet of the /10. So `feb0::1` read as **public in the browser and internal on the server**: the same host classified differently depending on which side answered. Now `fe[89ab][0-9a-f]:`, matching `IpLocality`.

## Method

There were **no tests on `GeoIpService` at all**, so this is a behaviour change with no safety net. I characterised the old behaviour first — pinning both defects *as they actually behaved* and running that green — to confirm they were real rather than inferred from reading the code, then changed it and flipped those two assertions.

## Verification

- 17 backend tests, 8 frontend; full suites green (449 backend, 619 frontend), both typechecks clean
- `docker compose up -d --build` succeeds
- Verified by mutation: restoring the prefix list fails **9**, dropping the null guard fails **2**, narrowing the frontend regex back to `fe80:` fails **4**

Vocabulary gate exemptions **2 → 1** (`clusterService.NEVER_CLUSTER_PREFIXES` remains, and is a genuinely different concept rather than a copy).

## What's left of #733

Finding 2 — custom private ranges bind in only one backend service — is the remainder, and it is the piece that needs the kernel design from #734 rather than a delegation. Finding 6 (severity colours) is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP address classification for IPv6 local and link-local ranges, including uppercase forms.
  * Prevented GeoIP lookups for blank values, MAC addresses, private, loopback, link-local, and unique-local addresses.
  * Ensured public IPv4 and external IPv6 addresses continue to receive GeoIP lookups.

* **Tests**
  * Added coverage for local, external, multicast, documentation, and edge-case IPv6 addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->