### PR TITLE
docs: document every env var, and gate the third edge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@
 # APP_MEMORY_MB unless BACKEND_MEM_LIMIT overrides it), else APP_MEMORY_MB:
 #   - Container limit  = APP_MEMORY_MB (cgroup cap; see BACKEND_MEM_LIMIT below)
 #   - JVM heap         = 50% of the effective budget
-#   - Max upload size  = 25% of the effective budget
+#   - Max upload size  = 16% of the effective budget
 #   - Nginx body limit = max upload + 50 MB multipart buffer
 #   - Proxy / analysis timeout scales with memory (300–900 s)
 #
@@ -18,10 +18,16 @@
 # (metaspace, thread stacks, direct buffers). See issue #378 and
 # docs/operations/production-hardening.rst (Container Resource Limits).
 #
+# The upload cap is 16%, not 25%, because analysis holds the whole capture in heap while parsing,
+# so an accepted file must fit in about a third of it. It was 25% when the heap was 75%; when the
+# heap dropped to 50% the cap was not revisited, and a 468 MB capture was accepted and then died
+# of OutOfMemoryError 25 minutes in (#779). scripts/check_memory_budget.py now fails the build if
+# the two drift apart again.
+#
 # Examples:
-#   2048  →  512 MB max upload, 1 GB heap  (default, suitable for most laptops)
-#   4096  →  1 GB  max upload, 2 GB heap   (recommended for captures >100 MB)
-#   8192  →  2 GB  max upload, 4 GB heap
+#   2048  →  327 MB max upload, 1 GB heap  (default, suitable for most laptops)
+#   4096  →  655 MB max upload, 2 GB heap   (recommended for captures >100 MB)
+#   8192  →  1.3 GB max upload, 4 GB heap
 APP_MEMORY_MB=2048
 
 # Container Resource Limits (issue #378)
@@ -247,3 +253,59 @@ VITE_SUPPORTED_FILE_TYPES=.pcap,.pcapng,.cap
 # limit in the Network Topology Diagram. Disabling this loads every conversation into the diagram,
 # which may cause browser slowdowns or out-of-memory errors on large captures.
 VITE_NETWORK_DIAGRAM_CONVERSATION_LIMIT=false
+
+# =============================================================================
+# Threat detection (Suricata)
+# =============================================================================
+# SURICATA_WARM_ENGINE_ENABLED: keep one Suricata process loaded between analyses instead of
+# rebuilding its ~50,000-rule detection engine per file. Measured 44s -> ~0.3s per capture with
+# identical alerts (#569). The per-file subprocess remains as an automatic fallback, so the worst
+# case of a broken warm engine is the old behaviour, not lost threat detection.
+SURICATA_WARM_ENGINE_ENABLED=true
+# Command socket. Must be writable by the container's runtime user (the app runs as `spring`, and
+# Suricata's packaged log directory is root-owned).
+SURICATA_WARM_ENGINE_SOCKET=/tmp/tracepcap-suricata/suricata.sock
+# Seconds to wait for the engine to finish building its ruleset before giving up on it.
+SURICATA_WARM_ENGINE_STARTUP_TIMEOUT=180
+# Seconds a single capture may take once the engine is warm.
+SURICATA_WARM_ENGINE_RUN_TIMEOUT=600
+# Seconds a caller waits for the engine before falling back. Generous on purpose: falling back
+# costs a full cold run, so waiting is almost always the better trade. A short wait was measurably
+# worse — eight concurrent captures each started their own Suricata and one Extract stage took 430s.
+SURICATA_WARM_ENGINE_LOCK_WAIT=900
+# Seconds for a single socket command. These are short exchanges; longer means the engine is wedged.
+SURICATA_WARM_ENGINE_COMMAND_TIMEOUT=30
+
+# =============================================================================
+# Story mode (LLM)
+# =============================================================================
+# LLM_TOOL_CALLING: auto = try tools once and remember whether the server accepts them,
+# on = always send them, off = the free-text-JSON path (#623).
+LLM_TOOL_CALLING=auto
+
+# =============================================================================
+# Network Cluster tuning
+# =============================================================================
+# Caps on what the cluster graph renders; raising them costs browser rendering time, not accuracy.
+INTELLIGENCE_MAX_CLUSTERS=60
+INTELLIGENCE_MAX_EDGES=200
+# Thresholds for the per-host DNS and HTTP suspicion signals. A host must exceed the minimum
+# volume before its ratio is considered at all, so a single failed lookup is not "suspicious".
+DNS_NXDOMAIN_SUSPICIOUS_RATIO=0.5
+DNS_NXDOMAIN_MIN_QUERIES=20
+HTTP_CLIENT_ERROR_SUSPICIOUS_RATIO=0.5
+HTTP_MIN_REQUESTS=20
+
+# =============================================================================
+# Miscellaneous
+# =============================================================================
+# APP_VERSION: baked in at build time. The default lives in docker-compose.yml and is synced on
+# every merge to dev by .github/workflows/app-version.yml; set this only to override a build.
+# APP_VERSION=
+# Path to the custom signature rules file, mounted into the backend.
+SIGNATURES_PATH=./signatures.yml
+# Resource caps for the one-shot MinIO bucket-initialisation container.
+MINIO_INIT_CPU_LIMIT=0.5
+MINIO_INIT_MEM_LIMIT=128M
+# TRACEPCAP_AUTH_ENABLED: set false only for local development without Keycloak.
+TRACEPCAP_AUTH_ENABLED=true

