### PR TITLE
fix: weight the progress bar from measurement, not estimate (#758)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -70,23 +70,53 @@ public class AnalysisService {
   private record StageStep(String label, int weight) {}
 
   /** Builds the ordered list of stages that will run for {@code file}, given its enabled options. */
-  private static List<StageStep> buildStagePlan(FileEntity file) {
-    boolean ndpi = file.isEnableNdpi();
-    // Weight only: the effective Suricata state (incl. the global kill-switch) is decided inside the
-    // extractor; using the per-file flag here is a close-enough heuristic for bar proportions.
+  /**
+   * Relative stage weights for the progress bar (#758).
+   *
+   * <p>The previous numbers were a reasonable guess that did not survive measurement: they put
+   * "Detecting applications & threats" at 35% of the job when it was 95%, so the bar sat at 23%
+   * for the whole of a 46-second analysis and then swept to 100% in under two seconds. A bar that
+   * is motionless for most of a job teaches people to ignore it, and an operator who cannot tell
+   * "working" from "hung" kills a job that was fine.
+   *
+   * <p>These are measured shares from real runs rather than estimates. Two profiles, because one
+   * vector cannot describe both: Suricata's detection engine costs ~45 s to build and ~0.3 s to
+   * use, so the first capture after a restart has a completely different shape from every capture
+   * after it (#569). {@link SuricataEngine#isWarm()} says which one we are in.
+   *
+   * <p>Still approximate for a different reason: parsing and the database writes scale with the
+   * capture while the rest does not, so these shares are right for a mid-sized capture and drift
+   * at the extremes. Re-weighting from the packet count once parsing has finished is the next step
+   * and is deliberately not attempted here.
+   */
+  private List<StageStep> buildStagePlan(FileEntity file) {
+    boolean extraction = file.isEnableFileExtraction();
+    // The per-file flag, not the effective state: the kill-switch is the extractor's business.
+    // Only the weighting depends on this, so being wrong costs a slightly misshapen bar.
     boolean suricata = file.isEnableSuricata();
+    boolean coldEngine = suricata && !suricataEngine.isWarm();
+
     List<StageStep> plan = new ArrayList<>();
     plan.add(new StageStep("Downloading capture", 3));
-    plan.add(new StageStep("Parsing packets", 20));
-    plan.add(new StageStep("Detecting applications & threats", 5 + (ndpi ? 10 : 0) + (suricata ? 20 : 0)));
-    plan.add(new StageStep("Classifying hosts & geo-locating", 12));
-    plan.add(new StageStep("Saving analysis summary", 2));
-    plan.add(new StageStep("Writing conversations & packets", 20));
-    if (file.isEnableFileExtraction()) {
-      plan.add(new StageStep("Extracting transferred files", 8));
+    plan.add(new StageStep("Parsing packets", coldEngine ? 2 : 21));
+    // The one stage whose cost is not about this capture at all: on a cold engine it is the
+    // ruleset build, which dwarfs everything else and is paid once per process.
+    // Labelled for what it is on a cold engine. The bar cannot move inside a stage, so this one
+    // stands still for ~45s however it is weighted; naming the wait as one-time setup is the
+    // difference between "hung" and "working on something known to be slow".
+    plan.add(
+        coldEngine
+            ? new StageStep("Building threat-detection ruleset (first run)", 90)
+            : new StageStep("Detecting applications & threats", 21));
+    plan.add(new StageStep("Classifying hosts & geo-locating", coldEngine ? 2 : 30));
+    plan.add(new StageStep("Saving analysis summary", 1));
+    plan.add(new StageStep("Writing conversations & packets", coldEngine ? 1 : 4));
+    if (extraction) {
+      plan.add(new StageStep("Extracting transferred files", coldEngine ? 1 : 22));
     }
     return plan;
   }
+
 
   /**
    * Publishes progress for the stage at {@code index} (0-based). {@code percent} is the weighted
@@ -134,6 +164,7 @@ public class AnalysisService {
   private final HostnameAdjudicator hostnameAdjudicator;
   private final org.springframework.context.ApplicationEventPublisher eventPublisher;
   private final HostnameClaimWriter hostnameClaimWriter;
+  private final SuricataEngine suricataEngine;
 
   /**
    * Runs the capture through the pipeline (#512 slice 7).

--- a/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
@@ -76,12 +76,31 @@ public class SuricataEngine {
   private final ReentrantLock lock = new ReentrantLock();
   private volatile Process daemon;
 
+  /**
+   * Whether the engine has finished building its ruleset.
+   *
+   * <p>A plain flag rather than a probe: callers ask this to size a progress bar, and shelling out
+   * to suricatasc to answer would cost more than the question is worth.
+   */
+  private volatile boolean warm;
+
+  /**
+   * Whether the next capture can skip the ~45 s detection-engine build (#569).
+   *
+   * <p>Progress estimation needs this because it is the difference between one stage taking 0.3 s
+   * and taking 45 s, and no static weighting can describe both (#758).
+   */
+  public boolean isWarm() {
+    return warm && daemon != null && daemon.isAlive();
+  }
+
   /** Where a warm run writes, kept apart from the caller's fallback output. */
   public static Path warmDir(Path outDir) {
     return outDir.resolve("warm");
   }
 
   private void discardDaemon() {
+    warm = false;
     Process p = daemon;
     daemon = null;
     if (p != null && p.isAlive()) p.destroyForcibly();
@@ -143,6 +162,7 @@ public class SuricataEngine {
         }
         if (isResponsive()) {
           log.info("Warm Suricata engine ready");
+          warm = true;
           return true;
         }
         Thread.sleep(1000);

--- a/backend/src/test/java/com/tracepcap/analysis/service/StagePlanWeightingTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/service/StagePlanWeightingTest.java
@@ -1,0 +1,147 @@
+package com.tracepcap.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.tracepcap.file.entity.FileEntity;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Progress weighting (#758).
+ *
+ * <p>The bar's job is to distinguish "working" from "hung". It failed at that: the old weights put
+ * the detection stage at 35% of the job when it was 95%, so the bar reached 23% almost immediately,
+ * sat there for 44 seconds, then swept to 100% in under two.
+ *
+ * <p>These assert the shape rather than exact numbers — the numbers are measured shares and will be
+ * re-measured when the pipeline changes, but the shape must hold: no stage may claim a share wildly
+ * unlike what it costs, and the cold and warm profiles must genuinely differ.
+ */
+class StagePlanWeightingTest {
+
+  private final SuricataEngine engine = mock(SuricataEngine.class);
+  private final AnalysisService service = serviceWithOnlyTheEngineWired();
+
+  /** 23 collaborators, one of which the plan needs; the rest are irrelevant to weighting. */
+  private AnalysisService serviceWithOnlyTheEngineWired() {
+    try {
+      var ctor = AnalysisService.class.getDeclaredConstructors()[0];
+      ctor.setAccessible(true);
+      Object[] args = new Object[ctor.getParameterCount()];
+      AnalysisService s = (AnalysisService) ctor.newInstance(args);
+      ReflectionTestUtils.setField(s, "suricataEngine", engine);
+      return s;
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("AnalysisService's constructor changed — update this test", e);
+    }
+  }
+
+  private static FileEntity file(boolean suricata, boolean extraction) {
+    FileEntity f = new FileEntity();
+    f.setEnableSuricata(suricata);
+    f.setEnableNdpi(true);
+    f.setEnableFileExtraction(extraction);
+    return f;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<?> plan(FileEntity f) {
+    try {
+      Method m = AnalysisService.class.getDeclaredMethod("buildStagePlan", FileEntity.class);
+      m.setAccessible(true);
+      return (List<Object>) m.invoke(service, f);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("buildStagePlan changed — update this test", e);
+    }
+  }
+
+  private int weightOf(Object step) {
+    return (int) ReflectionTestUtils.invokeGetterMethod(step, "weight");
+  }
+
+  private String labelOf(Object step) {
+    return (String) ReflectionTestUtils.invokeGetterMethod(step, "label");
+  }
+
+  private double shareOf(List<?> plan, String labelFragment) {
+    int total = plan.stream().mapToInt(this::weightOf).sum();
+    return plan.stream()
+            .filter(s -> labelOf(s).contains(labelFragment))
+            .mapToInt(this::weightOf)
+            .sum()
+        * 100.0
+        / total;
+  }
+
+  @Test
+  void onAColdEngineTheDetectionStageOwnsAlmostTheWholeBar() {
+    // Measured: 94.7% of a 47s first-run analysis is the ruleset build. Anything close to an
+    // even split here is what produced the 23%-for-95%-of-the-run stall.
+    when(engine.isWarm()).thenReturn(false);
+
+    assertThat(shareOf(plan(file(true, true)), "ruleset")).isGreaterThan(80.0);
+  }
+
+  @Test
+  void onAWarmEngineTheWorkIsSpreadAcrossStages() {
+    // Measured warm shares: parse 21%, detect 21%, classify 30%, extract-files 22%.
+    when(engine.isWarm()).thenReturn(true);
+    List<?> plan = plan(file(true, true));
+
+    assertThat(shareOf(plan, "Detecting")).isBetween(10.0, 35.0);
+    assertThat(shareOf(plan, "Classifying")).isBetween(15.0, 45.0);
+    assertThat(shareOf(plan, "Parsing")).isBetween(10.0, 35.0);
+  }
+
+  @Test
+  void theTwoProfilesAreActuallyDifferent() {
+    // The bug this fixes is one vector describing two very different jobs.
+    when(engine.isWarm()).thenReturn(false);
+    double cold = shareOf(plan(file(true, true)), "ruleset");
+    when(engine.isWarm()).thenReturn(true);
+    double warm = shareOf(plan(file(true, true)), "Detecting");
+
+    assertThat(cold - warm).isGreaterThan(40.0);
+  }
+
+  @Test
+  void aColdEngineSaysWhyItIsSlowAndThatItIsOneOff() {
+    // The bar cannot advance inside a stage, so this one is motionless for ~45s no matter how it
+    // is weighted. The label is what separates "hung" from "working on something known to be
+    // slow, once".
+    when(engine.isWarm()).thenReturn(false);
+
+    assertThat(plan(file(true, true)).stream().map(this::labelOf))
+        .anySatisfy(l -> assertThat(l).containsIgnoringCase("first run"));
+  }
+
+  @Test
+  void withSuricataOffTheColdPenaltyDoesNotApply() {
+    // No ruleset to build, so the first capture looks like every other one.
+    when(engine.isWarm()).thenReturn(false);
+
+    assertThat(shareOf(plan(file(false, true)), "Detecting")).isLessThan(35.0);
+    assertThat(plan(file(false, true)).stream().map(this::labelOf))
+        .noneSatisfy(l -> assertThat(l).containsIgnoringCase("first run"));
+  }
+
+  @Test
+  void theFileExtractionStageIsOnlyPlannedWhenItWillRun() {
+    when(engine.isWarm()).thenReturn(true);
+
+    assertThat(plan(file(true, false))).hasSize(6);
+    assertThat(plan(file(true, true))).hasSize(7);
+  }
+
+  @Test
+  void noStageIsWeightedZeroSoTheBarNeverStandsStill() {
+    // A zero-weight stage advances the bar by nothing while it runs, which reads as a hang.
+    when(engine.isWarm()).thenReturn(true);
+
+    assertThat(plan(file(true, true))).allSatisfy(s -> assertThat(weightOf(s)).isPositive());
+  }
+}


### PR DESCRIPTION
Closes #758. Due because #759 changed the thing the weights were modelling.

## The problem

The bar reached **23% almost immediately, sat there for 44 of a 47-second analysis**, then swept to 100% in under two seconds. A bar that is motionless for most of a job teaches people to ignore it — and an operator who cannot tell *working* from *hung* kills a job that was fine.

The weights were a plausible guess that did not survive measurement: detection at 35% of the job when it was 95%, database writes at 20% when they were 0.6%.

## Two profiles, because one vector cannot describe both

Suricata's detection engine costs ~45s to build and ~0.3s to use (#759). So the **first capture after a restart has a completely different shape from every capture after it**, and no single weighting is right for both. `SuricataEngine.isWarm()` says which one we are in.

Measured shares from real runs, not estimates:

| stage | cold plan | warm plan | measured warm |
|---|---|---|---|
| Parsing packets | 2 | 21 | 21.0% |
| Detection | **90** | 21 | 21.0% |
| Classifying + geo | 2 | 30 | 29.6% |
| Writing conversations | 1 | 4 | 3.4% |
| Extracting files | 1 | 22 | 22.2% |

(cold detection measured at 94.7% of a 47s first run)

## Verified live, not just in tests

**Cold** — now honest about proportion, and says why it is slow:
```
  0%  Downloading capture
  5%  Building threat-detection ruleset (first run)
  5%  Building threat-detection ruleset (first run)   ← for ~45s
```

**Warm** — climbs in step with the work:
```
  3%  Parsing packets
 24%  Detecting applications & threats
 44%  Classifying hosts & geo-locating
 78%  Extracting transferred files
```

## What this does not fix

The cold stage is **still motionless for ~45 seconds**, because the bar cannot advance inside a stage. Naming the wait as one-time setup is what separates "hung" from "working on something known to be slow", and is the honest fix short of reporting sub-stage progress from Suricata itself.

It is also still approximate at the extremes: parsing and database writes scale with the capture while the rest does not, so these shares are right for a mid-sized capture and drift for a tiny or enormous one. Re-weighting from the packet count once parsing has finished — which #758 suggests — is the real answer there, and is deliberately not attempted here.

## Verification

7 new tests asserting the *shape* rather than the exact numbers, since the numbers are measurements that will be re-taken when the pipeline changes. Full suite green (453). Verified by mutation: collapsing back to one vector fails 2, zeroing a stage's weight fails 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)