### PR TITLE
docs: rename Network Intelligence to Network Cluster (#745, tiers 1-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Changes are compared between consecutive snapshots (ordered by capture time):
 |-----------|------------|
 | **Backend** | Spring Boot 3.2.1, Java 21, Maven, Lombok, MapStruct |
 | **Frontend** | React 19, Vite, TypeScript, SGDS React |
-| **Visualization** | Sigma.js + graphology + ELK (network topology), React Flow (Network Intelligence cluster graph), Recharts, D3.js |
+| **Visualization** | Sigma.js + graphology + ELK (network topology), React Flow (Network Cluster cluster graph), Recharts, D3.js |
 | **Reverse Proxy** | Nginx |
 | **Packet Parsing** | tshark / Wireshark, nDPI v5 (deep packet inspection) |
 | **Database** | PostgreSQL 15 with Flyway migrations |
@@ -393,7 +393,7 @@ The [`sample-files/`](sample-files/) directory contains example PCAPs:
 - `atm_capture1.cap` — ATM network traffic sample
 - `free5gc.pcap` — 5G core network traffic sample
 - `demo_all_rules.pcap` — Triggers all 12 custom signature demo rules
-- `dns_demo.pcap` — Two LAN resolvers answering a variety of DNS record types (A, AAAA, CNAME, MX, TXT, PTR, SRV) for the Network Intelligence "DNS Servers" view. Regenerate with [`sample-files/gen_dns_demo.py`](sample-files/gen_dns_demo.py)
+- `dns_demo.pcap` — Two LAN resolvers answering a variety of DNS record types (A, AAAA, CNAME, MX, TXT, PTR, SRV) for the Network Cluster "DNS Servers" view. Regenerate with [`sample-files/gen_dns_demo.py`](sample-files/gen_dns_demo.py)
 - `http_demo.pcap` — A JSON API server, a plain website, and a host under endpoint enumeration (mostly 404s) — drives the web/API-server classification and the node-modal HTTP endpoint log. Regenerate with [`sample-files/gen_http_demo.py`](sample-files/gen_http_demo.py)
 - `monitor_large/` — 8 weekly snapshots of a simulated 550-node office network for testing the Network Monitor
 

--- a/backend/src/main/java/com/tracepcap/analysis/spi/HostServiceLogExtractor.java
+++ b/backend/src/main/java/com/tracepcap/analysis/spi/HostServiceLogExtractor.java
@@ -6,7 +6,7 @@ import java.io.File;
 /**
  * Extracts a per-host "service activity log" for hosts acting in a particular server role.
  *
- * <p>This is the reusable seam behind the Network Intelligence per-host service views. DNS is the
+ * <p>This is the reusable seam behind the Network Cluster per-host service views. DNS is the
  * first implementation ({@code DnsQueryLogExtractor}, surfacing which domains a DNS server resolves
  * and which fail); future roles — e.g. an HTTP/API endpoint log for web servers — implement this
  * same contract and are picked up automatically.

--- a/backend/src/main/java/com/tracepcap/intelligence/controller/NetworkIntelligenceController.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/controller/NetworkIntelligenceController.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/intelligence")
 @RequiredArgsConstructor
-@Tag(name = "Network Intelligence", description = "Large-scale network topology clustering and host analytics")
+@Tag(name = "Network Cluster", description = "Large-scale network topology clustering and host analytics")
 public class NetworkIntelligenceController {
 
   private final NetworkIntelligenceService intelligenceService;

--- a/backend/src/main/java/com/tracepcap/intelligence/dto/ServiceServerSummaryDto.java
+++ b/backend/src/main/java/com/tracepcap/intelligence/dto/ServiceServerSummaryDto.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * Role-agnostic summary of a host acting as a service server, for the Network Intelligence
+ * Role-agnostic summary of a host acting as a service server, for the Network Cluster
  * per-service cards. DNS populates it today (#362); future roles (e.g. web/API servers) reuse the
  * same shape — {@code okCount}/{@code failedCount}/{@code anomalyRatio} are interpreted per role.
  */

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -117,7 +117,7 @@ Controller: `ConversationTracerController`
 
 ---
 
-## Network Intelligence — `/api/v1/network/intelligence`
+## Network Cluster — `/api/v1/network/intelligence`
 
 Controller: `NetworkIntelligenceController`
 

--- a/docs/features/network-cluster.rst
+++ b/docs/features/network-cluster.rst
@@ -1,7 +1,7 @@
-Network Intelligence
-====================
+Network Cluster
+===============
 
-The **Network Intelligence** tab presents a high-level cluster graph that
+The **Network Cluster** tab presents a high-level cluster graph that
 groups all IP addresses in a capture into named clusters, making it easier to
 understand traffic between organisations, countries, subnets, or device
 classes at a glance.
@@ -92,12 +92,12 @@ Clicking a cluster opens a panel on the right showing:
 - A per-IP breakdown sortable by **Traffic** (bytes), **Conversations**,
   **Risk flags**, or **Unique peers**.
 - A conversation list for the selected cluster, filtered by the active
-  Network Intelligence filters (same filter set as the Conversations tab).
+  Network Cluster filters (same filter set as the Conversations tab).
 
 Filters
 -------
 
-The Network Intelligence tab exposes the full conversation filter panel
+The Network Cluster tab exposes the full conversation filter panel
 (IP, port, protocol, application, country, device type, risk, custom
 signatures, etc.), identical to the Conversations tab. Filters apply to
 both the cluster graph and the side-panel conversation list.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Designed for air-gapped and offline deployments — GeoIP lookups use a bundled 
 
    features/pcap-upload
    features/network-visualization
-   features/network-intelligence
+   features/network-cluster
    features/comparison
    features/ndpi-analysis
    features/ids-threat-detection

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -514,7 +514,7 @@ export const AnalysisPage = () => {
             className={`nav-link ${activeTab === 'network-intelligence' ? 'active' : ''}`}
             onClick={() => handleTabChange('network-intelligence')}
           >
-            <i className="bi bi-globe-europe-africa me-2"></i>Network Intelligence
+            <i className="bi bi-globe-europe-africa me-2"></i>Network Cluster
           </button>
         </li>
         </ul>

--- a/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
+++ b/frontend/src/pages/NetworkDiagram/NetworkDiagramPage.tsx
@@ -429,7 +429,7 @@ export const NetworkDiagramPage = () => {
         </h4>
         <p className="text-muted small mb-0">
           Visualise individual hosts and the connections between them. Best for captures with fewer than 50 hosts —
-          for larger captures, use the <strong>Network Intelligence</strong> tab for a cluster-level overview.
+          for larger captures, use the <strong>Network Cluster</strong> tab for a cluster-level overview.
         </p>
       </div>
 

--- a/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
+++ b/frontend/src/pages/NetworkIntelligence/NetworkIntelligencePage.tsx
@@ -259,7 +259,7 @@ export const NetworkIntelligencePage = () => {
   return (
     <div className="network-intelligence-page">
       <div className="mb-3">
-        <h4 className="mb-1">Network Intelligence</h4>
+        <h4 className="mb-1">Network Cluster</h4>
         <p className="text-muted small mb-0">
           Identify who your network is talking to, where the traffic is flowing, and where risks are concentrated —
           without reviewing individual conversations. Best suited for large captures with many hosts.

--- a/frontend/src/services/api/endpoints.ts
+++ b/frontend/src/services/api/endpoints.ts
@@ -67,7 +67,7 @@ export const API_ENDPOINTS = {
   EXTRACTED_FILE_PREVIEW: (fileId: string, extractionId: string) =>
     `/files/${fileId}/extractions/${extractionId}/preview`,
 
-  // Network Intelligence
+  // Network Cluster
   NETWORK_INTELLIGENCE_CLUSTERS: (fileId: string, groupBy: string) =>
     `/intelligence/${fileId}/clusters?groupBy=${groupBy}`,
   NETWORK_INTELLIGENCE_TOP_HOSTS: (fileId: string, sortBy: string, limit: number) =>

--- a/frontend/src/utils/volumeColor.ts
+++ b/frontend/src/utils/volumeColor.ts
@@ -7,7 +7,7 @@ import { scaleSequentialLog, interpolateRgbBasis } from 'd3';
  * Shared sequential colour scale for traffic **volume** (magnitude).
  *
  * One hue (blue), light→dark, used everywhere volume is encoded as colour:
- * the node-to-node heatmap, volume-coloured diagram edges, Network Intelligence
+ * the node-to-node heatmap, volume-coloured diagram edges, Network Cluster
  * cluster nodes and the country map. Previously each of those hand-rolled its own
  * linear `trafficColor` — this replaces them so a given shade always means the
  * same number across views.

--- a/openapi/baseline.json
+++ b/openapi/baseline.json
@@ -6176,7 +6176,7 @@
         },
         "summary": "Get clustered network topology",
         "tags": [
-          "Network Intelligence"
+          "Network Cluster"
         ]
       }
     },
@@ -6212,7 +6212,7 @@
         },
         "summary": "List DNS servers and their resolution health",
         "tags": [
-          "Network Intelligence"
+          "Network Cluster"
         ]
       }
     },
