### PR TITLE
ci: run the tool-dependent tests for real, and notice when they cannot (#701)

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -36,6 +36,21 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      # tshark, editcap and capinfos, because without them the tool-dependent tests pass while
+      # testing nothing (#701). Those services degrade gracefully by design, so a missing binary
+      # is not an error — the subprocess fails to start, the catch fires, the method returns
+      # early, and the assertions still hold. Verified by hiding tshark from PATH locally:
+      # DnsQueryLogExtractorTest reported 13 passed either way. The 4-point coverage gap between
+      # this job and a developer's machine was that, made visible.
+      #
+      # Suricata is deliberately not installed: it is ~700MB of ruleset and ~45s of engine build
+      # per run (#569), and the full-stack job already exercises it against a real container.
+      - name: Install packet-analysis tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tshark
+          tshark --version | head -1
+
       # Testcontainers needs a Docker daemon; ubuntu-latest runners provide one.
       - name: Run unit + integration tests
         run: mvn -B clean verify

--- a/backend/src/test/java/com/tracepcap/analysis/ExternalToolsAvailableTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/ExternalToolsAvailableTest.java
@@ -1,0 +1,55 @@
+package com.tracepcap.analysis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The tools the extraction tests need must actually be present (#701).
+ *
+ * <p>Those services degrade gracefully by design: a missing binary is not an error, so the
+ * subprocess fails to start, the catch fires, the method returns early, and every assertion in
+ * {@code DnsQueryLogExtractorTest} still holds. Hiding {@code tshark} from {@code PATH} locally
+ * produced <b>13 passed</b>, exactly as with it present — the tests were verifying the
+ * degradation path while claiming to verify extraction.
+ *
+ * <p>That is invisible from a test report, which is why it survived: CI and a developer's machine
+ * ran identical counts, 340 tests and 1 skipped in both, and differed only by ~2,100 covered
+ * instructions.
+ *
+ * <p>This fails instead. It is not testing the tools; it is asserting the precondition that makes
+ * the other tests mean anything.
+ */
+class ExternalToolsAvailableTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"tshark", "editcap", "capinfos"})
+  void theToolIsOnThePath(String tool) {
+    assertThat(canRun(tool))
+        .as(
+            "%s is missing. The extraction tests will still pass without it — they will just be "
+                + "exercising the graceful-degradation path instead of the parsing they are named "
+                + "for (#701). Install it rather than deleting this assertion.",
+            tool)
+        .isTrue();
+  }
+
+  private static boolean canRun(String tool) {
+    try {
+      Process p = new ProcessBuilder(tool, "--version").redirectErrorStream(true).start();
+      if (!p.waitFor(20, TimeUnit.SECONDS)) {
+        p.destroyForcibly();
+        return false;
+      }
+      return p.exitValue() == 0;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Closes #701. The coverage gap was a symptom; the cause is that CI's tool-dependent tests were passing without testing.

## Not a measurement artifact

| | instructions | covered | total |
|---|---|---|---|
| CI | 20.29% | 13,123 | **64,663** |
| Local | 23.60% | 15,258 | **64,663** |

**Totals identical**, which rules out every candidate the issue listed — Lombok `@Generated` filtering, `<excludes>` resolution, a stale `target/`. The same classes are analysed. 2,135 more instructions simply *execute* locally.

All of them shell out to a tool: `PcapParserService` (+739), `AnalysisService` (+350), `WebServerLogExtractor` (+282), `DnsQueryLogExtractor` (+255), `HostnameResolverService` (+248). This host has `tshark`; `ubuntu-latest` does not.

## The tests were hollow, not skipped

These services degrade gracefully by design — *"never throws: on any failure it persists whatever it parsed"*. Correct in production; in CI it means the subprocess fails to start, the catch fires, the method returns early, and **every assertion still holds**:

```
tshark working          -> Tests run: 13, Failures: 0
tshark → shim exit 127  -> Tests run: 13, Failures: 0
```

`DnsQueryLogExtractorTest` would pass if the parsing logic were deleted. That is why the counts matched exactly in both environments (340 tests, 1 skipped) and only coverage disagreed — nothing was skipped, it was hollow.

Same failure mode as #630 and #650, one layer down: a green check that verifies less than its name claims.

## The fix

- **CI installs `tshark`**, so those tests exercise what they are named for. One `apt-get` line; the fixtures already exist.
- **`ExternalToolsAvailableTest`** asserts the precondition, so a future absence fails loudly instead of silently halving what the suite checks. Verified: passes with the tool, fails with the shim.
- **Suricata deliberately not installed** — ~700 MB of ruleset and ~45 s of engine build per run (#569), and the full-stack job already exercises it against a real container.

## A correction on method

My first attempt to demonstrate this stripped `PATH` and reported "identical results with tshark absent". **That proved nothing** — `/bin` is a symlink to `/usr/bin`, so tshark stayed reachable and both runs were identical for the wrong reason. I only found that when the same trick failed to make the new guard fail. The shim is what actually shadows the binary, and the conclusion only stands on the second experiment.

## After this lands

Coverage from the two environments should converge. Only then is the #697 ratchet worth setting from CI — and the baseline in #660 was recorded on a machine with tshark, so it describes the fuller path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)