### PR TITLE
fix: restore @Transactional on analyzeFile (regression from #750)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -147,6 +147,7 @@ public class AnalysisService {
    * the temp file's lifetime, and the failure path — which has to mark the record FAILED in its own
    * committed transaction, since the one being rolled back cannot record why it failed.
    */
+  @Transactional
   public void analyzeFile(UUID fileId) {
     log.info("Starting analysis for file: {}", fileId);
 

--- a/backend/src/main/java/com/tracepcap/analysis/service/AsyncAnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AsyncAnalysisService.java
@@ -1,5 +1,7 @@
 package com.tracepcap.analysis.service;
 
+import com.tracepcap.analysis.entity.AnalysisResultEntity;
+import com.tracepcap.analysis.repository.AnalysisResultRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +15,8 @@ import org.springframework.stereotype.Service;
 public class AsyncAnalysisService {
 
   private final AnalysisService analysisService;
+  private final AnalysisRecordService analysisRecordService;
+  private final AnalysisResultRepository analysisResultRepository;
 
   @Async("asyncAnalysisExecutor")
   public void analyzeFileAsync(UUID fileId) {
@@ -22,6 +26,27 @@ public class AsyncAnalysisService {
       log.info("Completed async analysis for file: {}", fileId);
     } catch (Exception e) {
       log.error("Failed async analysis for file {}: {}", fileId, e.getMessage(), e);
+      markFailedIfStillPending(fileId, e);
+    }
+  }
+
+  /**
+   * Records a failure that {@code analyzeFile} could not record itself.
+   *
+   * <p>Its own catch block handles anything thrown inside the method. It cannot handle a failure at
+   * commit: a best-effort catch inside the pipeline can leave the transaction rollback-only, and
+   * the proxy then throws {@code UnexpectedRollbackException} after {@code analyzeFile} has already
+   * returned. This runs outside that transaction, so it is the last place able to say what
+   * happened — without it the file sits in PROCESSING until the reconciliation cron notices.
+   */
+  private void markFailedIfStillPending(UUID fileId, Exception cause) {
+    try {
+      analysisResultRepository
+          .findByFileId(fileId)
+          .filter(a -> a.getStatus() != AnalysisResultEntity.AnalysisStatus.FAILED)
+          .ifPresent(a -> analysisRecordService.markFailed(a.getId(), fileId, cause.getMessage()));
+    } catch (Exception markEx) {
+      log.error("Could not mark analysis for file {} as FAILED: {}", fileId, markEx.getMessage());
     }
   }
 }

--- a/backend/src/test/java/com/tracepcap/analysis/service/AnalysisTransactionBoundaryTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/service/AnalysisTransactionBoundaryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -25,12 +26,26 @@ class AnalysisTransactionBoundaryTest {
   void analyzeFileIsTransactional() throws Exception {
     Method analyze = AnalysisService.class.getMethod("analyzeFile", java.util.UUID.class);
 
-    assertThat(analyze.isAnnotationPresent(Transactional.class))
+    Transactional tx = analyze.getAnnotation(Transactional.class);
+
+    assertThat(tx)
         .as(
             "analyzeFile writes conversations and packets in a batch and calls "
                 + "EntityManager.flush() every %d conversations; without a transaction that throws "
                 + "on any capture large enough to reach the flush",
             50)
-        .isTrue();
+        .isNotNull();
+
+    // Presence alone is not the property. readOnly = true is a plausible copy-paste from the four
+    // read-only methods below this one, and NOT_SUPPORTED suspends the transaction outright —
+    // both would satisfy isAnnotationPresent while reproducing the bug exactly.
+    assertThat(tx.readOnly()).as("a read-only transaction cannot flush writes").isFalse();
+    assertThat(tx.propagation())
+        .as("the pipeline must run inside a real transaction, not with one suspended")
+        .isIn(Propagation.REQUIRED, Propagation.REQUIRES_NEW);
+
+    // AdjudicatorRunner listens for AnalysisCompletedEvent on AFTER_COMMIT. With no transaction
+    // there is no commit, so identity adjudication was skipped for every file — including the
+    // small ones that appeared to analyse fine.
   }
 }

--- a/backend/src/test/java/com/tracepcap/analysis/service/AnalysisTransactionBoundaryTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/service/AnalysisTransactionBoundaryTest.java
@@ -1,0 +1,36 @@
+package com.tracepcap.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * {@code analyzeFile} must run in a transaction.
+ *
+ * <p>#750 removed the annotation while restructuring the method, and nothing noticed. It compiles,
+ * every unit test passes, and small captures analyse fine — JPA autocommits each save on its own.
+ * The failure needs more than {@code JPA_FLUSH_INTERVAL} (50) conversations in one capture, because
+ * only then does the batch flush run, and {@code EntityManager.flush()} outside a transaction
+ * throws {@code TransactionRequiredException}. Every fixture used to verify that change was smaller
+ * than that, so the pipeline reported success on small files and failed on real ones.
+ *
+ * <p>An annotation assertion is a blunt test, and the right one here: the defect was not bad logic,
+ * it was a silently deleted line that no behavioural test in reach could see.
+ */
+class AnalysisTransactionBoundaryTest {
+
+  @Test
+  void analyzeFileIsTransactional() throws Exception {
+    Method analyze = AnalysisService.class.getMethod("analyzeFile", java.util.UUID.class);
+
+    assertThat(analyze.isAnnotationPresent(Transactional.class))
+        .as(
+            "analyzeFile writes conversations and packets in a batch and calls "
+                + "EntityManager.flush() every %d conversations; without a transaction that throws "
+                + "on any capture large enough to reach the flush",
+            50)
+        .isTrue();
+  }
+}


### PR DESCRIPTION
**Production-breaking regression I introduced in #750.** Analysis fails on any capture with more than 50 conversations, and the file's summary then returns 500 — *"Failed to Load Analysis"*.

## What broke

#750 restructured `analyzeFile` into per-stage methods. My rewrite replaced the method region starting from the blank line above it, meaning to preserve a preceding javadoc. `@Transactional` sat on that line and went with it.

```java
-  @Transactional
   public void analyzeFile(UUID fileId) {
```

## Why it looked fine

Without a transaction, JPA autocommits each `save()` individually, so analysis **appears to work**. The failure needs a capture with more than `JPA_FLUSH_INTERVAL` (50) conversations, because only then does the batch flush run — and `EntityManager.flush()` outside a transaction throws `TransactionRequiredException`, failing the whole analysis.

Every fixture I verified #750 with was below that line. `ftp.pcap` has **5 conversations**. So the pipeline genuinely reported success, in order, all seven stages, on a file that could never hit the bug. The full-stack CI job uses a small fixture too, which is why it stayed green through this and four subsequent merges.

## Verification

A 184-conversation capture, which crosses the flush boundary three times:

```
[2/7] PCAP parse: 806ms  (1500 packets, 184 conversations)
[6/7] DB inserts done: 236ms  (184 conversations, 1500 packets)
Analysis complete: total 47741ms
GET /api/v1/analysis/{id}/summary -> 200
```

The file analysed while the bug was live still returns 500 — its record is genuinely incomplete and needs re-analysing. That is data, not a code path.

## The test

An annotation assertion, which is blunt and is the right shape here: the defect was not bad logic, it was a deleted line. It fails without the fix.

It does not close the real gap, which is that **nothing exercises the analysis write path against a real database with enough conversations to flush**. That wants a Testcontainers test with a >50-conversation fixture, and a bigger fixture for the full-stack CI job. Filing separately rather than bundling it into a hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)