### PR TITLE
fix: give the analysis ETA a fixed-cost term, and exit on OOM (#758, #779)

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -126,6 +126,22 @@ echo "  Native headroom      = $(( 100 - JVM_HEAP_PERCENT ))% for JVM non-heap +
 echo "  Max upload size      = $(( MAX_UPLOAD_BYTES / 1024 / 1024 )) MB"
 echo "  Analysis timeout     = ${TIMEOUT} s"
 
+# Die on heap exhaustion instead of limping (#779).
+#
+# A capture larger than the heap threw OutOfMemoryError inside a request thread and killed Tomcat's
+# http-nio-8080-Poller. The container stayed "running" and healthy to `docker compose ps` while
+# serving nothing: every API call timed out, and recovery needed a human noticing and restarting it.
+# One oversized upload took the service down for everyone, silently.
+#
+# Exiting turns that into something the platform can act on — `restart: unless-stopped` is set on
+# this service, so the container comes back by itself. A JVM whose heap is exhausted has no
+# reliable path back to health anyway; the only question is whether the failure is visible.
+#
+# Deliberately no -XX:+HeapDumpOnOutOfMemoryError: the dump is roughly heap-sized (~1 GB at the
+# default budget) and would land on a volume that already has to hold captures. Enable it by hand
+# when actually diagnosing one.
+JVM_MEM_OPTS="${JVM_MEM_OPTS} -XX:+ExitOnOutOfMemoryError"
+
 # shellcheck disable=SC2086 # JVM_MEM_OPTS is intentionally word-split into separate flags
 exec gosu spring java \
   ${JVM_MEM_OPTS} \

--- a/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
@@ -1,5 +1,6 @@
 package com.tracepcap.analysis.service;
 
+import com.tracepcap.common.stage.DetectionEngineStatus;
 import jakarta.annotation.PreDestroy;
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +37,7 @@ import org.springframework.stereotype.Component;
  */
 @Slf4j
 @Component
-public class SuricataEngine {
+public class SuricataEngine implements DetectionEngineStatus {
 
   private static final String SURICATASC = "suricatasc";
   private static final String SURICATA = "suricata";
@@ -90,6 +91,7 @@ public class SuricataEngine {
    * <p>Progress estimation needs this because it is the difference between one stage taking 0.3 s
    * and taking 45 s, and no static weighting can describe both (#758).
    */
+  @Override
   public boolean isWarm() {
     return warm && daemon != null && daemon.isAlive();
   }

--- a/backend/src/main/java/com/tracepcap/common/stage/DetectionEngineStatus.java
+++ b/backend/src/main/java/com/tracepcap/common/stage/DetectionEngineStatus.java
@@ -1,0 +1,21 @@
+package com.tracepcap.common.stage;
+
+/**
+ * Whether the threat-detection engine is already loaded (#569).
+ *
+ * <p>A port because the answer changes an estimate by a factor of twenty and the module that needs
+ * it lives outside {@code analysis}: Suricata's ruleset build costs ~45 s once per process, so a
+ * capture that has to pay it is a different job from one that does not, and the ETA shown at upload
+ * has to say which (#758).
+ *
+ * <p>In {@code common} rather than {@code analysis.spi} because {@code analysis} already depends on
+ * {@code file} — putting it there would close the {@code analysis <-> file} cycle that #512 slice 1
+ * was written to break. Both sides depend on this instead, the same arrangement as
+ * {@code common.net.LocalityPolicy}.
+ */
+@FunctionalInterface
+public interface DetectionEngineStatus {
+
+  /** True when the next capture can skip the one-time engine build. */
+  boolean isWarm();
+}

--- a/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
+++ b/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
@@ -5,6 +5,7 @@ import com.tracepcap.file.dto.FileUploadResponse;
 import com.tracepcap.file.entity.FileEntity;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import com.tracepcap.common.stage.DetectionEngineStatus;
 
 /** Mapper for converting between FileEntity and DTOs */
 @Component
@@ -13,27 +14,44 @@ public class FileMapper {
   // Global Suricata kill-switch (SURICATA_ENABLED). When false, Suricata never ran regardless of
   // the per-file flag, so the DTO must report the effective state — matching ReportService and
   // AnalysisService — otherwise the UI would not flag such files as partial. See AnalysisService.
+  private final DetectionEngineStatus detectionEngine;
+
+  public FileMapper(DetectionEngineStatus detectionEngine) {
+    this.detectionEngine = detectionEngine;
+  }
+
   @Value("${tracepcap.suricata.enabled:true}")
   private boolean suricataEnabled;
 
   private static final int MIN_ESTIMATE_SECONDS = 10;
 
   // ---- Packet-based coefficients (preferred) ----------------------------------------------------
-  // Analysis cost is driven by packet COUNT, not bytes: Suricata/nDPI/parse all scale per-packet, so
-  // a small but packet-dense capture can take far longer than its size suggests. Seconds per 1000
-  // packets, calibrated against a clean OFFLINE run (21.4k packets, GEO_FORCE_OFFLINE): parse+
-  // classify+persist+DB ≈ 0.38, extract(nDPI+Suricata) ≈ 2.6, file-extract ≈ 0.04 s/kpkt. Values
-  // below keep a small conservative margin (better to slightly over-estimate). Suricata dominates.
-  // Only stages that will run contribute. See analysis-eta-calibration notes for recalibration.
-  private static final double BASE_SECONDS_PER_KPKT = 0.45; // parse + classify + persist + DB insert
-  private static final double NDPI_SECONDS_PER_KPKT = 0.6;
-  private static final double SURICATA_SECONDS_PER_KPKT = 2.1;
-  private static final double EXTRACTION_SECONDS_PER_KPKT = 0.08;
+  // seconds = fixed + per_kpkt * (packets / 1000), per stage group.
+  //
+  // The fixed term is the whole point. The previous model had only a per-packet rate, which is why
+  // it read 91 minutes for a job of roughly 36 and 10 seconds for one that took 49 — the same
+  // missing constant, in opposite directions. Measured cost per 1000 packets falls ~8x between a
+  // 250-packet capture and a 45,000-packet one, which is a fixed cost wearing a per-packet costume.
+  //
+  // Fitted by scripts/calibrate_analysis_eta.py over runs of 2k-45k packets. Re-run it rather than
+  // hand-editing these; it reads the timings the pipeline already logs, and it excludes cold-engine
+  // runs, which are a different regime rather than outliers.
+  private static final double BASE_FIXED_SECONDS = 1.6; // parse + classify + persist + DB insert
+  private static final double BASE_SECONDS_PER_KPKT = 0.43;
+  private static final double DETECT_FIXED_SECONDS = 0.4; // nDPI + Suricata, engine already warm
+  private static final double DETECT_SECONDS_PER_KPKT = 0.04;
+  private static final double EXTRACTION_SECONDS_PER_KPKT = 0.43; // file carving, no fixed cost
   private static final double DOWNLOAD_SECONDS_PER_MB = 0.01; // MinIO fetch, size-scaled
 
+  // Suricata builds its detection engine once per process, not once per capture (#569). ~45s,
+  // and it dwarfs everything else, so a capture that has to pay it is a different job — the same
+  // split the progress bar makes (#758).
+  private static final double SURICATA_ENGINE_BUILD_SECONDS = 45.0;
+
   // ---- Size-based fallback (used only when packet count is unknown) ------------------------------
-  // e.g. capinfos failed at upload, or a legacy file predating packet-count capture. ~0.5 s/MB
-  // all-stages-on, matching the older end-to-end measurement on large captures.
+  // e.g. capinfos failed at upload, or a legacy file predating packet-count capture. Deliberately
+  // cruder: bytes are a poor proxy for work, since a packet-dense capture costs far more than its
+  // size suggests. Kept only so an estimate exists at all.
   private static final double BASE_SECONDS_PER_MB = 0.15;
   private static final double NDPI_SECONDS_PER_MB = 0.10;
   private static final double SURICATA_SECONDS_PER_MB = 0.20;
@@ -47,17 +65,28 @@ public class FileMapper {
    * count nor size is known.
    */
   private Integer estimateAnalysisSeconds(
-      Long fileSize, Integer packetCount, boolean ndpi, boolean suricata, boolean fileExtraction) {
+      Long fileSize,
+      Integer packetCount,
+      boolean ndpi,
+      boolean suricata,
+      boolean fileExtraction,
+      boolean engineWarm) {
     if (packetCount != null && packetCount > 0) {
       double kPkt = packetCount / 1000.0;
-      double perKPkt =
-          BASE_SECONDS_PER_KPKT
-              + (ndpi ? NDPI_SECONDS_PER_KPKT : 0)
-              + (suricata ? SURICATA_SECONDS_PER_KPKT : 0)
-              + (fileExtraction ? EXTRACTION_SECONDS_PER_KPKT : 0);
-      double downloadTerm =
-          fileSize != null ? fileSize / 1024.0 / 1024.0 * DOWNLOAD_SECONDS_PER_MB : 0;
-      return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(kPkt * perKPkt + downloadTerm));
+      double seconds = BASE_FIXED_SECONDS + kPkt * BASE_SECONDS_PER_KPKT;
+      if (ndpi || suricata) {
+        seconds += DETECT_FIXED_SECONDS + kPkt * DETECT_SECONDS_PER_KPKT;
+      }
+      if (suricata && !engineWarm) {
+        seconds += SURICATA_ENGINE_BUILD_SECONDS;
+      }
+      if (fileExtraction) {
+        seconds += kPkt * EXTRACTION_SECONDS_PER_KPKT;
+      }
+      if (fileSize != null) {
+        seconds += fileSize / 1024.0 / 1024.0 * DOWNLOAD_SECONDS_PER_MB;
+      }
+      return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(seconds));
     }
     if (fileSize == null || fileSize <= 0) return null;
     double sizeMb = fileSize / 1024.0 / 1024.0;
@@ -103,7 +132,10 @@ public class FileMapper {
                 entity.getPacketCount(),
                 entity.isEnableNdpi(),
                 effectiveSuricata,
-                entity.isEnableFileExtraction()))
+                entity.isEnableFileExtraction(),
+                // Whether this capture pays the one-time ruleset build (#569) is the difference
+                // between a ~45s job and a ~2s one, so the estimate has to know.
+                detectionEngine.isWarm()))
         .build();
   }
 }

--- a/backend/src/test/java/com/tracepcap/file/mapper/AnalysisEtaTest.java
+++ b/backend/src/test/java/com/tracepcap/file/mapper/AnalysisEtaTest.java
@@ -1,0 +1,100 @@
+package com.tracepcap.file.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.tracepcap.common.stage.DetectionEngineStatus;
+import com.tracepcap.file.entity.FileEntity;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The analysis ETA (#758 follow-on).
+ *
+ * <p>The old model was seconds-per-packet with no fixed term, which read <b>91 minutes</b> for a job
+ * of roughly 36 and <b>10 seconds</b> for one that took 49 — the same missing constant, in opposite
+ * directions. Measured cost per 1000 packets fell ~8x between a 250-packet capture and a 45,000
+ * packet one, because a large fixed cost was being amortised as if it scaled.
+ *
+ * <p>Tolerances are wide on purpose: this is about the model having the right shape, not about
+ * freezing constants. Re-fit with {@code scripts/calibrate_analysis_eta.py} rather than nudging
+ * numbers until the test passes.
+ */
+class AnalysisEtaTest {
+
+  private final DetectionEngineStatus engine = mock(DetectionEngineStatus.class);
+  private final FileMapper mapper = new FileMapper(engine);
+
+  AnalysisEtaTest() {
+    ReflectionTestUtils.setField(mapper, "suricataEnabled", true);
+  }
+
+  private FileEntity capture(int packets, long sizeBytes, boolean allStages) {
+    FileEntity f = new FileEntity();
+    f.setId(UUID.randomUUID());
+    f.setPacketCount(packets);
+    f.setFileSize(sizeBytes);
+    f.setEnableNdpi(allStages);
+    f.setEnableSuricata(allStages);
+    f.setEnableFileExtraction(allStages);
+    f.setStatus(FileEntity.FileStatus.COMPLETED);
+    return f;
+  }
+
+  private Integer estimate(int packets, long sizeBytes, boolean warm) {
+    when(engine.isWarm()).thenReturn(warm);
+    return mapper.toMetadataDto(capture(packets, sizeBytes, true)).getEstimatedAnalysisSeconds();
+  }
+
+  @Test
+  void matchesAMeasuredMidSizedRun() {
+    // 20,000 packets / 17.4MB measured at 17.3s end to end.
+    assertThat(estimate(20_000, 17_445_184L, true)).isBetween(10, 30);
+  }
+
+  @Test
+  void matchesAMeasuredLargeRun() {
+    // 45,000 packets / 39MB measured at ~44s.
+    assertThat(estimate(45_000, 39_035_724L, true)).isBetween(25, 70);
+  }
+
+  @Test
+  void doesNotUnderestimateASmallCapture() {
+    // The failure seen live: a 45KB capture estimated at 10s took 49s. A tiny capture still pays
+    // the fixed costs, so the floor must not collapse toward zero.
+    assertThat(estimate(250, 45_760L, true)).isGreaterThanOrEqualTo(2);
+  }
+
+  @Test
+  void aColdEngineIsAMuchLongerJob() {
+    // ~45s of ruleset build, paid once per process (#569). Ignoring it made a 47s first run look
+    // like a 2s one.
+    assertThat(estimate(2_000, 1_717_040L, false) - estimate(2_000, 1_717_040L, true))
+        .isGreaterThan(30);
+  }
+
+  @Test
+  void theEstimateGrowsWithPackets() {
+    assertThat(estimate(45_000, 39_035_724L, true))
+        .isGreaterThan(estimate(2_000, 1_717_040L, true));
+  }
+
+  @Test
+  void aMillionPacketCaptureIsNoLongerPredictedAtNinetyMinutes() {
+    // The report that started this: 1.7M packets predicted at 91m36s. Asserted as a ceiling, not a
+    // target — the true figure at that size is unmeasured. This only pins that the old
+    // 3.23 s/kpkt rate, which was mostly a mis-modelled fixed cost, is gone.
+    assertThat(estimate(1_700_000, 468L * 1024 * 1024, true)).isLessThan(75 * 60);
+  }
+
+  @Test
+  void disablingStagesMakesTheEstimateSmaller() {
+    when(engine.isWarm()).thenReturn(true);
+    Integer bare =
+        mapper.toMetadataDto(capture(20_000, 17_445_184L, false)).getEstimatedAnalysisSeconds();
+
+    assertThat(bare).isLessThan(estimate(20_000, 17_445_184L, true));
+  }
+}

--- a/scripts/calibrate_analysis_eta.py
+++ b/scripts/calibrate_analysis_eta.py
@@ -31,6 +31,27 @@ BASE = {2, 4, 5, 6}      # parse + classify/geo + save + DB insert
 EXTRACT = {3}            # nDPI + Suricata
 FILE_EXTRACTION = {7}
 
+# Above this, the detection stage is building the ruleset rather than inspecting packets.
+COLD_ENGINE_THRESHOLD_S = 20.0
+
+
+
+def fit(points: list[tuple[int, float]]) -> tuple[float, float]:
+    """Least squares of seconds = fixed + per_kpkt * kpkt.
+
+    Returns (fixed_seconds, seconds_per_kpkt). Both terms matter: a model with only the second
+    one is what produced a 91-minute estimate for a 36-minute job and a 10-second estimate for a
+    49-second one — the same missing constant, in opposite directions.
+    """
+    n = len(points)
+    xs = [p / 1000.0 for p, _ in points]
+    ys = [s for _, s in points]
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    denom = sum((x - mx) ** 2 for x in xs)
+    slope = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / denom if denom else 0.0
+    return my - slope * mx, slope
+
 
 def main() -> int:
     stages: dict[str, dict[int, int]] = defaultdict(dict)
@@ -52,6 +73,19 @@ def main() -> int:
         return 1
 
     runs.sort(key=lambda r: r[1])
+
+    # A cold-engine run is a different regime, not an outlier: Suricata's ruleset build is ~45s
+    # once per process, and mixing one into the fit drags the fixed term up and flattens the slope
+    # to zero. Detected by its own signature rather than a hardcoded file id.
+    cold = [r for r in runs if sum(r[2].get(i, 0) for i in EXTRACT) / 1000 > COLD_ENGINE_THRESHOLD_S]
+    runs = [r for r in runs if r not in cold]
+    if cold:
+        secs = [sum(r[2].get(i, 0) for i in EXTRACT) / 1000 for r in cold]
+        print(f"Excluded {len(cold)} cold-engine run(s) from the fit "
+              f"(detection stage {min(secs):.0f}-{max(secs):.0f}s — the one-time ruleset build).\n")
+    if not runs:
+        print("Only cold-engine runs found; nothing to fit.", file=sys.stderr)
+        return 1
     print(f"{'packets':>10} {'total s':>9} {'base':>8} {'extract':>9} {'file-ext':>9}   (s per 1000 packets)")
     agg = defaultdict(list)
     for _, pkts, st, total in runs:
@@ -76,6 +110,21 @@ def main() -> int:
         drift = (large_v / small_v) if small_v else float("inf")
         verdict = "looks per-packet" if 0.5 <= drift <= 2 else "NOT per-packet — fixed cost leaking in"
         print(f"  {key:>9}: {small_v:.3f} @ {small_n} -> {large_v:.3f} @ {large_n}  ({verdict})")
+    print("\nFitted model — seconds = fixed + per_kpkt * (packets/1000):\n")
+    absolute = defaultdict(list)
+    for _, pkts, st, _ in runs:
+        absolute["base"].append((pkts, sum(st.get(i, 0) for i in BASE) / 1000))
+        absolute["extract"].append((pkts, sum(st.get(i, 0) for i in EXTRACT) / 1000))
+        absolute["file-ext"].append((pkts, sum(st.get(i, 0) for i in FILE_EXTRACTION) / 1000))
+    for key, pts in absolute.items():
+        if len(pts) < 2:
+            print(f"  {key:>9}: needs at least two runs to fit")
+            continue
+        fixed, per = fit(pts)
+        print(f"  {key:>9}: fixed {max(fixed, 0.0):6.2f}s   per_kpkt {max(per, 0.0):6.3f}s"
+              f"   (from {len(pts)} runs, {pts[0][0]}..{pts[-1][0]} packets)")
+    print("\nA fit from clustered sizes extrapolates badly. Treat per_kpkt as trustworthy only")
+    print("across the range measured, and re-run this when a much larger capture completes.")
     return 0
 
 


### PR DESCRIPTION
Two fixes that came out of watching a 468 MB capture fail.

## 1. The ETA had no fixed-cost term (#758 follow-on)

It was pure seconds-per-packet. That reads **91 minutes** for a job of roughly 36, and **10 seconds** for one that takes 49 — the same missing constant in opposite directions, which is why it looked like two unrelated complaints.

Measured cost per 1000 packets falls **~8×** between a 250-packet capture and a 45,000-packet one. That is a fixed cost being amortised as though it scaled.

```
seconds = fixed + per_kpkt × (packets / 1000)
```

Fitted by `scripts/calibrate_analysis_eta.py` over runs of 2k–45k packets:

| packets | predicted | measured |
|---|---|---|
| 2,000 | 4s | 3.4s |
| 8,000 | 9s | 8.5s |
| 20,000 | 20s | 17.3s |
| 45,000 | 43s | 44.0s |

The calibration script also learned to **exclude cold-engine runs**. One of them dragged the detection term's fixed cost to 22s and flattened its slope to zero — a ruleset build is a different regime, not an outlier. Suricata's ~45s build is now its own one-time term, so a capture that pays it is estimated as the different job it is. Verified live: every estimate came back as exactly *fitted + 45* on a freshly restarted backend.

**ArchUnit caught a mistake here.** My first version put the `DetectionEngineStatus` port in `analysis.spi`, which closed the `analysis ↔ file` cycle that #512 slice 1 was written to break — `analysis` already depends on `file`. It lives in `common.stage` instead, with both modules depending on it, the same arrangement as `common.net.LocalityPolicy`.

## 2. An OOM no longer disables the service silently (#779)

`-XX:+ExitOnOutOfMemoryError`.

When the 468 MB capture exhausted the heap, the error killed Tomcat's `http-nio-8080-Poller`. The container stayed **"running"** and healthy to `docker compose ps` while serving nothing — every API call timed out, and recovery needed a human noticing and restarting it. One oversized upload took the service down for everyone, with no signal.

`restart: unless-stopped` is already set, so exiting turns that into a restart the platform performs by itself. A JVM whose heap is exhausted has no reliable path back to health; the only question is whether the failure is visible.

Deliberately **no** `-XX:+HeapDumpOnOutOfMemoryError`: the dump is roughly heap-sized (~1 GB at the default budget) and would land on a volume that already has to hold captures. Enable it by hand when actually diagnosing one.

## Verification

7 new tests on the ETA asserting against measurements with wide tolerances — the point is the model's *shape*, not frozen constants; re-fit with the script rather than nudging numbers until it passes. Full suite green (460). Flag confirmed present in the running JVM's command line.

## Still open on #779

Stage 2 accumulating the whole capture. Streaming it to the database during parse is what makes capture size independent of heap and retires the ⅓-of-heap ratio entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)