### PR TITLE
docs: main stays the default branch, dev is opt-in per PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ Only build a custom component if SGDS has no equivalent.
 
 ## Branching
 
-- `dev` is the default and integration branch; `main` is the release branch.
+- `dev` is the integration branch; `main` is the release branch and remains the repo default.
+- **`gh pr create` defaults to `main`, which is wrong for everyday work — always pass
+  `--base dev` explicitly.**
 - Branch from `dev`, and open PRs **against `dev`**. Never open a PR against `main` except the
   periodic `dev` -> `main` release PR, and never commit to `main` directly.
 - `dev` runs the same gates as `main` and is expected to be green.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,16 @@ API rules, the offline requirement), see [`CLAUDE.md`](./CLAUDE.md).
 
 ## Branching
 
-`dev` is the integration branch and the default. `main` is the release branch.
+`dev` is the integration branch. `main` is the release branch, and stays the **default** — it is
+what a visitor to the repository sees and what a plain `git clone` checks out, so it should show
+the released state rather than work in progress.
+
+The cost of that choice is that `gh pr create` and the GitHub UI both default to `main`, which is
+**not** where everyday work goes. Pass the base explicitly:
+
+```bash
+gh pr create --base dev
+```
 
 ```
 feature/xyz ──PR──> dev ──PR──> main
@@ -15,8 +24,8 @@ feature/xyz ──PR──> dev ──PR──> main
                   lands here   (publishes images)
 ```
 
-**Everyday work targets `dev`.** Branch from it, open the PR against it, merge when the gates
-pass. `dev` is expected to be green at all times — it runs the same checks as `main`, so
+**Everyday work targets `dev`.** Branch from it, open the PR against it with `--base dev`, and
+merge when the gates pass. `dev` is expected to be green at all times — it runs the same checks as `main`, so
 "integration branch" does not mean "allowed to be broken".
 
 **`main` only ever receives a PR from `dev`,** cut when you want a release. Nothing else merges


### PR DESCRIPTION
Correcting #769. I switched the repository default to `dev`; that was wrong.

`main` is what a visitor to the repository sees and what a plain `git clone` checks out, so it should show the **released** state rather than work in progress. The default is back to `main`.

## The trade-off, written down rather than discovered

With `main` as default, `gh pr create` and the GitHub UI both target `main` — which is *not* where everyday work goes. That is a foot-gun that will fire the first time someone forgets, and the failure is silent: the PR looks fine, it just aims at the release branch.

So both docs now say it explicitly:

```bash
gh pr create --base dev
```

`CLAUDE.md` states it in the imperative, since that is the one place the mistake actually gets made in practice.

## Note on the outage

`main` already carries the `@Transactional` fix — f8603a9, merged before `dev` was cut, and I verified the annotation is present on `origin/main`. The published images are not carrying the regression.

`dev` is currently 2 commits ahead: the branching workflow itself and its version stamp. Cutting the first `dev → main` release next so `main` picks those up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)