--- a/.github/workflows/env-passthrough.yml
+++ b/.github/workflows/env-passthrough.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'backend/src/main/resources/application*.yml'
       - 'docker-compose*.yml'
+      - '.env.example'
       - 'scripts/check_env_passthrough.py'
       - '.github/workflows/env-passthrough.yml'
   workflow_dispatch:

--- a/scripts/check_env_passthrough.py
+++ b/scripts/check_env_passthrough.py
@@ -28,6 +28,7 @@ Usage: python3 scripts/check_env_passthrough.py
 Exit:  0 clean, 1 unreachable variables found
 """
 
+import pathlib
 import re
 import sys
 from pathlib import Path
@@ -100,8 +101,33 @@ def vars_passed(compose_files):
     return passed
 
 
+# Internal wiring rather than operator knobs: compose builds these from variables .env.example
+# does document (DATABASE_URL from POSTGRES_DB, MINIO_ACCESS_KEY from MINIO_ROOT_USER, and so on).
+# Documenting the derived name would invite someone to set it and wonder why the source still won.
+INTERNAL_WIRING = {
+    "DATABASE_URL",
+    "DATABASE_USERNAME",
+    "DATABASE_PASSWORD",
+    "MINIO_ENDPOINT",
+    "MINIO_ACCESS_KEY",
+    "MINIO_SECRET_KEY",
+    "MINIO_BUCKET",
+    "TZ",
+}
+
+
+def documented_vars(path="\u002eenv.example"):
+    """Variables .env.example mentions, commented-out ones included.
+
+    A commented default still documents that the knob exists, which is the point — an operator
+    reads this file to learn what is tunable.
+    """
+    text = pathlib.Path(".env.example").read_text() if pathlib.Path(".env.example").exists() else ""
+    return set(re.findall(r"^#?\s*([A-Z_][A-Z0-9_]*)=", text, re.M))
+
+
 def main():
-    unreachable, dead = [], []
+    unreachable, dead, undocumented = [], [], []
     for stack, (compose_files, profile_files) in sorted(STACKS.items()):
         reachable = vars_passed(compose_files)
         read = vars_read(profile_files)
@@ -119,8 +145,28 @@ def main():
             if var not in EXEMPT and var not in read and var not in PASSTHROUGH
         )
 
-    if not unreachable and not dead:
-        print("OK — backend environment and Spring config agree in both directions.")
+    # Third edge of the same triangle: compose <-> application.yml was already checked, but a
+    # variable can be wired end to end and still be invisible, because nothing tells the operator
+    # it exists. .env.example is the only place they look.
+    documented = documented_vars()
+    for stack, (compose_files, _) in sorted(STACKS.items()):
+        if stack != "prod":
+            continue  # one representative stack; the others are supersets of the same names
+        undocumented.extend(
+            var
+            for var in sorted(vars_passed(compose_files))
+            if var not in EXEMPT and var not in INTERNAL_WIRING and var not in documented
+        )
+
+    if undocumented:
+        print("Passed to the backend but absent from .env.example:\n")
+        for var in undocumented:
+            print(f"  {var}")
+        print("\nAdd each with a short note on what it does and its default. A setting nobody")
+        print("knows about is not configurable.\n")
+
+    if not unreachable and not dead and not undocumented:
+        print("OK — compose, Spring config and .env.example all agree.")
         return 0
 
     if unreachable:


### PR DESCRIPTION
Prompted by opening `.env.example` — it was wrong in a way I caused today.

## The stale promise

```
#   - Max upload size  = 25% of the effective budget
#   2048  →  512 MB max upload, 1 GB heap
```

#780 changed that to **16% / 327 MB** this afternoon. So the file an operator reads to size their deployment was advertising 512 MB while the app enforced 327 MB — the same advertised-versus-enforced split that let a 468 MB capture be accepted and fail 25 minutes into parsing.

Corrected, with the *reason* recorded rather than just the number, so the next person to wonder why it is 16% finds the answer instead of "fixing" it back.

## Eleven undocumented variables

Every one I added today was missing: the warm Suricata engine's five, `LLM_TOOL_CALLING`, plus the cluster caps and the DNS/HTTP suspicion thresholds that predate me. All now documented with what they do and why the default is what it is.

## The third edge

`check_env_passthrough.py` already checked **compose ↔ Spring config**, in both directions — that is what caught `LLM_TOOL_CALLING` being wired but unbound earlier today, and my own warm-engine variables going only halfway.

But a variable can be wired end to end and still be invisible, because `.env.example` is the only place an operator looks. That edge was ungated, which is exactly how eleven of them accumulated.

```
compose ──✅── application.yml
   │                  
   └──────── .env.example      ← was ungated
```

Verified by planting a new compose variable and watching it fail.

**Exempt:** `DATABASE_*`, `MINIO_*`, `TZ`. Compose derives these from variables that *are* documented — `DATABASE_URL` from `POSTGRES_DB`, `MINIO_ACCESS_KEY` from `MINIO_ROOT_USER`. Documenting the derived name would invite someone to set it and wonder why the source still won.

🤖 Generated with [Claude Code](https://claude.com/claude-code)