### PR TITLE
fix: one severity palette for monitor events (#733)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "lint:css:fix": "stylelint \"src/**/*.css\" --fix",
     "preview": "vite preview",
     "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.app.json --noEmit",
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "api:types": "openapi-typescript ../openapi/baseline.json -o src/services/api/generated/schema.d.ts",
     "test:watch": "vitest",

--- a/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
+++ b/frontend/src/components/monitor/ChangeEventBadge/ChangeEventBadge.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { Button, Form } from '@govtechsg/sgds-react';
 import type { ChangeEvent, NetworkSnapshot } from '@/features/monitor/types/monitor.types';
 import { parseDateTime } from '@/utils/dateUtils';
+import { severityHex, severityIcon } from '@/utils/severityColors';
 
 interface ChangeEventBadgeProps {
   event: ChangeEvent;
@@ -10,17 +11,6 @@ interface ChangeEventBadgeProps {
   onPatch: (eventId: string, patch: { reviewed?: boolean; notes?: string | null }) => Promise<void>;
 }
 
-const SEVERITY_CLASSES: Record<string, string> = {
-  CRITICAL: 'text-danger',
-  WARNING:  'text-warning',
-  INFO:     'text-info',
-};
-
-const SEVERITY_ICONS: Record<string, string> = {
-  CRITICAL: 'bi-exclamation-circle-fill',
-  WARNING:  'bi-exclamation-triangle-fill',
-  INFO:     'bi-info-circle-fill',
-};
 
 /** Human label for a security-drift signalKind payload value. */
 function securityKindLabel(kind: unknown): string {
@@ -132,7 +122,8 @@ export const ChangeEventBadge = ({ event, snapshots, onPatch }: ChangeEventBadge
       style={{ transition: 'opacity 0.2s' }}
     >
       <i
-        className={`bi ${SEVERITY_ICONS[event.severity] ?? 'bi-circle-fill'} ${SEVERITY_CLASSES[event.severity] ?? ''} flex-shrink-0 mt-1`}
+        className={`bi ${severityIcon(event.severity)} flex-shrink-0 mt-1`}
+        style={{ color: severityHex(event.severity) }}
       />
       <div className="flex-grow-1 min-w-0">
         <div className="text-break">{describeEvent(event)}</div>

--- a/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
+++ b/frontend/src/components/monitor/SnapshotDetailModal/SnapshotDetailModal.tsx
@@ -28,14 +28,10 @@ import { VolumeLegend } from '@/components/network/VolumeLegend';
 import { useResolvedDark } from '@/utils/useResolvedDark';
 import { parseDateTime } from '@/utils/dateUtils';
 import { nodeIdentityKey } from '@/utils/deviceType';
+import { severityHex } from '@/utils/severityColors';
 
 type Tab = 'diagram' | 'changes' | 'security' | 'context' | 'subnets' | 'insights';
 
-const HIGHLIGHT_COLORS: Record<string, string> = {
-  CRITICAL: '#e74c3c',
-  WARNING:  '#f39c12',
-  INFO:     '#2ecc71',
-};
 
 function labelForChange(changeType: string, oldValue: Record<string, unknown> | null, newValue: Record<string, unknown> | null): string {
   switch (changeType) {
@@ -59,7 +55,7 @@ function severityRank(s: string): number {
 function buildHighlightMap(events: ChangeEvent[], toSnapshotId: string): Map<string, NodeHighlight> {
   const map = new Map<string, NodeHighlight>();
   for (const e of events.filter(ev => ev.toSnapshotId === toSnapshotId)) {
-    const color = HIGHLIGHT_COLORS[e.severity] ?? HIGHLIGHT_COLORS.INFO;
+    const color = severityHex(e.severity);
     const label = labelForChange(e.changeType, e.oldValue, e.newValue);
     const addHl = (key: string, description?: string) => {
       const existing = map.get(key);
@@ -485,7 +481,7 @@ export const SnapshotDetailModal = ({
                     {snapshotEvents.length > 0 && (
                       <span className="badge rounded-pill ms-1" style={{
                         fontSize: '0.6rem',
-                        background: snapshotEvents.some(e => e.severity === 'CRITICAL') ? '#dc3545' : '#fd7e14',
+                        background: severityHex(snapshotEvents.some(e => e.severity === 'CRITICAL') ? 'CRITICAL' : 'WARNING'),
                         color: '#fff',
                       }}>
                         {snapshotEvents.length}

--- a/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
+++ b/frontend/src/components/monitor/SnapshotSecurityTab/SnapshotSecurityTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Pagination } from '@components/common/Pagination/Pagination';
 import type { GraphEdge } from '@/features/network/types';
+import { severityHex } from '@/utils/severityColors';
 
 /**
  * Absolute security posture of a single snapshot's capture. Aggregates the four analysis-mode
@@ -41,11 +42,6 @@ interface SignalSection {
   rows: SignalRow[];
 }
 
-const SEVERITY_COLOR: Record<Severity, string> = {
-  CRITICAL: '#dc3545',
-  WARNING: '#fd7e14',
-  INFO: '#6c757d',
-};
 
 /** Group one signal across all edges: value → distinct flows (deduped by label). */
 function aggregate(edges: GraphEdge[], pick: (e: GraphEdge) => string[] | undefined): SignalRow[] {
@@ -93,11 +89,11 @@ function SignalSectionView({
   return (
     <div className="mb-4">
       <div className="d-flex align-items-center gap-2 mb-1">
-        <i className={`bi ${section.icon}`} style={{ color: SEVERITY_COLOR[section.severity] }} />
+        <i className={`bi ${section.icon}`} style={{ color: severityHex(section.severity) }} />
         <span className="fw-semibold">{section.title}</span>
         <span
           className="badge rounded-pill"
-          style={{ fontSize: '0.7rem', background: SEVERITY_COLOR[section.severity], color: '#fff' }}
+          style={{ fontSize: '0.7rem', background: severityHex(section.severity), color: '#fff' }}
         >
           {section.rows.length}
         </span>

--- a/frontend/src/utils/__tests__/severityColors.test.ts
+++ b/frontend/src/utils/__tests__/severityColors.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { severityBadgeBg, severityHex, severityIcon } from '../severityColors'
+
+describe('severityColors', () => {
+  it('gives each severity one colour across every panel', () => {
+    // Four maps disagreed before this. The specific values matter less than there being one
+    // answer: an operator comparing the event list with the security tab was comparing colours
+    // that meant the same thing and looked different.
+    expect(severityHex('CRITICAL')).toBe('#dc3545')
+    expect(severityHex('WARNING')).toBe('#fd7e14')
+    expect(severityHex('INFO')).toBe('#6c757d')
+  })
+
+  it('does not render INFO as green', () => {
+    // The snapshot modal drew INFO in #2ecc71. Green is the success colour everywhere else in
+    // the app, so an informational event read as "this is fine" in that one panel.
+    expect(severityHex('INFO')).not.toBe('#2ecc71')
+  })
+
+  it('keeps WARNING distinguishable from CRITICAL', () => {
+    // Bootstrap's text-warning is #ffc107, a yellow that reads as much softer than the orange
+    // the other panels used. Pinned so the two stay visually ordered.
+    expect(severityHex('WARNING')).not.toBe(severityHex('CRITICAL'))
+    expect(severityHex('WARNING')).not.toBe('#ffc107')
+  })
+
+  it('falls back visibly for an unknown severity', () => {
+    // A new severity from the backend must not render transparent or undefined.
+    expect(severityHex('SOMETHING_NEW')).toBe('#6c757d')
+    expect(severityHex(null)).toBe('#6c757d')
+    expect(severityHex(undefined)).toBe('#6c757d')
+  })
+
+  it('pairs an icon with each severity, and a visible fallback', () => {
+    expect(severityIcon('CRITICAL')).toBe('bi-exclamation-circle-fill')
+    expect(severityIcon('WARNING')).toBe('bi-exclamation-triangle-fill')
+    expect(severityIcon('INFO')).toBe('bi-info-circle-fill')
+    expect(severityIcon('SOMETHING_NEW')).toBe('bi-circle-fill')
+  })
+
+  it('maps to Bootstrap badge variants for the legend copy', () => {
+    expect(severityBadgeBg('CRITICAL')).toBe('danger')
+    expect(severityBadgeBg('WARNING')).toBe('warning')
+    expect(severityBadgeBg('INFO')).toBe('secondary')
+  })
+})

--- a/frontend/src/utils/severityColors.ts
+++ b/frontend/src/utils/severityColors.ts
@@ -1,0 +1,48 @@
+/**
+ * One severity palette for monitor change events (#733 finding 6).
+ *
+ * Four definitions existed and they disagreed, most consequentially about INFO — cyan in the
+ * event list, grey in the security tab and **green** in the snapshot modal. Green is the success
+ * colour everywhere else in the app, so an informational event read as "this is fine" in one
+ * panel and as neutral in another. WARNING was likewise Bootstrap yellow in one place and orange
+ * in two others.
+ *
+ * Exported as hex rather than Bootstrap class names on purpose: `text-warning` is #ffc107 while
+ * every other panel drew #fd7e14, so a map of class names and a map of hexes for the same three
+ * severities is two definitions again. One map, used for both text and fills.
+ */
+export type MonitorSeverity = 'CRITICAL' | 'WARNING' | 'INFO';
+
+const SEVERITY_HEX: Record<MonitorSeverity, string> = {
+  CRITICAL: '#dc3545',
+  WARNING: '#fd7e14',
+  // Grey, not green: informational is neutral, and green means "good" elsewhere in the app.
+  INFO: '#6c757d',
+};
+
+/** Fallback keeps an unrecognised severity visible rather than transparent. */
+export function severityHex(severity: string | null | undefined): string {
+  return SEVERITY_HEX[severity as MonitorSeverity] ?? SEVERITY_HEX.INFO;
+}
+
+const SEVERITY_ICON: Record<MonitorSeverity, string> = {
+  CRITICAL: 'bi-exclamation-circle-fill',
+  WARNING: 'bi-exclamation-triangle-fill',
+  INFO: 'bi-info-circle-fill',
+};
+
+export function severityIcon(severity: string | null | undefined): string {
+  return SEVERITY_ICON[severity as MonitorSeverity] ?? 'bi-circle-fill';
+}
+
+/** Bootstrap `bg` variant, for the SGDS/Bootstrap Badge in the legend copy. */
+export function severityBadgeBg(severity: string | null | undefined): string {
+  switch (severity) {
+    case 'CRITICAL':
+      return 'danger';
+    case 'WARNING':
+      return 'warning';
+    default:
+      return 'secondary';
+  }
+}


### PR DESCRIPTION
The last finding of #733 — and it turned up something more important than the colours.

## The colours

Four maps disagreed, and not only cosmetically:

| severity | event list | security tab | snapshot modal |
|---|---|---|---|
| CRITICAL | `text-danger` (#dc3545) | `#dc3545` | `#e74c3c` |
| WARNING | `text-warning` (#ffc107, yellow) | `#fd7e14` | `#f39c12` |
| INFO | `text-info` (cyan) | `#6c757d` (grey) | **`#2ecc71` (green)** |

**INFO rendered green in the snapshot modal.** Green is the success colour everywhere else in the app, so an informational event read as *"this is fine"* in one panel and as neutral in another. That is a meaning change, not a shade difference.

One map now, in `utils/severityColors.ts`, exported as **hex rather than Bootstrap class names** — a map of classes plus a map of hexes for the same three severities is two definitions again, and that is exactly how `text-warning` (#ffc107) drifted from the #fd7e14 every other panel drew.

`appColors.getSeverityColor` is left alone: it serves the findings vocabulary (`critical/high/medium/low`), a different domain, not a drifted copy.

## The more important find

While verifying this I noticed `tsc` reporting clean on a file containing an undefined identifier. **`npx tsc --noEmit` type-checks nothing.**

`frontend/tsconfig.json` is `"files": []` plus project references, so the bare form reads no source files and exits 0 unconditionally. Run explicitly:

```
$ npx tsc -p tsconfig.app.json --noEmit
src/.../SnapshotDetailModal.tsx(58,46): error TS2304: Cannot find name 'HIGHLIGHT_COLORS'.
```

**So my "tsc clean" claims in earlier PRs this session were vacuous.** The work was still covered — CI runs `docker compose up -d --build`, the image build runs `npm run build` = `tsc -b && vite build`, and `tsc -b` does build the referenced projects — but the local signal I was quoting as evidence was worth nothing, and `npm run typecheck:test` (which is explicit) was the only real one.

Added `npm run typecheck`, and confirmed it is not itself a no-op by planting a type error and watching it fail with exit 2. The written-down advice that sent me to the wrong command is corrected.

## Verification

- 6 new tests pinning the palette, including "INFO is not green" and "WARNING is not Bootstrap yellow" as named cases rather than bare value assertions
- Frontend suite green (619), `npm run typecheck` and `typecheck:test` both clean — and this time that means something
- `docker compose up -d --build` succeeds

**#733 is now fully closed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized severity colors, icons, and badges across monitoring views.
  * Added neutral fallback styling for unknown or missing severity values.
  * Improved visual consistency between snapshot details, security sections, and change event indicators.

* **Tests**
  * Added coverage for severity colors, icons, badge variants, and fallback behavior.

* **Developer Experience**
  * Added a TypeScript type-checking command that runs without generating files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->