### PR TITLE
ci: make dev the integration branch and main the release branch

### DIFF
--- a/.github/workflows/app-version.yml
+++ b/.github/workflows/app-version.yml
@@ -1,7 +1,7 @@
 name: Sync App Version
 
 # Keeps the VITE_APP_VERSION default in docker-compose.yml pointing at the latest
-# main commit, so a plain `docker compose up -d --build` bakes in a real version
+# dev commit, so a plain `docker compose up -d --build` bakes in a real version
 # with no local setup. Compose only interpolates ${...} from the shell env and .env
 # (which is gitignored), so the value has to live in the compose file itself.
 #
@@ -15,7 +15,7 @@ name: Sync App Version
 on:
   push:
     branches:
-      - main
+      - dev
 
 # Serialise runs so two quick merges to main can't open competing bump PRs.
 concurrency:
@@ -96,10 +96,10 @@ jobs:
           PR_URL=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // empty')
           if [ -z "$PR_URL" ]; then
             PR_URL=$(gh pr create \
-              --base main \
+              --base dev \
               --head "$BRANCH" \
               --title "chore: sync app version to ${VERSION}" \
-              --body "Automated: keeps the VITE_APP_VERSION default in docker-compose.yml pointing at the latest main commit. Opened by .github/workflows/app-version.yml.")
+              --body "Automated: keeps the VITE_APP_VERSION default in docker-compose.yml pointing at the latest dev commit. Opened by .github/workflows/app-version.yml.")
           fi
 
           # Step off the bump branch: git refuses to delete a checked-out branch.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - "docs/**"
   pull_request:

--- a/.github/workflows/minio-policy.yml
+++ b/.github/workflows/minio-policy.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - 'docker-compose*.yml'
       - 'scripts/check_minio_policy.py'

--- a/.github/workflows/shared-vocabulary.yml
+++ b/.github/workflows/shared-vocabulary.yml
@@ -25,6 +25,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - 'backend/src/main/java/**'
       - 'frontend/src/**'

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     paths:
       - 'backend/**'

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     paths:
       - 'backend/**'

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     paths:
       - 'frontend/**'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,15 @@ Only build a custom component if SGDS has no equivalent.
 - **Forms that create/edit a thing** (add evidence, override a label, add a snapshot) belong in an **SGDS `Modal`**, not an inline expanding panel — keep the surface uncluttered and the action focused.
 - Keep the copy inside these modals task-oriented: say what the thing is and how to act on it (e.g. "click a badge to inspect it and add evidence").
 
+## Branching
+
+- `dev` is the default and integration branch; `main` is the release branch.
+- Branch from `dev`, and open PRs **against `dev`**. Never open a PR against `main` except the
+  periodic `dev` -> `main` release PR, and never commit to `main` directly.
+- `dev` runs the same gates as `main` and is expected to be green.
+- See CONTRIBUTING.md for what runs where and how to cut a release.
+
+
 ## Stack
 
 - **Frontend**: React + TypeScript + Vite, served via nginx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,53 @@ Thanks for contributing! This guide covers workflows that aren't obvious from th
 code alone. For architecture and coding conventions (stack, UI components, REST
 API rules, the offline requirement), see [`CLAUDE.md`](./CLAUDE.md).
 
+## Branching
+
+`dev` is the integration branch and the default. `main` is the release branch.
+
+```
+feature/xyz ──PR──> dev ──PR──> main
+                     ▲            │
+                 everything    releases only
+                  lands here   (publishes images)
+```
+
+**Everyday work targets `dev`.** Branch from it, open the PR against it, merge when the gates
+pass. `dev` is expected to be green at all times — it runs the same checks as `main`, so
+"integration branch" does not mean "allowed to be broken".
+
+**`main` only ever receives a PR from `dev`,** cut when you want a release. Nothing else merges
+into it, and nothing is committed to it directly. That rule is what makes `main` mean something:
+if a commit is on `main`, it went through `dev` and a full CI run first.
+
+### Why the split
+
+`main` used to take every merge directly, which meant its history and "the current state of the
+work" were the same thing — there was no point at which you could say *this is a version we
+stand behind*. Releases publish container images from `main` (`publish-ghcr.yml`), so that
+distinction is not academic: whatever is on `main` is what someone can pull.
+
+### What runs where
+
+| | on a PR | on push to `dev` | on push to `main` |
+|---|---|---|---|
+| tests, lint, contract and vocabulary gates | yes | yes | yes |
+| version stamp (`app-version.yml`) | — | yes, PR into `dev` | — |
+| container publish (`publish-ghcr.yml`) | — | — | yes |
+
+The version stamp runs on `dev` deliberately. If its chore PR landed on `main`, `main` would
+drift ahead of `dev` and every later release would start from a diverged base. At release time
+`dev` and `main` are equal, so stamping from `dev` still records exactly the released commit.
+
+### Cutting a release
+
+```bash
+gh pr create --base main --head dev --title "release: <summary>"
+```
+
+Review the accumulated diff, let CI run, merge. The merge to `main` publishes the images.
+
+
 ## API Contract Workflow
 
 The REST API has a committed contract snapshot at


### PR DESCRIPTION
Sets up the branching model you asked for. **This PR targets `dev`, so it is also the first use of the flow it introduces.**

```
feature/xyz ──PR──> dev ──PR──> main
                     ▲            │
                 everything    releases only
                  lands here   (publishes images)
```

## Why it matters here specifically

Everything has been merging straight into `main`, which meant `main`'s history and "the current state of the work" were the same thing — there was no point at which you could say *this is a version we stand behind*.

That is not academic in this repo: `publish-ghcr.yml` builds and pushes container images on every push to `main`. Whatever lands on `main` is what someone can `docker pull`. Today's `@Transactional` regression sat on `main` — and therefore in published images — through four subsequent merges.

## What changed

- **`dev` is now the default branch.** New PRs target it automatically.
- **Gates run on both branches** — tests, lint, contract, vocabulary, minio policy, docs, system tests. `dev` is expected to be green; "integration branch" does not mean "allowed to be broken".
- **`publish-ghcr.yml` stays `main`-only.** Publishing is what a release *is*.
- **`app-version.yml` moves to `dev`**, and opens its chore PR into `dev` rather than `main`.

That last one is the non-obvious bit. If the version-stamp PR landed on `main`, `main` would drift ahead of `dev`, and every later `dev → main` release would start from a diverged base — you would be merging a branch that is simultaneously ahead and behind. At release time the two branches are equal, so stamping from `dev` still records exactly the released commit.

## Cutting a release

```bash
gh pr create --base main --head dev --title "release: <summary>"
```

Review the accumulated diff, let CI run, merge — the merge publishes the images.

## Not included: branch protection

I have not added a rule blocking direct pushes to `main`, because a misconfigured protection rule can lock you out of your own repository and I would rather you choose the settings. The default-branch change already does the practical work (PRs target `dev` unless you say otherwise).

If you want it enforced rather than conventional, the useful rule on `main` is: require a pull request, and require the same status checks that `dev` runs. Say the word and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for the branching and release workflow, including integration and release branch responsibilities.
  - Documented pull request requirements, CI expectations, version stamping, container publishing, and release procedures.

- **Chores**
  - Expanded automated documentation, testing, policy, and versioning workflows to run against the development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->