### PR TITLE
docs: record why dev is protected (it was deleted by its own release)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,20 @@ The version stamp runs on `dev` deliberately. If its chore PR landed on `main`, 
 drift ahead of `dev` and every later release would start from a diverged base. At release time
 `dev` and `main` are equal, so stamping from `dev` still records exactly the released commit.
 
+### Why `dev` is a protected branch
+
+The repository has **"Automatically delete head branches"** enabled, which is what keeps merged
+feature branches from piling up. A release PR's head branch is `dev` — so the first `dev -> main`
+release deleted `dev` on merge. It came back from `main` with nothing lost, because the two are
+identical at exactly that moment, but every open PR based on `dev` would have been orphaned.
+
+`dev` is therefore protected with `allow_deletions: false`, matching `main`. GitHub will not
+delete a protected branch, so the setting keeps tidying feature branches and cannot touch either
+long-lived one.
+
+The `delete-branch-on-close.yml` workflow already treats a 422 as "protected, leave it", so it
+needs no exclusion list — the protection is the exclusion list.
+
 ### Cutting a release
 
 ```bash


### PR DESCRIPTION
`dev` vanished after the first release. Diagnosed, restored, and prevented.

## What happened

The repository has **"Automatically delete head branches"** enabled — that is what keeps merged feature branches from piling up, and it is why the branch list has stayed clean all day.

A release PR's head branch is `dev`. So merging #773 (`dev → main`) deleted `dev`.

The `delete-branch-on-close.yml` workflow was not responsible and correctly skipped it; the run log shows `head=dev … skipped`. It only handles PRs closed *without* merging. The repo-level setting handles the merged case, and it does not know `dev` is special.

## Why it was harmless this time, and would not be next time

`main` and `dev` are identical at exactly the moment a release merges, so recreating `dev` from `main` restored it byte-for-byte. Nothing was lost.

That is luck about timing, not a property worth relying on: **every open PR based on `dev` would have been orphaned**, and on a normal day that is most of them.

## The fix

`dev` now has `allow_deletions: false`, matching `main` — which is exactly why `main` survives the same setting. GitHub will not delete a protected branch, so the setting keeps tidying feature branches and cannot touch either long-lived one.

No workflow change needed: `delete-branch-on-close.yml` already treats a 422 as *"protected, leave it"*. The protection **is** the exclusion list, in one place, rather than a second list that could drift from it.

Documented in CONTRIBUTING.md so the next person to wonder why `dev` is protected finds the answer instead of removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)