### PR TITLE
release: branching workflow, and today's fixes on main

### DIFF
--- a/.github/workflows/app-version.yml
+++ b/.github/workflows/app-version.yml
@@ -1,7 +1,7 @@
 name: Sync App Version
 
 # Keeps the VITE_APP_VERSION default in docker-compose.yml pointing at the latest
-# main commit, so a plain `docker compose up -d --build` bakes in a real version
+# dev commit, so a plain `docker compose up -d --build` bakes in a real version
 # with no local setup. Compose only interpolates ${...} from the shell env and .env
 # (which is gitignored), so the value has to live in the compose file itself.
 #
@@ -15,7 +15,7 @@ name: Sync App Version
 on:
   push:
     branches:
-      - main
+      - dev
 
 # Serialise runs so two quick merges to main can't open competing bump PRs.
 concurrency:
@@ -96,10 +96,10 @@ jobs:
           PR_URL=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // empty')
           if [ -z "$PR_URL" ]; then
             PR_URL=$(gh pr create \
-              --base main \
+              --base dev \
               --head "$BRANCH" \
               --title "chore: sync app version to ${VERSION}" \
-              --body "Automated: keeps the VITE_APP_VERSION default in docker-compose.yml pointing at the latest main commit. Opened by .github/workflows/app-version.yml.")
+              --body "Automated: keeps the VITE_APP_VERSION default in docker-compose.yml pointing at the latest dev commit. Opened by .github/workflows/app-version.yml.")
           fi
 
           # Step off the bump branch: git refuses to delete a checked-out branch.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - "docs/**"
   pull_request:

--- a/.github/workflows/minio-policy.yml
+++ b/.github/workflows/minio-policy.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - 'docker-compose*.yml'
       - 'scripts/check_minio_policy.py'

--- a/.github/workflows/shared-vocabulary.yml
+++ b/.github/workflows/shared-vocabulary.yml
@@ -25,6 +25,7 @@ on:
   push:
     branches:
       - main
+      - dev
     paths:
       - 'backend/src/main/java/**'
       - 'frontend/src/**'

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     paths:
       - 'backend/**'

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     paths:
       - 'backend/**'

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     paths:
       - 'frontend/**'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ Only build a custom component if SGDS has no equivalent.
 
 ## Branching
 
-- `dev` is the default and integration branch; `main` is the release branch.
+- `dev` is the integration branch; `main` is the release branch and remains the repo default.
+- **`gh pr create` defaults to `main`, which is wrong for everyday work — always pass
+  `--base dev` explicitly.**
 - Branch from `dev`, and open PRs **against `dev`**. Never open a PR against `main` except the
   periodic `dev` -> `main` release PR, and never commit to `main` directly.
 - `dev` runs the same gates as `main` and is expected to be green.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,15 @@ Only build a custom component if SGDS has no equivalent.
 - **Forms that create/edit a thing** (add evidence, override a label, add a snapshot) belong in an **SGDS `Modal`**, not an inline expanding panel — keep the surface uncluttered and the action focused.
 - Keep the copy inside these modals task-oriented: say what the thing is and how to act on it (e.g. "click a badge to inspect it and add evidence").
 
+## Branching
+
+- `dev` is the default and integration branch; `main` is the release branch.
+- Branch from `dev`, and open PRs **against `dev`**. Never open a PR against `main` except the
+  periodic `dev` -> `main` release PR, and never commit to `main` directly.
+- `dev` runs the same gates as `main` and is expected to be green.
+- See CONTRIBUTING.md for what runs where and how to cut a release.
+
+
 ## Stack
 
 - **Frontend**: React + TypeScript + Vite, served via nginx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,53 @@ Thanks for contributing! This guide covers workflows that aren't obvious from th
 code alone. For architecture and coding conventions (stack, UI components, REST
 API rules, the offline requirement), see [`CLAUDE.md`](./CLAUDE.md).
 
+## Branching
+
+`dev` is the integration branch and the default. `main` is the release branch.
+
+```
+feature/xyz ──PR──> dev ──PR──> main
+                     ▲            │
+                 everything    releases only
+                  lands here   (publishes images)
+```
+
+**Everyday work targets `dev`.** Branch from it, open the PR against it, merge when the gates
+pass. `dev` is expected to be green at all times — it runs the same checks as `main`, so
+"integration branch" does not mean "allowed to be broken".
+
+**`main` only ever receives a PR from `dev`,** cut when you want a release. Nothing else merges
+into it, and nothing is committed to it directly. That rule is what makes `main` mean something:
+if a commit is on `main`, it went through `dev` and a full CI run first.
+
+### Why the split
+
+`main` used to take every merge directly, which meant its history and "the current state of the
+work" were the same thing — there was no point at which you could say *this is a version we
+stand behind*. Releases publish container images from `main` (`publish-ghcr.yml`), so that
+distinction is not academic: whatever is on `main` is what someone can pull.
+
+### What runs where
+
+| | on a PR | on push to `dev` | on push to `main` |
+|---|---|---|---|
+| tests, lint, contract and vocabulary gates | yes | yes | yes |
+| version stamp (`app-version.yml`) | — | yes, PR into `dev` | — |
+| container publish (`publish-ghcr.yml`) | — | — | yes |
+
+The version stamp runs on `dev` deliberately. If its chore PR landed on `main`, `main` would
+drift ahead of `dev` and every later release would start from a diverged base. At release time
+`dev` and `main` are equal, so stamping from `dev` still records exactly the released commit.
+
+### Cutting a release
+
+```bash
+gh pr create --base main --head dev --title "release: <summary>"
+```
+
+Review the accumulated diff, let CI run, merge. The merge to `main` publishes the images.
+
+
 ## API Contract Workflow
 
 The REST API has a committed contract snapshot at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,16 @@ API rules, the offline requirement), see [`CLAUDE.md`](./CLAUDE.md).
 
 ## Branching
 
-`dev` is the integration branch and the default. `main` is the release branch.
+`dev` is the integration branch. `main` is the release branch, and stays the **default** — it is
+what a visitor to the repository sees and what a plain `git clone` checks out, so it should show
+the released state rather than work in progress.
+
+The cost of that choice is that `gh pr create` and the GitHub UI both default to `main`, which is
+**not** where everyday work goes. Pass the base explicitly:
+
+```bash
+gh pr create --base dev
+```
 
 ```
 feature/xyz ──PR──> dev ──PR──> main
@@ -15,8 +24,8 @@ feature/xyz ──PR──> dev ──PR──> main
                   lands here   (publishes images)
 ```
 
-**Everyday work targets `dev`.** Branch from it, open the PR against it, merge when the gates
-pass. `dev` is expected to be green at all times — it runs the same checks as `main`, so
+**Everyday work targets `dev`.** Branch from it, open the PR against it with `--base dev`, and
+merge when the gates pass. `dev` is expected to be green at all times — it runs the same checks as `main`, so
 "integration branch" does not mean "allowed to be broken".
 
 **`main` only ever receives a PR from `dev`,** cut when you want a release. Nothing else merges

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-334-gf8603a9}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-336-gecab425}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-336-gecab425}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-338-g2ded9ff}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:


### PR DESCRIPTION
First `dev → main` release, cut with the flow it introduces.

## What is in it

| | |
|---|---|
| #769 | `dev` as the integration branch, `main` as the release branch; gates run on both |
| #771 | correction — `main` stays the repository **default**; `--base dev` is explicit per PR |
| #770 | version stamp |

Three commits. Everything else that landed today was merged to `main` directly, before the branching change existed.

## On the outage

**`main` was already fixed.** The `@Transactional` regression was repaired in #766 and merged to `main` (f8603a9) before `dev` was cut, and I verified the annotation is present on `origin/main`. Published images are not carrying it.

Worth being precise about the window, though: the regression landed in #750 and was fixed in #766, and `publish-ghcr.yml` builds an image on **every** push to `main`. So images published between those two points do carry it — analysis fails on any capture with more than 50 conversations, and host-identity adjudication is skipped on all of them. Anything pulled from that window should be replaced with a build from `main` at f8603a9 or later.

That window is the argument for this release branch existing. From here, a regression has to survive `dev` and a release review before it can reach a published image.

## After this merges

`main` and `dev` are equal, and the next feature PR targets `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)