@@ -6253,7 +6253,7 @@
         },
         "summary": "Get the DNS query log for one DNS server",
         "tags": [
-          "Network Intelligence"
+          "Network Cluster"
         ]
       }
     },
@@ -6295,7 +6295,7 @@
         },
         "summary": "Locate a packet by frame number",
         "tags": [
-          "Network Intelligence"
+          "Network Cluster"
         ]
       }
     },
@@ -6347,7 +6347,7 @@
         },
         "summary": "Get top hosts by traffic volume",
         "tags": [
-          "Network Intelligence"
+          "Network Cluster"
         ]
       }
     },
@@ -6383,7 +6383,7 @@
         },
         "summary": "List web/API servers and their HTTP health",
         "tags": [
-          "Network Intelligence"
+          "Network Cluster"
         ]
       }
     },
@@ -6424,7 +6424,7 @@
         },
         "summary": "Get the HTTP endpoint log + detail for one web/API server",
         "tags": [
-          "Network Intelligence"
+          "Network Cluster"
         ]
       }
     },
@@ -8774,12 +8774,12 @@
       "name": "Network Annotations"
     },
     {
-      "description": "A human's final answer to an adjudicated question — outranks the machine vote",
-      "name": "Adjudication Overrides"
+      "description": "Large-scale network topology clustering and host analytics",
+      "name": "Network Cluster"
     },
     {
-      "description": "Large-scale network topology clustering and host analytics",
-      "name": "Network Intelligence"
+      "description": "A human's final answer to an adjudicated question — outranks the machine vote",
+      "name": "Adjudication Overrides"
     },
     {
       "description": "Packet-level conversation trace with AI explanations",


### PR DESCRIPTION
Tiers 1 and 2 of #745 — user-visible copy and docs. Tier 3 deliberately excluded.

## Why

"Network Intelligence" said nothing about what the tab does: it clusters hosts by topology, ASN/org and geography. "Network Cluster" names that. "Intelligence" was also the vaguest word in the app's vocabulary, colliding with Monitor's security signals and Story mode's findings — both more literally intelligence.

## What changed

**Copy:** tab label, page heading, the cross-reference from the network diagram, and the OpenAPI `@Tag` (which is what Swagger UI shows).

**Docs:** `docs/features/network-intelligence.rst` → `network-cluster.rst` with the toctree entry, plus `docs/api/README.md` and `README.md`. RST underlines re-fitted to the shorter title.

**OpenAPI baseline regenerated**, since the `@Tag` name is part of the snapshot. The diff is **tag names only, no path changed** — which is the check that this stayed inside tier 1 and did not accidentally break an API contract.

## What is deliberately not here

Tier 3 — the frontend route `network-intelligence`, the `/intelligence` endpoint path, the Java package `com.tracepcap.intelligence`, and the frontend directories. Those are **contracts, not labels**:

- the endpoint is versioned public API, so renaming it needs a deprecation window or an explicit decision that no external consumer exists
- the route change breaks bookmarks and shared links unless a redirect goes in
- renaming the Java package churns every path in the ArchUnit frozen store, which has to be hand-edited in this environment

It also waits on #734: that issue uses this exact package as its evidence that module boundaries are UI-shaped, and if `intelligence` merges into a `host` module then renaming the package first is wasted churn on the store.

There is a neat irony worth recording — #734's heuristic is *"if a UI rename forces a package rename, the package is named wrong."* This issue is that heuristic firing in real life.

## Verification

- Docs build clean; `network-cluster.html` produced and the toctree resolves with no dangling reference to the old path. The remaining sphinx warnings are pre-existing in `network-monitor.rst` and `streaming-upload.rst`.
- Frontend suite green (619), `tsc -p tsconfig.app.json --noEmit` and `typecheck:test` both clean
- `docker compose up -d --build` succeeds and the app serves

🤖 Generated with [Claude Code](https://claude.com/claude-code)