### PR TITLE
perf: share the strings every packet repeats (#779)

### DIFF
--- a/backend/src/main/java/com/tracepcap/analysis/service/PcapParserService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/PcapParserService.java
@@ -32,6 +32,8 @@ public class PcapParserService {
     Map<String, LinkedHashSet<String>> hostMacObservations = new HashMap<>();
 
     Map<String, ConversationInfo> conversationMap = new HashMap<>();
+    // Discarded with the parse; see pooled().
+    Map<String, String> stringPool = new HashMap<>();
 
     // Fields: epoch | len | ipv4.src | ipv4.dst | ipv6.src | ipv6.dst |
     //         tcp.sport | tcp.dport | udp.sport | udp.dport | protocol | info |
@@ -333,6 +335,7 @@ public class PcapParserService {
             conv.getPackets()
                 .add(
                     buildPacketInfo(
+                        stringPool,
                         frameNumber,
                         timestamp,
                         srcIp,
@@ -381,7 +384,26 @@ public class PcapParserService {
   // Helpers
   // ---------------------------------------------------------------------------
 
+  /**
+   * Pool for the values every packet repeats (#779).
+   *
+   * <p>A capture has a few hundred distinct addresses and a handful of protocols, but millions of
+   * packets, and {@code split()} hands back a fresh String for each one. At ~776 bytes per
+   * PacketInfo, 1.7M packets need ~1.26 GB against a 1 GB heap — which is the OutOfMemoryError.
+   * Addresses and protocols are ~150 of those bytes and are almost entirely duplicates.
+   *
+   * <p>A local map rather than {@link String#intern()}: intern's table is JVM-wide and permanent,
+   * so a capture's addresses would outlive the analysis that read them. This is discarded with the
+   * parse.
+   */
+  private static String pooled(Map<String, String> pool, String value) {
+    if (value == null) return null;
+    String existing = pool.putIfAbsent(value, value);
+    return existing != null ? existing : value;
+  }
+
   private PacketInfo buildPacketInfo(
+      Map<String, String> pool,
       long packetNumber,
       LocalDateTime timestamp,
       String srcIp,
@@ -396,11 +418,11 @@ public class PcapParserService {
     PacketInfo pkt = new PacketInfo();
     pkt.setPacketNumber(packetNumber);
     pkt.setTimestamp(timestamp);
-    pkt.setSrcIp(srcIp);
+    pkt.setSrcIp(pooled(pool, srcIp));
     pkt.setSrcPort(srcPort);
-    pkt.setDstIp(dstIp);
+    pkt.setDstIp(pooled(pool, dstIp));
     pkt.setDstPort(dstPort);
-    pkt.setProtocol(protocol);
+    pkt.setProtocol(pooled(pool, protocol));
     pkt.setPacketSize(packetSize);
     pkt.setInfo(info);
     pkt.setPayload(payloadHex);

--- a/backend/src/test/java/com/tracepcap/analysis/service/PacketStringPoolingTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/service/PacketStringPoolingTest.java
@@ -1,0 +1,73 @@
+package com.tracepcap.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Packets share the strings they repeat (#779).
+ *
+ * <p>A capture has a few hundred distinct addresses and millions of packets, and {@code split()}
+ * returns a fresh String for every field of every packet. At ~776 bytes per PacketInfo, 1.7M
+ * packets need ~1.26 GB against a 1 GB heap — the OutOfMemoryError that made a 468 MB capture
+ * unanalysable.
+ *
+ * <p>Identity is the assertion, not equality: two equal Strings that are separate objects are
+ * exactly the waste being removed, and {@code isEqualTo} would pass while the bug remained.
+ */
+class PacketStringPoolingTest {
+
+  private static String pooled(Map<String, String> pool, String value) {
+    try {
+      Method m = PcapParserService.class.getDeclaredMethod("pooled", Map.class, String.class);
+      m.setAccessible(true);
+      return (String) m.invoke(null, pool, value);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("pooled() changed — update this test", e);
+    }
+  }
+
+  @Test
+  void repeatedValuesBecomeTheSameObject() {
+    Map<String, String> pool = new HashMap<>();
+    // Deliberately not literals: those would already be interned by the compiler and the test
+    // would pass without the pool doing anything.
+    String first = new String("192.168.1.1");
+    String second = new String("192.168.1.1");
+
+    assertThat(pooled(pool, first)).isSameAs(pooled(pool, second));
+  }
+
+  @Test
+  void distinctValuesStayDistinct() {
+    Map<String, String> pool = new HashMap<>();
+
+    assertThat(pooled(pool, new String("10.0.0.1")))
+        .isNotSameAs(pooled(pool, new String("10.0.0.2")));
+    assertThat(pooled(pool, new String("10.0.0.1"))).isEqualTo("10.0.0.1");
+  }
+
+  @Test
+  void nullPassesThroughRatherThanBeingPooled() {
+    Map<String, String> pool = new HashMap<>();
+
+    assertThat(pooled(pool, null)).isNull();
+    assertThat(pool).isEmpty();
+  }
+
+  @Test
+  void thePoolHoldsOneEntryPerDistinctValueNotOnePerPacket() {
+    // The property that bounds the saving: a million packets across ten addresses must cost ten
+    // strings, not a million.
+    Map<String, String> pool = new HashMap<>();
+    for (int i = 0; i < 10_000; i++) {
+      pooled(pool, new String("10.0.0." + (i % 10)));
+      pooled(pool, new String("TCP"));
+    }
+
+    assertThat(pool).hasSize(11);
+  }
+}


### PR DESCRIPTION
A partial improvement to #779, clearly labelled as partial.

## The arithmetic behind the OOM

| | |
|---|---|
| per `PacketInfo` | ~776 bytes |
| 1.7M packets | **~1,258 MB** |
| heap at the default budget | **1,024 MB** |

That is the `OutOfMemoryError` exactly. Of those 776 bytes, roughly 150 are `srcIp`, `dstIp` and `protocol` — values a capture repeats endlessly across a few hundred distinct addresses, but which `split()` hands back as a fresh String for every field of every packet.

They now come from a per-parse pool. A local map rather than `String.intern()`, because intern's table is JVM-wide and permanent — a capture's addresses would outlive the analysis that read them.

## What this does not do

**It raises the ceiling; it does not remove it.** The per-packet object count is unchanged and memory still scales with the capture.

**I have not measured the end-to-end saving.** Doing so honestly needs an A/B on the same file with and without the change, and the stack is in use — I already interrupted one of the user's analyses today by rebuilding underneath it. The tests verify the objects are genuinely shared, by **identity rather than equality** (equal-but-distinct Strings are precisely the waste being removed, so `isEqualTo` would pass while the bug remained). The size of the win on a real capture is unmeasured, and I would rather say that than quote a number I fitted after the fact.

## Verification

4 tests, including that the pool holds one entry per distinct value rather than one per packet — the property that bounds the saving. Removing the pooling fails 2. Full suite green (464).

## The real fix, still open

Streaming stage 2 to the database instead of accumulating. The design is written up on #779: insert a conversation stub on first sight to get its id, buffer packets to a bounded size, flush, and update the conversation aggregates at end of parse. That makes capture size independent of heap and retires the ⅓-of-heap ratio from #780 entirely.

I have not attempted it here. It restructures the most critical path in the app, which I broke once already today, and it deserves its own focused change rather than being appended to a session this long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)