### PR TITLE
fix: raise Jackson's 20MB JSON string cap for report topology diagrams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -242,6 +242,14 @@ EXTRACTION_MAX_STREAM_CONVERSATIONS=50
 # Larger files are detected but skipped (shown with a "Too large" badge). Increase to store bigger files.
 EXTRACTION_MAX_FILE_SIZE_MB=50
 
+# Report Generation
+# The max size of a single JSON string value (the PDF report's base64-encoded topology diagram is
+# the only field that can get this big) is NOT set directly here — like the upload limit above, it
+# is derived from APP_MEMORY_MB by backend/docker-entrypoint.sh (2.5% of the effective budget,
+# clamped to 8-256 MB) so it scales with the memory actually available instead of using Jackson's
+# fixed 20 MB default regardless of deployment size. Raise APP_MEMORY_MB if large topology diagrams
+# still fail to download.
+
 # Frontend Configuration
 # VITE_MAP_RESOLUTION: Controls the polygon fidelity of the world map at build time.
 # Allowed values: 110m (low fidelity, ~170 KB), 50m (medium — default, ~760 KB), 10m (high fidelity, ~1 MB)

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -82,6 +82,19 @@ TIMEOUT=$(( EFFECTIVE_MEM_MB * 45 / 100 ))
 if [ "$TIMEOUT" -lt 300 ]; then TIMEOUT=300; fi
 if [ "$TIMEOUT" -gt 900 ]; then TIMEOUT=900; fi
 
+# Max length (chars) of a single JSON string value across the API — currently only reachable via
+# the PDF report's base64-encoded topology diagram, which a dense capture can inflate past
+# Jackson's own fixed 20MB default. That default doesn't know how much heap it's borrowing
+# against, so it's too generous on a small deployment and an arbitrary ceiling on a large one.
+# 2.5% of the effective budget, clamped to [8, 256] MB (#792). Unlike the upload path, parsing
+# one JSON string only needs a small multiple of its own size in transient buffer growth (no
+# whole-capture object graph held alongside it), so this stays well under the heap fraction the
+# upload cap uses — see MAX_UPLOAD_BYTES above.
+JACKSON_MAX_STRING_MB=$(( EFFECTIVE_MEM_MB / 40 ))
+if [ "$JACKSON_MAX_STRING_MB" -lt 8 ]; then JACKSON_MAX_STRING_MB=8; fi
+if [ "$JACKSON_MAX_STRING_MB" -gt 256 ]; then JACKSON_MAX_STRING_MB=256; fi
+JACKSON_MAX_STRING_BYTES=$(( JACKSON_MAX_STRING_MB * 1024 * 1024 ))
+
 # Ensure signatures.yml exists and is writable by the spring user.
 # Runs as root so it can fix ownership regardless of how the named volume was seeded.
 if [ ! -f /app/config/signatures.yml ] && [ -f /app/config-defaults/signatures.yml ]; then
@@ -125,6 +138,7 @@ echo "  JVM heap             = ${JVM_HEAP_MB} MB (${JVM_HEAP_PERCENT}% of budget
 echo "  Native headroom      = $(( 100 - JVM_HEAP_PERCENT ))% for JVM non-heap + tshark/ndpi/Suricata"
 echo "  Max upload size      = $(( MAX_UPLOAD_BYTES / 1024 / 1024 )) MB"
 echo "  Analysis timeout     = ${TIMEOUT} s"
+echo "  Max JSON string      = ${JACKSON_MAX_STRING_MB} MB (report topology diagram)"
 
 # Die on heap exhaustion instead of limping (#779).
 #
@@ -147,4 +161,5 @@ exec gosu spring java \
   ${JVM_MEM_OPTS} \
   -DMAX_UPLOAD_SIZE_BYTES=${MAX_UPLOAD_BYTES} \
   -DANALYSIS_TIMEOUT_SECONDS=${TIMEOUT} \
+  -DJACKSON_MAX_STRING_LENGTH=${JACKSON_MAX_STRING_BYTES} \
   -jar app.jar

--- a/backend/src/main/java/com/tracepcap/config/JacksonConfig.java
+++ b/backend/src/main/java/com/tracepcap/config/JacksonConfig.java
@@ -1,0 +1,33 @@
+package com.tracepcap.config;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Raises Jackson's default 20MB max-string-length constraint (jackson-databind 2.15+), which
+ * otherwise rejects report-generation request bodies carrying a base64-encoded topology diagram
+ * PNG once the capture is large/dense enough to push the base64 string past the default. See
+ * #792.
+ */
+@Configuration
+public class JacksonConfig {
+
+  @Value("${tracepcap.jackson.max-string-length}")
+  private int maxStringLength;
+
+  @Bean
+  public Jackson2ObjectMapperBuilderCustomizer streamReadConstraintsCustomizer() {
+    return builder ->
+        builder.postConfigurer(
+            mapper ->
+                mapper
+                    .getFactory()
+                    .setStreamReadConstraints(
+                        StreamReadConstraints.builder()
+                            .maxStringLength(maxStringLength)
+                            .build()));
+  }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -332,4 +332,9 @@ tracepcap:
     # posts a base64-encoded topology diagram PNG in the request body, and a large/dense diagram
     # capture can push that string past the default, rejecting the request before it reaches the
     # controller. See JacksonConfig and #792.
-    max-string-length: ${JACKSON_MAX_STRING_LENGTH:52428800}
+    #
+    # 53477376 (51MB) matches what backend/docker-entrypoint.sh derives at its documented default
+    # (APP_MEMORY_MB=2048 -> EFFECTIVE_MEM_MB/40 = 51MB) — kept in sync so a run that bypasses the
+    # entrypoint (mvn spring-boot:run, an IDE run, a test) behaves the same as the real deployment
+    # at that default, instead of silently falling back to a different cap.
+    max-string-length: ${JACKSON_MAX_STRING_LENGTH:53477376}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -327,3 +327,9 @@ tracepcap:
     iot-apps:
       - IPP
       - MDNS
+  jackson:
+    # Jackson's default max JSON string length (StreamReadConstraints) is 20MB. Report generation
+    # posts a base64-encoded topology diagram PNG in the request body, and a large/dense diagram
+    # capture can push that string past the default, rejecting the request before it reaches the
+    # controller. See JacksonConfig and #792.
+    max-string-length: ${JACKSON_MAX_STRING_LENGTH:52428800}

--- a/backend/src/test/java/com/tracepcap/config/JacksonConfigTest.java
+++ b/backend/src/test/java/com/tracepcap/config/JacksonConfigTest.java
@@ -1,0 +1,67 @@
+package com.tracepcap.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Guards against a regression of #792: Jackson's default 20MB max-string-length
+ * (StreamReadConstraints) rejected report-generation requests carrying a base64-encoded topology
+ * diagram once the capture was large enough, with the request failing before it reached the
+ * controller.
+ */
+class JacksonConfigTest {
+
+  // One character past jackson-databind's compiled-in default (StreamReadConstraints.DEFAULT_MAX_STRING_LEN).
+  private static final int OVER_JACKSON_DEFAULT = 20_000_001;
+
+  private static String jsonWithStringOfLength(int length) {
+    return "{\"value\":\"" + "a".repeat(length) + "\"}";
+  }
+
+  @Test
+  void unconfiguredObjectMapperRejectsAStringPastTheDefaultLimit() {
+    ObjectMapper mapper = new ObjectMapper();
+    String json = jsonWithStringOfLength(OVER_JACKSON_DEFAULT);
+
+    assertThatThrownBy(() -> mapper.readValue(json, Map.class))
+        .isInstanceOf(StreamConstraintsException.class);
+  }
+
+  @Test
+  void customizedObjectMapperAcceptsAStringPastTheDefaultLimit() throws Exception {
+    JacksonConfig config = new JacksonConfig();
+    ReflectionTestUtils.setField(config, "maxStringLength", 52_428_800);
+
+    Jackson2ObjectMapperBuilder builder = new Jackson2ObjectMapperBuilder();
+    config.streamReadConstraintsCustomizer().customize(builder);
+    ObjectMapper mapper = builder.build();
+
+    String json = jsonWithStringOfLength(OVER_JACKSON_DEFAULT);
+
+    Map<?, ?> parsed = (Map<?, ?>) mapper.readValue(json, Map.class);
+
+    assertThat(((String) parsed.get("value"))).hasSize(OVER_JACKSON_DEFAULT);
+  }
+
+  @Test
+  void customizedObjectMapperStillRejectsPastItsOwnConfiguredLimit() {
+    JacksonConfig config = new JacksonConfig();
+    ReflectionTestUtils.setField(config, "maxStringLength", 100);
+
+    Jackson2ObjectMapperBuilder builder = new Jackson2ObjectMapperBuilder();
+    config.streamReadConstraintsCustomizer().customize(builder);
+    ObjectMapper mapper = builder.build();
+
+    String json = jsonWithStringOfLength(101);
+
+    assertThatThrownBy(() -> mapper.readValue(json, Map.class))
+        .isInstanceOf(StreamConstraintsException.class);
+  }
+}

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -23,8 +23,10 @@ directly. Set ``APP_MEMORY_MB`` and everything else scales automatically.
        the enforced container memory limit and the budget for derived settings.
        All derived values use the *effective* budget (the enforced cgroup limit
        when one is set, else this value): JVM heap = 50%, max upload size = 25%,
-       nginx body limit = max upload + 50 MB multipart buffer, and the
-       proxy/analysis timeout scales with memory (300–900 s). Examples:
+       nginx body limit = max upload + 50 MB multipart buffer, the max JSON
+       string length (report topology diagrams — see `Report Generation`_) =
+       2.5% clamped to 8-256 MB, and the proxy/analysis timeout scales with
+       memory (300–900 s). Examples:
        ``2048`` → 512 MB max upload
        (default), ``4096`` → 1 GB, ``8192`` → 2 GB. The heap is 50% rather than
        75% because tshark/ndpi/Suricata allocate outside the JVM heap — see
@@ -494,6 +496,27 @@ limit is hit, a warning is shown on the Extracted Files tab. See
      - ``50``
      - Max size (MB) of a single extracted file that will be stored. Larger
        files are detected but skipped (shown with a "Too large" badge).
+
+Report Generation
+-----------------
+
+The PDF report request carries a base64-encoded PNG of the topology diagram
+(force-directed and hierarchical layouts) as a single JSON string field. Jackson
+caps any single JSON string token at 20 MB by default, purely as a memory-safety
+guard against unbounded allocation from one request — a dense topology's
+captured diagram can exceed that, which fails the request with
+``String length (...) exceeds the maximum length (...)`` before it reaches the
+controller.
+
+There is no separate variable for this. Like the upload limit in
+`Memory & Upload`_, it is **derived from** ``APP_MEMORY_MB`` by
+``backend/docker-entrypoint.sh``: 2.5% of the effective budget, clamped to
+8-256 MB. At the default ``APP_MEMORY_MB=2048`` that is ~51 MB — above
+Jackson's 20 MB default but still a small, heap-proportional ceiling rather
+than a flat one, so it doesn't threaten a small deployment's heap the way a
+fixed 50 MB default would. Raise ``APP_MEMORY_MB`` (see `Memory & Upload`_) if
+large/dense topology diagrams still fail to download. See
+:doc:`../features/report-export`.
 
 Frontend (build-time)
 ---------------------

--- a/scripts/check_env_passthrough.py
+++ b/scripts/check_env_passthrough.py
@@ -64,6 +64,7 @@ STACKS = {
 EXEMPT = {
     "MAX_UPLOAD_SIZE_BYTES":   "passed as -D by backend/docker-entrypoint.sh, derived from the memory budget",
     "ANALYSIS_TIMEOUT_SECONDS": "passed as -D by backend/docker-entrypoint.sh, derived from the memory budget",
+    "JACKSON_MAX_STRING_LENGTH": "passed as -D by backend/docker-entrypoint.sh, derived from the memory budget",
     "SERVER_PORT":             "internal; fixed at 8080 behind nginx",
     "SPRING_PROFILES_ACTIVE":  "set per compose file to select the profile",
     "LOG_DIR":                 "set by backend/docker-entrypoint.sh",


### PR DESCRIPTION
## Summary
- Report downloads could fail with `JSON parse error: String length (...) exceeds the maximum length (20000000)` — the PDF report request embeds the topology diagram as a base64-encoded PNG in one JSON field, and a dense-enough network topology pushes that string past Jackson's default 20MB max-string-length constraint, rejecting the request before it reaches `ReportController`.
- Added `JacksonConfig` (`Jackson2ObjectMapperBuilderCustomizer`) raising the cap.
- Made the cap scale with the deployment's memory budget instead of a flat default — `backend/docker-entrypoint.sh` now derives it the same way it already derives `MAX_UPLOAD_SIZE_BYTES`/analysis timeout from `APP_MEMORY_MB`: 2.5% of the effective budget, clamped to [8, 256] MB (~51MB at the default `APP_MEMORY_MB=2048`).
- Documented in `.env.example` and `docs/configuration/environment-variables.rst`, folded into the existing "Memory & Upload" derivation story rather than as a separately-settable var (consistent with how upload size/timeout are documented).

Closes #792. Follow-up filed: #791 (no execution test currently exercises any of the `docker-entrypoint.sh`-derived values — only a static ratio check).

## Test plan
- [x] `JacksonConfigTest` (new): plain `ObjectMapper` rejects a string past the 20MB default; the customized mapper accepts it; still rejects past its own configured limit.
- [x] `mvn test -Dtest=JacksonConfigTest,WebConfigTest,ControllerContractTest` — 14/14 passing, including the ArchUnit/API-conventions contract test.
- [x] End-to-end against a real rebuilt container (`docker compose up -d --build backend`): startup log confirms `Max JSON string = 51 MB` at default `APP_MEMORY_MB=2048`. Posted a 30MB payload to `/api/v1/files/{fileId}/report` (fake file ID) — previously would 400 with the JSON parse error, now reaches the controller and 404s on the file lookup instead. Posted a 55MB payload (above the new cap) — correctly 500s with `StreamConstraintsException` at the new `53477376`-byte (51MB) threshold, confirming the cap is raised, not disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDyaaPSRNzNXRzJoS794C4