### PR TITLE
release: report-download JSON string cap, upload-cap heap fit, ETA fixes, and accumulated dev fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@
 # APP_MEMORY_MB unless BACKEND_MEM_LIMIT overrides it), else APP_MEMORY_MB:
 #   - Container limit  = APP_MEMORY_MB (cgroup cap; see BACKEND_MEM_LIMIT below)
 #   - JVM heap         = 50% of the effective budget
-#   - Max upload size  = 25% of the effective budget
+#   - Max upload size  = 16% of the effective budget
 #   - Nginx body limit = max upload + 50 MB multipart buffer
 #   - Proxy / analysis timeout scales with memory (300–900 s)
 #
@@ -18,10 +18,16 @@
 # (metaspace, thread stacks, direct buffers). See issue #378 and
 # docs/operations/production-hardening.rst (Container Resource Limits).
 #
+# The upload cap is 16%, not 25%, because analysis holds the whole capture in heap while parsing,
+# so an accepted file must fit in about a third of it. It was 25% when the heap was 75%; when the
+# heap dropped to 50% the cap was not revisited, and a 468 MB capture was accepted and then died
+# of OutOfMemoryError 25 minutes in (#779). scripts/check_memory_budget.py now fails the build if
+# the two drift apart again.
+#
 # Examples:
-#   2048  →  512 MB max upload, 1 GB heap  (default, suitable for most laptops)
-#   4096  →  1 GB  max upload, 2 GB heap   (recommended for captures >100 MB)
-#   8192  →  2 GB  max upload, 4 GB heap
+#   2048  →  327 MB max upload, 1 GB heap  (default, suitable for most laptops)
+#   4096  →  655 MB max upload, 2 GB heap   (recommended for captures >100 MB)
+#   8192  →  1.3 GB max upload, 4 GB heap
 APP_MEMORY_MB=2048
 
 # Container Resource Limits (issue #378)
@@ -247,3 +253,59 @@ VITE_SUPPORTED_FILE_TYPES=.pcap,.pcapng,.cap
 # limit in the Network Topology Diagram. Disabling this loads every conversation into the diagram,
 # which may cause browser slowdowns or out-of-memory errors on large captures.
 VITE_NETWORK_DIAGRAM_CONVERSATION_LIMIT=false
+
+# =============================================================================
+# Threat detection (Suricata)
+# =============================================================================
+# SURICATA_WARM_ENGINE_ENABLED: keep one Suricata process loaded between analyses instead of
+# rebuilding its ~50,000-rule detection engine per file. Measured 44s -> ~0.3s per capture with
+# identical alerts (#569). The per-file subprocess remains as an automatic fallback, so the worst
+# case of a broken warm engine is the old behaviour, not lost threat detection.
+SURICATA_WARM_ENGINE_ENABLED=true
+# Command socket. Must be writable by the container's runtime user (the app runs as `spring`, and
+# Suricata's packaged log directory is root-owned).
+SURICATA_WARM_ENGINE_SOCKET=/tmp/tracepcap-suricata/suricata.sock
+# Seconds to wait for the engine to finish building its ruleset before giving up on it.
+SURICATA_WARM_ENGINE_STARTUP_TIMEOUT=180
+# Seconds a single capture may take once the engine is warm.
+SURICATA_WARM_ENGINE_RUN_TIMEOUT=600
+# Seconds a caller waits for the engine before falling back. Generous on purpose: falling back
+# costs a full cold run, so waiting is almost always the better trade. A short wait was measurably
+# worse — eight concurrent captures each started their own Suricata and one Extract stage took 430s.
+SURICATA_WARM_ENGINE_LOCK_WAIT=900
+# Seconds for a single socket command. These are short exchanges; longer means the engine is wedged.
+SURICATA_WARM_ENGINE_COMMAND_TIMEOUT=30
+
+# =============================================================================
+# Story mode (LLM)
+# =============================================================================
+# LLM_TOOL_CALLING: auto = try tools once and remember whether the server accepts them,
+# on = always send them, off = the free-text-JSON path (#623).
+LLM_TOOL_CALLING=auto
+
+# =============================================================================
+# Network Cluster tuning
+# =============================================================================
+# Caps on what the cluster graph renders; raising them costs browser rendering time, not accuracy.
+INTELLIGENCE_MAX_CLUSTERS=60
+INTELLIGENCE_MAX_EDGES=200
+# Thresholds for the per-host DNS and HTTP suspicion signals. A host must exceed the minimum
+# volume before its ratio is considered at all, so a single failed lookup is not "suspicious".
+DNS_NXDOMAIN_SUSPICIOUS_RATIO=0.5
+DNS_NXDOMAIN_MIN_QUERIES=20
+HTTP_CLIENT_ERROR_SUSPICIOUS_RATIO=0.5
+HTTP_MIN_REQUESTS=20
+
+# =============================================================================
+# Miscellaneous
+# =============================================================================
+# APP_VERSION: baked in at build time. The default lives in docker-compose.yml and is synced on
+# every merge to dev by .github/workflows/app-version.yml; set this only to override a build.
+# APP_VERSION=
+# Path to the custom signature rules file, mounted into the backend.
+SIGNATURES_PATH=./signatures.yml
+# Resource caps for the one-shot MinIO bucket-initialisation container.
+MINIO_INIT_CPU_LIMIT=0.5
+MINIO_INIT_MEM_LIMIT=128M
+# TRACEPCAP_AUTH_ENABLED: set false only for local development without Keycloak.
+TRACEPCAP_AUTH_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -242,6 +242,14 @@ EXTRACTION_MAX_STREAM_CONVERSATIONS=50
 # Larger files are detected but skipped (shown with a "Too large" badge). Increase to store bigger files.
 EXTRACTION_MAX_FILE_SIZE_MB=50
 
+# Report Generation
+# The max size of a single JSON string value (the PDF report's base64-encoded topology diagram is
+# the only field that can get this big) is NOT set directly here — like the upload limit above, it
+# is derived from APP_MEMORY_MB by backend/docker-entrypoint.sh (2.5% of the effective budget,
+# clamped to 8-256 MB) so it scales with the memory actually available instead of using Jackson's
+# fixed 20 MB default regardless of deployment size. Raise APP_MEMORY_MB if large topology diagrams
+# still fail to download.
+
 # Frontend Configuration
 # VITE_MAP_RESOLUTION: Controls the polygon fidelity of the world map at build time.
 # Allowed values: 110m (low fidelity, ~170 KB), 50m (medium — default, ~760 KB), 10m (high fidelity, ~1 MB)

--- a/.github/workflows/env-passthrough.yml
+++ b/.github/workflows/env-passthrough.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'backend/src/main/resources/application*.yml'
       - 'docker-compose*.yml'
+      - '.env.example'
       - 'scripts/check_env_passthrough.py'
       - '.github/workflows/env-passthrough.yml'
   workflow_dispatch:

--- a/.github/workflows/memory-budget.yml
+++ b/.github/workflows/memory-budget.yml
@@ -1,0 +1,46 @@
+name: Memory Budget
+
+# Stage 2 of the analysis pipeline holds the whole capture in heap, so the largest file the app
+# accepts is bounded by the JVM heap. Those two numbers are derived separately in
+# backend/docker-entrypoint.sh, and nothing connected them: #92 set the upload cap at 25% when the
+# heap was 75%, #586 lowered the heap to 50% without revisiting the cap, and a 468MB capture was
+# then accepted and died of OutOfMemoryError 25 minutes into parsing (#779).
+#
+# Static and instant. It asserts the relationship between the limits, which is the thing that
+# drifted; whether the parser's real multiplier is a third of the heap is a separate question that
+# only a capacity test can answer.
+
+on:
+  pull_request:
+    paths:
+      - 'backend/docker-entrypoint.sh'
+      - 'backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java'
+      - 'scripts/check_memory_budget.py'
+      - '.github/workflows/memory-budget.yml'
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - 'backend/docker-entrypoint.sh'
+      - 'backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java'
+      - 'scripts/check_memory_budget.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Upload cap fits the heap that parses it
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        # Pinned and without a persisted token: this job only reads two files.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Check the upload cap against the heap budget
+        run: python3 scripts/check_memory_budget.py

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -36,6 +36,21 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
+      # tshark, editcap and capinfos, because without them the tool-dependent tests pass while
+      # testing nothing (#701). Those services degrade gracefully by design, so a missing binary
+      # is not an error — the subprocess fails to start, the catch fires, the method returns
+      # early, and the assertions still hold. Verified by hiding tshark from PATH locally:
+      # DnsQueryLogExtractorTest reported 13 passed either way. The 4-point coverage gap between
+      # this job and a developer's machine was that, made visible.
+      #
+      # Suricata is deliberately not installed: it is ~700MB of ruleset and ~45s of engine build
+      # per run (#569), and the full-stack job already exercises it against a real container.
+      - name: Install packet-analysis tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tshark
+          tshark --version | head -1
+
       # Testcontainers needs a Docker daemon; ubuntu-latest runners provide one.
       - name: Run unit + integration tests
         run: mvn -B clean verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,20 @@ The version stamp runs on `dev` deliberately. If its chore PR landed on `main`, 
 drift ahead of `dev` and every later release would start from a diverged base. At release time
 `dev` and `main` are equal, so stamping from `dev` still records exactly the released commit.
 
+### Why `dev` is a protected branch
+
+The repository has **"Automatically delete head branches"** enabled, which is what keeps merged
+feature branches from piling up. A release PR's head branch is `dev` — so the first `dev -> main`
+release deleted `dev` on merge. It came back from `main` with nothing lost, because the two are
+identical at exactly that moment, but every open PR based on `dev` would have been orphaned.
+
+`dev` is therefore protected with `allow_deletions: false`, matching `main`. GitHub will not
+delete a protected branch, so the setting keeps tidying feature branches and cannot touch either
+long-lived one.
+
+The `delete-branch-on-close.yml` workflow already treats a 422 as "protected, leave it", so it
+needs no exclusion list — the protection is the exclusion list.
+
 ### Cutting a release
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This makes it well-suited for:
 
 | Feature | Description |
 |---------|-------------|
-| **PCAP Upload & Management** | Upload and manage PCAP/PCAPNG/CAP files (upload limit derived from `APP_MEMORY_MB`, 512MB by default) with MinIO object storage; duplicate detection and configurable upload limits |
+| **PCAP Upload & Management** | Upload and manage PCAP/PCAPNG/CAP files (upload limit derived from `APP_MEMORY_MB`, 327MB by default) with MinIO object storage; duplicate detection and configurable upload limits |
 | **Network Visualization** | Interactive network topology using Sigma.js (WebGL) + graphology with ForceAtlas2 / ELK layouts, a rich filter panel (IP, port, device type, protocol, risk), fullscreen toggle, layout controls, and clickable node detail panels |
 | **nDPI Security Detection** | Deep packet inspection via nDPI v5: application identification, traffic categories, risk/alert flags, JA3/JA3S TLS fingerprints, SNI extraction, and TLS certificate metadata per conversation |
 | **Conversation Tracking** | Paginated conversation list with advanced filtering (IP, port, protocol, app, risk, custom rules, device type, country, payload pattern), multi-column sorting, column picker, and bulk PCAP export |
@@ -89,11 +89,12 @@ or internet-hosted API.
 | Storage | 10GB (database, PCAP files, object storage) | 50GB+ for large PCAP collections | 100GB+ SSD |
 
 **Comfortable** assumes Suricata enabled and routine work on large captures. Raise the
-`.env` defaults to match — the shipped `APP_MEMORY_MB=2048` caps uploads at 512MB, since
-max upload is 25% of the backend budget:
+`.env` defaults to match — the shipped `APP_MEMORY_MB=2048` caps uploads at 327MB, since
+max upload is 16% of the backend budget (at most 1/3 of the 50% heap, since the parser
+holds the whole capture in memory):
 
 ```ini
-APP_MEMORY_MB=8192      # 4 GB heap, 2 GB max upload
+APP_MEMORY_MB=8192      # 4 GB heap, ~1.3 GB max upload
 BACKEND_CPU_LIMIT=6
 POSTGRES_MEM_LIMIT=2g
 MINIO_MEM_LIMIT=1g
@@ -117,8 +118,8 @@ cp .env.example .env
 **2. Configure `.env`:**
 ```env
 # Memory & Upload Configuration
-# Upload limits are derived from this single value (max upload = 25% of it).
-APP_MEMORY_MB=2048  # 512MB max upload (default)
+# Upload limits are derived from this single value (max upload = 16% of it).
+APP_MEMORY_MB=2048  # 327MB max upload (default)
 
 # Nginx Port Configuration
 NGINX_PORT=80  # Change if port 80 is already in use
@@ -171,7 +172,7 @@ The Network Monitor lets you build a picture of an unknown network from multiple
 
 ### Supported File Formats
 
-PCAP, PCAPNG, CAP (max 512MB default, derived from `APP_MEMORY_MB`)
+PCAP, PCAPNG, CAP (max 327MB default, derived from `APP_MEMORY_MB`)
 
 ## How Network Monitor Works
 

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -126,6 +126,22 @@ echo "  Native headroom      = $(( 100 - JVM_HEAP_PERCENT ))% for JVM non-heap +
 echo "  Max upload size      = $(( MAX_UPLOAD_BYTES / 1024 / 1024 )) MB"
 echo "  Analysis timeout     = ${TIMEOUT} s"
 
+# Die on heap exhaustion instead of limping (#779).
+#
+# A capture larger than the heap threw OutOfMemoryError inside a request thread and killed Tomcat's
+# http-nio-8080-Poller. The container stayed "running" and healthy to `docker compose ps` while
+# serving nothing: every API call timed out, and recovery needed a human noticing and restarting it.
+# One oversized upload took the service down for everyone, silently.
+#
+# Exiting turns that into something the platform can act on — `restart: unless-stopped` is set on
+# this service, so the container comes back by itself. A JVM whose heap is exhausted has no
+# reliable path back to health anyway; the only question is whether the failure is visible.
+#
+# Deliberately no -XX:+HeapDumpOnOutOfMemoryError: the dump is roughly heap-sized (~1 GB at the
+# default budget) and would land on a volume that already has to hold captures. Enable it by hand
+# when actually diagnosing one.
+JVM_MEM_OPTS="${JVM_MEM_OPTS} -XX:+ExitOnOutOfMemoryError"
+
 # shellcheck disable=SC2086 # JVM_MEM_OPTS is intentionally word-split into separate flags
 exec gosu spring java \
   ${JVM_MEM_OPTS} \

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -82,6 +82,19 @@ TIMEOUT=$(( EFFECTIVE_MEM_MB * 45 / 100 ))
 if [ "$TIMEOUT" -lt 300 ]; then TIMEOUT=300; fi
 if [ "$TIMEOUT" -gt 900 ]; then TIMEOUT=900; fi
 
+# Max length (chars) of a single JSON string value across the API — currently only reachable via
+# the PDF report's base64-encoded topology diagram, which a dense capture can inflate past
+# Jackson's own fixed 20MB default. That default doesn't know how much heap it's borrowing
+# against, so it's too generous on a small deployment and an arbitrary ceiling on a large one.
+# 2.5% of the effective budget, clamped to [8, 256] MB (#792). Unlike the upload path, parsing
+# one JSON string only needs a small multiple of its own size in transient buffer growth (no
+# whole-capture object graph held alongside it), so this stays well under the heap fraction the
+# upload cap uses — see MAX_UPLOAD_BYTES above.
+JACKSON_MAX_STRING_MB=$(( EFFECTIVE_MEM_MB / 40 ))
+if [ "$JACKSON_MAX_STRING_MB" -lt 8 ]; then JACKSON_MAX_STRING_MB=8; fi
+if [ "$JACKSON_MAX_STRING_MB" -gt 256 ]; then JACKSON_MAX_STRING_MB=256; fi
+JACKSON_MAX_STRING_BYTES=$(( JACKSON_MAX_STRING_MB * 1024 * 1024 ))
+
 # Ensure signatures.yml exists and is writable by the spring user.
 # Runs as root so it can fix ownership regardless of how the named volume was seeded.
 if [ ! -f /app/config/signatures.yml ] && [ -f /app/config-defaults/signatures.yml ]; then
@@ -125,6 +138,7 @@ echo "  JVM heap             = ${JVM_HEAP_MB} MB (${JVM_HEAP_PERCENT}% of budget
 echo "  Native headroom      = $(( 100 - JVM_HEAP_PERCENT ))% for JVM non-heap + tshark/ndpi/Suricata"
 echo "  Max upload size      = $(( MAX_UPLOAD_BYTES / 1024 / 1024 )) MB"
 echo "  Analysis timeout     = ${TIMEOUT} s"
+echo "  Max JSON string      = ${JACKSON_MAX_STRING_MB} MB (report topology diagram)"
 
 # Die on heap exhaustion instead of limping (#779).
 #
@@ -147,4 +161,5 @@ exec gosu spring java \
   ${JVM_MEM_OPTS} \
   -DMAX_UPLOAD_SIZE_BYTES=${MAX_UPLOAD_BYTES} \
   -DANALYSIS_TIMEOUT_SECONDS=${TIMEOUT} \
+  -DJACKSON_MAX_STRING_LENGTH=${JACKSON_MAX_STRING_BYTES} \
   -jar app.jar

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -70,7 +70,12 @@ esac
 # the same effective budget keeps the 50/25 split coherent at any limit.
 #
 # Max upload = 25% of the effective budget, expressed in bytes
-MAX_UPLOAD_BYTES=$(( EFFECTIVE_MEM_MB * 25 / 100 * 1024 * 1024 ))
+# 16%, not 25%: stage 2 holds the whole capture in heap, so an accepted file must fit in a
+# third of it (#92's original rule). That held when the heap was 75%; #586 lowered it to 50%
+# for native subprocesses without revisiting this, and a 468MB capture was accepted and then
+# died of OutOfMemoryError 25 minutes into parsing (#779). scripts/check_memory_budget.py
+# now fails the build if these two drift apart again.
+MAX_UPLOAD_BYTES=$(( EFFECTIVE_MEM_MB * 16 / 100 * 1024 * 1024 ))
 
 # Analysis/proxy timeout: 45% of the effective budget, clamped to [300, 900] seconds
 TIMEOUT=$(( EFFECTIVE_MEM_MB * 45 / 100 ))

--- a/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/AnalysisService.java
@@ -70,23 +70,53 @@ public class AnalysisService {
   private record StageStep(String label, int weight) {}
 
   /** Builds the ordered list of stages that will run for {@code file}, given its enabled options. */
-  private static List<StageStep> buildStagePlan(FileEntity file) {
-    boolean ndpi = file.isEnableNdpi();
-    // Weight only: the effective Suricata state (incl. the global kill-switch) is decided inside the
-    // extractor; using the per-file flag here is a close-enough heuristic for bar proportions.
+  /**
+   * Relative stage weights for the progress bar (#758).
+   *
+   * <p>The previous numbers were a reasonable guess that did not survive measurement: they put
+   * "Detecting applications & threats" at 35% of the job when it was 95%, so the bar sat at 23%
+   * for the whole of a 46-second analysis and then swept to 100% in under two seconds. A bar that
+   * is motionless for most of a job teaches people to ignore it, and an operator who cannot tell
+   * "working" from "hung" kills a job that was fine.
+   *
+   * <p>These are measured shares from real runs rather than estimates. Two profiles, because one
+   * vector cannot describe both: Suricata's detection engine costs ~45 s to build and ~0.3 s to
+   * use, so the first capture after a restart has a completely different shape from every capture
+   * after it (#569). {@link SuricataEngine#isWarm()} says which one we are in.
+   *
+   * <p>Still approximate for a different reason: parsing and the database writes scale with the
+   * capture while the rest does not, so these shares are right for a mid-sized capture and drift
+   * at the extremes. Re-weighting from the packet count once parsing has finished is the next step
+   * and is deliberately not attempted here.
+   */
+  private List<StageStep> buildStagePlan(FileEntity file) {
+    boolean extraction = file.isEnableFileExtraction();
+    // The per-file flag, not the effective state: the kill-switch is the extractor's business.
+    // Only the weighting depends on this, so being wrong costs a slightly misshapen bar.
     boolean suricata = file.isEnableSuricata();
+    boolean coldEngine = suricata && !suricataEngine.isWarm();
+
     List<StageStep> plan = new ArrayList<>();
     plan.add(new StageStep("Downloading capture", 3));
-    plan.add(new StageStep("Parsing packets", 20));
-    plan.add(new StageStep("Detecting applications & threats", 5 + (ndpi ? 10 : 0) + (suricata ? 20 : 0)));
-    plan.add(new StageStep("Classifying hosts & geo-locating", 12));
-    plan.add(new StageStep("Saving analysis summary", 2));
-    plan.add(new StageStep("Writing conversations & packets", 20));
-    if (file.isEnableFileExtraction()) {
-      plan.add(new StageStep("Extracting transferred files", 8));
+    plan.add(new StageStep("Parsing packets", coldEngine ? 2 : 21));
+    // The one stage whose cost is not about this capture at all: on a cold engine it is the
+    // ruleset build, which dwarfs everything else and is paid once per process.
+    // Labelled for what it is on a cold engine. The bar cannot move inside a stage, so this one
+    // stands still for ~45s however it is weighted; naming the wait as one-time setup is the
+    // difference between "hung" and "working on something known to be slow".
+    plan.add(
+        coldEngine
+            ? new StageStep("Building threat-detection ruleset (first run)", 90)
+            : new StageStep("Detecting applications & threats", 21));
+    plan.add(new StageStep("Classifying hosts & geo-locating", coldEngine ? 2 : 30));
+    plan.add(new StageStep("Saving analysis summary", 1));
+    plan.add(new StageStep("Writing conversations & packets", coldEngine ? 1 : 4));
+    if (extraction) {
+      plan.add(new StageStep("Extracting transferred files", coldEngine ? 1 : 22));
     }
     return plan;
   }
+
 
   /**
    * Publishes progress for the stage at {@code index} (0-based). {@code percent} is the weighted
@@ -134,6 +164,7 @@ public class AnalysisService {
   private final HostnameAdjudicator hostnameAdjudicator;
   private final org.springframework.context.ApplicationEventPublisher eventPublisher;
   private final HostnameClaimWriter hostnameClaimWriter;
+  private final SuricataEngine suricataEngine;
 
   /**
    * Runs the capture through the pipeline (#512 slice 7).

--- a/backend/src/main/java/com/tracepcap/analysis/service/PcapParserService.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/PcapParserService.java
@@ -32,6 +32,8 @@ public class PcapParserService {
     Map<String, LinkedHashSet<String>> hostMacObservations = new HashMap<>();
 
     Map<String, ConversationInfo> conversationMap = new HashMap<>();
+    // Discarded with the parse; see pooled().
+    Map<String, String> stringPool = new HashMap<>();
 
     // Fields: epoch | len | ipv4.src | ipv4.dst | ipv6.src | ipv6.dst |
     //         tcp.sport | tcp.dport | udp.sport | udp.dport | protocol | info |
@@ -333,6 +335,7 @@ public class PcapParserService {
             conv.getPackets()
                 .add(
                     buildPacketInfo(
+                        stringPool,
                         frameNumber,
                         timestamp,
                         srcIp,
@@ -381,7 +384,26 @@ public class PcapParserService {
   // Helpers
   // ---------------------------------------------------------------------------
 
+  /**
+   * Pool for the values every packet repeats (#779).
+   *
+   * <p>A capture has a few hundred distinct addresses and a handful of protocols, but millions of
+   * packets, and {@code split()} hands back a fresh String for each one. At ~776 bytes per
+   * PacketInfo, 1.7M packets need ~1.26 GB against a 1 GB heap — which is the OutOfMemoryError.
+   * Addresses and protocols are ~150 of those bytes and are almost entirely duplicates.
+   *
+   * <p>A local map rather than {@link String#intern()}: intern's table is JVM-wide and permanent,
+   * so a capture's addresses would outlive the analysis that read them. This is discarded with the
+   * parse.
+   */
+  private static String pooled(Map<String, String> pool, String value) {
+    if (value == null) return null;
+    String existing = pool.putIfAbsent(value, value);
+    return existing != null ? existing : value;
+  }
+
   private PacketInfo buildPacketInfo(
+      Map<String, String> pool,
       long packetNumber,
       LocalDateTime timestamp,
       String srcIp,
@@ -396,11 +418,11 @@ public class PcapParserService {
     PacketInfo pkt = new PacketInfo();
     pkt.setPacketNumber(packetNumber);
     pkt.setTimestamp(timestamp);
-    pkt.setSrcIp(srcIp);
+    pkt.setSrcIp(pooled(pool, srcIp));
     pkt.setSrcPort(srcPort);
-    pkt.setDstIp(dstIp);
+    pkt.setDstIp(pooled(pool, dstIp));
     pkt.setDstPort(dstPort);
-    pkt.setProtocol(protocol);
+    pkt.setProtocol(pooled(pool, protocol));
     pkt.setPacketSize(packetSize);
     pkt.setInfo(info);
     pkt.setPayload(payloadHex);

--- a/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
@@ -1,5 +1,6 @@
 package com.tracepcap.analysis.service;
 
+import com.tracepcap.common.stage.DetectionEngineStatus;
 import jakarta.annotation.PreDestroy;
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +37,7 @@ import org.springframework.stereotype.Component;
  */
 @Slf4j
 @Component
-public class SuricataEngine {
+public class SuricataEngine implements DetectionEngineStatus {
 
   private static final String SURICATASC = "suricatasc";
   private static final String SURICATA = "suricata";
@@ -90,6 +91,7 @@ public class SuricataEngine {
    * <p>Progress estimation needs this because it is the difference between one stage taking 0.3 s
    * and taking 45 s, and no static weighting can describe both (#758).
    */
+  @Override
   public boolean isWarm() {
     return warm && daemon != null && daemon.isAlive();
   }

--- a/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
@@ -227,6 +227,7 @@ public class SuricataEngine implements DetectionEngineStatus {
         String current = runCommand("pcap-current");
         if (current == null) {
           log.warn("Lost contact with the warm Suricata engine — falling back");
+          discardDaemon();
           return false;
         }
         if (current.contains("None") && Files.exists(eve)) return true;

--- a/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
@@ -76,12 +76,31 @@ public class SuricataEngine {
   private final ReentrantLock lock = new ReentrantLock();
   private volatile Process daemon;
 
+  /**
+   * Whether the engine has finished building its ruleset.
+   *
+   * <p>A plain flag rather than a probe: callers ask this to size a progress bar, and shelling out
+   * to suricatasc to answer would cost more than the question is worth.
+   */
+  private volatile boolean warm;
+
+  /**
+   * Whether the next capture can skip the ~45 s detection-engine build (#569).
+   *
+   * <p>Progress estimation needs this because it is the difference between one stage taking 0.3 s
+   * and taking 45 s, and no static weighting can describe both (#758).
+   */
+  public boolean isWarm() {
+    return warm && daemon != null && daemon.isAlive();
+  }
+
   /** Where a warm run writes, kept apart from the caller's fallback output. */
   public static Path warmDir(Path outDir) {
     return outDir.resolve("warm");
   }
 
   private void discardDaemon() {
+    warm = false;
     Process p = daemon;
     daemon = null;
     if (p != null && p.isAlive()) p.destroyForcibly();
@@ -143,6 +162,7 @@ public class SuricataEngine {
         }
         if (isResponsive()) {
           log.info("Warm Suricata engine ready");
+          warm = true;
           return true;
         }
         Thread.sleep(1000);

--- a/backend/src/main/java/com/tracepcap/common/stage/DetectionEngineStatus.java
+++ b/backend/src/main/java/com/tracepcap/common/stage/DetectionEngineStatus.java
@@ -1,0 +1,21 @@
+package com.tracepcap.common.stage;
+
+/**
+ * Whether the threat-detection engine is already loaded (#569).
+ *
+ * <p>A port because the answer changes an estimate by a factor of twenty and the module that needs
+ * it lives outside {@code analysis}: Suricata's ruleset build costs ~45 s once per process, so a
+ * capture that has to pay it is a different job from one that does not, and the ETA shown at upload
+ * has to say which (#758).
+ *
+ * <p>In {@code common} rather than {@code analysis.spi} because {@code analysis} already depends on
+ * {@code file} — putting it there would close the {@code analysis <-> file} cycle that #512 slice 1
+ * was written to break. Both sides depend on this instead, the same arrangement as
+ * {@code common.net.LocalityPolicy}.
+ */
+@FunctionalInterface
+public interface DetectionEngineStatus {
+
+  /** True when the next capture can skip the one-time engine build. */
+  boolean isWarm();
+}

--- a/backend/src/main/java/com/tracepcap/config/JacksonConfig.java
+++ b/backend/src/main/java/com/tracepcap/config/JacksonConfig.java
@@ -1,0 +1,33 @@
+package com.tracepcap.config;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Raises Jackson's default 20MB max-string-length constraint (jackson-databind 2.15+), which
+ * otherwise rejects report-generation request bodies carrying a base64-encoded topology diagram
+ * PNG once the capture is large/dense enough to push the base64 string past the default. See
+ * #792.
+ */
+@Configuration
+public class JacksonConfig {
+
+  @Value("${tracepcap.jackson.max-string-length}")
+  private int maxStringLength;
+
+  @Bean
+  public Jackson2ObjectMapperBuilderCustomizer streamReadConstraintsCustomizer() {
+    return builder ->
+        builder.postConfigurer(
+            mapper ->
+                mapper
+                    .getFactory()
+                    .setStreamReadConstraints(
+                        StreamReadConstraints.builder()
+                            .maxStringLength(maxStringLength)
+                            .build()));
+  }
+}

--- a/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
+++ b/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
@@ -5,6 +5,7 @@ import com.tracepcap.file.dto.FileUploadResponse;
 import com.tracepcap.file.entity.FileEntity;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import com.tracepcap.common.stage.DetectionEngineStatus;
 
 /** Mapper for converting between FileEntity and DTOs */
 @Component
@@ -13,27 +14,44 @@ public class FileMapper {
   // Global Suricata kill-switch (SURICATA_ENABLED). When false, Suricata never ran regardless of
   // the per-file flag, so the DTO must report the effective state — matching ReportService and
   // AnalysisService — otherwise the UI would not flag such files as partial. See AnalysisService.
+  private final DetectionEngineStatus detectionEngine;
+
+  public FileMapper(DetectionEngineStatus detectionEngine) {
+    this.detectionEngine = detectionEngine;
+  }
+
   @Value("${tracepcap.suricata.enabled:true}")
   private boolean suricataEnabled;
 
   private static final int MIN_ESTIMATE_SECONDS = 10;
 
   // ---- Packet-based coefficients (preferred) ----------------------------------------------------
-  // Analysis cost is driven by packet COUNT, not bytes: Suricata/nDPI/parse all scale per-packet, so
-  // a small but packet-dense capture can take far longer than its size suggests. Seconds per 1000
-  // packets, calibrated against a clean OFFLINE run (21.4k packets, GEO_FORCE_OFFLINE): parse+
-  // classify+persist+DB ≈ 0.38, extract(nDPI+Suricata) ≈ 2.6, file-extract ≈ 0.04 s/kpkt. Values
-  // below keep a small conservative margin (better to slightly over-estimate). Suricata dominates.
-  // Only stages that will run contribute. See analysis-eta-calibration notes for recalibration.
-  private static final double BASE_SECONDS_PER_KPKT = 0.45; // parse + classify + persist + DB insert
-  private static final double NDPI_SECONDS_PER_KPKT = 0.6;
-  private static final double SURICATA_SECONDS_PER_KPKT = 2.1;
-  private static final double EXTRACTION_SECONDS_PER_KPKT = 0.08;
+  // seconds = fixed + per_kpkt * (packets / 1000), per stage group.
+  //
+  // The fixed term is the whole point. The previous model had only a per-packet rate, which is why
+  // it read 91 minutes for a job of roughly 36 and 10 seconds for one that took 49 — the same
+  // missing constant, in opposite directions. Measured cost per 1000 packets falls ~8x between a
+  // 250-packet capture and a 45,000-packet one, which is a fixed cost wearing a per-packet costume.
+  //
+  // Fitted by scripts/calibrate_analysis_eta.py over runs of 2k-45k packets. Re-run it rather than
+  // hand-editing these; it reads the timings the pipeline already logs, and it excludes cold-engine
+  // runs, which are a different regime rather than outliers.
+  private static final double BASE_FIXED_SECONDS = 1.6; // parse + classify + persist + DB insert
+  private static final double BASE_SECONDS_PER_KPKT = 0.43;
+  private static final double DETECT_FIXED_SECONDS = 0.4; // nDPI + Suricata, engine already warm
+  private static final double DETECT_SECONDS_PER_KPKT = 0.04;
+  private static final double EXTRACTION_SECONDS_PER_KPKT = 0.43; // file carving, no fixed cost
   private static final double DOWNLOAD_SECONDS_PER_MB = 0.01; // MinIO fetch, size-scaled
 
+  // Suricata builds its detection engine once per process, not once per capture (#569). ~45s,
+  // and it dwarfs everything else, so a capture that has to pay it is a different job — the same
+  // split the progress bar makes (#758).
+  private static final double SURICATA_ENGINE_BUILD_SECONDS = 45.0;
+
   // ---- Size-based fallback (used only when packet count is unknown) ------------------------------
-  // e.g. capinfos failed at upload, or a legacy file predating packet-count capture. ~0.5 s/MB
-  // all-stages-on, matching the older end-to-end measurement on large captures.
+  // e.g. capinfos failed at upload, or a legacy file predating packet-count capture. Deliberately
+  // cruder: bytes are a poor proxy for work, since a packet-dense capture costs far more than its
+  // size suggests. Kept only so an estimate exists at all.
   private static final double BASE_SECONDS_PER_MB = 0.15;
   private static final double NDPI_SECONDS_PER_MB = 0.10;
   private static final double SURICATA_SECONDS_PER_MB = 0.20;
@@ -47,17 +65,28 @@ public class FileMapper {
    * count nor size is known.
    */
   private Integer estimateAnalysisSeconds(
-      Long fileSize, Integer packetCount, boolean ndpi, boolean suricata, boolean fileExtraction) {
+      Long fileSize,
+      Integer packetCount,
+      boolean ndpi,
+      boolean suricata,
+      boolean fileExtraction,
+      boolean engineWarm) {
     if (packetCount != null && packetCount > 0) {
       double kPkt = packetCount / 1000.0;
-      double perKPkt =
-          BASE_SECONDS_PER_KPKT
-              + (ndpi ? NDPI_SECONDS_PER_KPKT : 0)
-              + (suricata ? SURICATA_SECONDS_PER_KPKT : 0)
-              + (fileExtraction ? EXTRACTION_SECONDS_PER_KPKT : 0);
-      double downloadTerm =
-          fileSize != null ? fileSize / 1024.0 / 1024.0 * DOWNLOAD_SECONDS_PER_MB : 0;
-      return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(kPkt * perKPkt + downloadTerm));
+      double seconds = BASE_FIXED_SECONDS + kPkt * BASE_SECONDS_PER_KPKT;
+      if (ndpi || suricata) {
+        seconds += DETECT_FIXED_SECONDS + kPkt * DETECT_SECONDS_PER_KPKT;
+      }
+      if (suricata && !engineWarm) {
+        seconds += SURICATA_ENGINE_BUILD_SECONDS;
+      }
+      if (fileExtraction) {
+        seconds += kPkt * EXTRACTION_SECONDS_PER_KPKT;
+      }
+      if (fileSize != null) {
+        seconds += fileSize / 1024.0 / 1024.0 * DOWNLOAD_SECONDS_PER_MB;
+      }
+      return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(seconds));
     }
     if (fileSize == null || fileSize <= 0) return null;
     double sizeMb = fileSize / 1024.0 / 1024.0;
@@ -103,7 +132,10 @@ public class FileMapper {
                 entity.getPacketCount(),
                 entity.isEnableNdpi(),
                 effectiveSuricata,
-                entity.isEnableFileExtraction()))
+                entity.isEnableFileExtraction(),
+                // Whether this capture pays the one-time ruleset build (#569) is the difference
+                // between a ~45s job and a ~2s one, so the estimate has to know.
+                detectionEngine.isWarm()))
         .build();
   }
 }

--- a/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
+++ b/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
@@ -95,7 +95,11 @@ public class FileMapper {
             + (ndpi ? NDPI_SECONDS_PER_MB : 0)
             + (suricata ? SURICATA_SECONDS_PER_MB : 0)
             + (fileExtraction ? EXTRACTION_SECONDS_PER_MB : 0);
-    return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(sizeMb * perMb));
+    double seconds = sizeMb * perMb;
+    if (suricata && !engineWarm) {
+      seconds += SURICATA_ENGINE_BUILD_SECONDS;
+    }
+    return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(seconds));
   }
 
   public FileUploadResponse toUploadResponse(FileEntity entity) {

--- a/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
+++ b/backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -43,7 +43,6 @@ import org.springframework.web.multipart.MultipartFile;
 /** Implementation of FileService */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class FileServiceImpl implements FileService {
 
   private final FileRepository fileRepository;
@@ -52,7 +51,29 @@ public class FileServiceImpl implements FileService {
   private final ApplicationEventPublisher eventPublisher;
 
   private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(".pcap", ".pcapng", ".cap");
-  private static final long MAX_FILE_SIZE = 500 * 1024 * 1024; // 500MB
+  /**
+   * The largest capture we will accept, from {@code app.max-file-size} (#779).
+   *
+   * <p>Was a hardcoded 500 MB, which is how a 468 MB capture was accepted and then failed with an
+   * OutOfMemoryError 25 minutes into parsing. The value the entrypoint derives from the memory
+   * budget, and that {@code /system/limits} reports to the upload page, was never consulted here —
+   * so the number the user was shown and the number actually enforced were different numbers.
+   */
+  private final long maxFileSize;
+
+  public FileServiceImpl(
+      FileRepository fileRepository,
+      StorageService storageService,
+      FileMapper fileMapper,
+      ApplicationEventPublisher eventPublisher,
+      @Value("${app.max-file-size:536870912}") long maxFileSize) {
+    this.fileRepository = fileRepository;
+    this.storageService = storageService;
+    this.fileMapper = fileMapper;
+    this.eventPublisher = eventPublisher;
+    this.maxFileSize = maxFileSize;
+  }
+
 
   @Override
   @Transactional
@@ -211,8 +232,9 @@ public class FileServiceImpl implements FileService {
     }
 
     // Check file size
-    if (file.getSize() > MAX_FILE_SIZE) {
-      throw new InvalidFileException("File size exceeds maximum allowed size of 500MB");
+    if (file.getSize() > maxFileSize) {
+      throw new InvalidFileException(
+          "File size exceeds maximum allowed size of " + (maxFileSize / 1024 / 1024) + "MB");
     }
 
     // Check file extension (strip any Windows/Unix path prefix before checking)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -327,3 +327,14 @@ tracepcap:
     iot-apps:
       - IPP
       - MDNS
+  jackson:
+    # Jackson's default max JSON string length (StreamReadConstraints) is 20MB. Report generation
+    # posts a base64-encoded topology diagram PNG in the request body, and a large/dense diagram
+    # capture can push that string past the default, rejecting the request before it reaches the
+    # controller. See JacksonConfig and #792.
+    #
+    # 53477376 (51MB) matches what backend/docker-entrypoint.sh derives at its documented default
+    # (APP_MEMORY_MB=2048 -> EFFECTIVE_MEM_MB/40 = 51MB) — kept in sync so a run that bypasses the
+    # entrypoint (mvn spring-boot:run, an IDE run, a test) behaves the same as the real deployment
+    # at that default, instead of silently falling back to a different cap.
+    max-string-length: ${JACKSON_MAX_STRING_LENGTH:53477376}

--- a/backend/src/test/java/com/tracepcap/analysis/ExternalToolsAvailableTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/ExternalToolsAvailableTest.java
@@ -1,0 +1,55 @@
+package com.tracepcap.analysis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The tools the extraction tests need must actually be present (#701).
+ *
+ * <p>Those services degrade gracefully by design: a missing binary is not an error, so the
+ * subprocess fails to start, the catch fires, the method returns early, and every assertion in
+ * {@code DnsQueryLogExtractorTest} still holds. Hiding {@code tshark} from {@code PATH} locally
+ * produced <b>13 passed</b>, exactly as with it present — the tests were verifying the
+ * degradation path while claiming to verify extraction.
+ *
+ * <p>That is invisible from a test report, which is why it survived: CI and a developer's machine
+ * ran identical counts, 340 tests and 1 skipped in both, and differed only by ~2,100 covered
+ * instructions.
+ *
+ * <p>This fails instead. It is not testing the tools; it is asserting the precondition that makes
+ * the other tests mean anything.
+ */
+class ExternalToolsAvailableTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"tshark", "editcap", "capinfos"})
+  void theToolIsOnThePath(String tool) {
+    assertThat(canRun(tool))
+        .as(
+            "%s is missing. The extraction tests will still pass without it — they will just be "
+                + "exercising the graceful-degradation path instead of the parsing they are named "
+                + "for (#701). Install it rather than deleting this assertion.",
+            tool)
+        .isTrue();
+  }
+
+  private static boolean canRun(String tool) {
+    try {
+      Process p = new ProcessBuilder(tool, "--version").redirectErrorStream(true).start();
+      if (!p.waitFor(20, TimeUnit.SECONDS)) {
+        p.destroyForcibly();
+        return false;
+      }
+      return p.exitValue() == 0;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+}

--- a/backend/src/test/java/com/tracepcap/analysis/service/PacketStringPoolingTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/service/PacketStringPoolingTest.java
@@ -1,0 +1,73 @@
+package com.tracepcap.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Packets share the strings they repeat (#779).
+ *
+ * <p>A capture has a few hundred distinct addresses and millions of packets, and {@code split()}
+ * returns a fresh String for every field of every packet. At ~776 bytes per PacketInfo, 1.7M
+ * packets need ~1.26 GB against a 1 GB heap — the OutOfMemoryError that made a 468 MB capture
+ * unanalysable.
+ *
+ * <p>Identity is the assertion, not equality: two equal Strings that are separate objects are
+ * exactly the waste being removed, and {@code isEqualTo} would pass while the bug remained.
+ */
+class PacketStringPoolingTest {
+
+  private static String pooled(Map<String, String> pool, String value) {
+    try {
+      Method m = PcapParserService.class.getDeclaredMethod("pooled", Map.class, String.class);
+      m.setAccessible(true);
+      return (String) m.invoke(null, pool, value);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("pooled() changed — update this test", e);
+    }
+  }
+
+  @Test
+  void repeatedValuesBecomeTheSameObject() {
+    Map<String, String> pool = new HashMap<>();
+    // Deliberately not literals: those would already be interned by the compiler and the test
+    // would pass without the pool doing anything.
+    String first = new String("192.168.1.1");
+    String second = new String("192.168.1.1");
+
+    assertThat(pooled(pool, first)).isSameAs(pooled(pool, second));
+  }
+
+  @Test
+  void distinctValuesStayDistinct() {
+    Map<String, String> pool = new HashMap<>();
+
+    assertThat(pooled(pool, new String("10.0.0.1")))
+        .isNotSameAs(pooled(pool, new String("10.0.0.2")));
+    assertThat(pooled(pool, new String("10.0.0.1"))).isEqualTo("10.0.0.1");
+  }
+
+  @Test
+  void nullPassesThroughRatherThanBeingPooled() {
+    Map<String, String> pool = new HashMap<>();
+
+    assertThat(pooled(pool, null)).isNull();
+    assertThat(pool).isEmpty();
+  }
+
+  @Test
+  void thePoolHoldsOneEntryPerDistinctValueNotOnePerPacket() {
+    // The property that bounds the saving: a million packets across ten addresses must cost ten
+    // strings, not a million.
+    Map<String, String> pool = new HashMap<>();
+    for (int i = 0; i < 10_000; i++) {
+      pooled(pool, new String("10.0.0." + (i % 10)));
+      pooled(pool, new String("TCP"));
+    }
+
+    assertThat(pool).hasSize(11);
+  }
+}

--- a/backend/src/test/java/com/tracepcap/analysis/service/StagePlanWeightingTest.java
+++ b/backend/src/test/java/com/tracepcap/analysis/service/StagePlanWeightingTest.java
@@ -1,0 +1,147 @@
+package com.tracepcap.analysis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.tracepcap.file.entity.FileEntity;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Progress weighting (#758).
+ *
+ * <p>The bar's job is to distinguish "working" from "hung". It failed at that: the old weights put
+ * the detection stage at 35% of the job when it was 95%, so the bar reached 23% almost immediately,
+ * sat there for 44 seconds, then swept to 100% in under two.
+ *
+ * <p>These assert the shape rather than exact numbers — the numbers are measured shares and will be
+ * re-measured when the pipeline changes, but the shape must hold: no stage may claim a share wildly
+ * unlike what it costs, and the cold and warm profiles must genuinely differ.
+ */
+class StagePlanWeightingTest {
+
+  private final SuricataEngine engine = mock(SuricataEngine.class);
+  private final AnalysisService service = serviceWithOnlyTheEngineWired();
+
+  /** 23 collaborators, one of which the plan needs; the rest are irrelevant to weighting. */
+  private AnalysisService serviceWithOnlyTheEngineWired() {
+    try {
+      var ctor = AnalysisService.class.getDeclaredConstructors()[0];
+      ctor.setAccessible(true);
+      Object[] args = new Object[ctor.getParameterCount()];
+      AnalysisService s = (AnalysisService) ctor.newInstance(args);
+      ReflectionTestUtils.setField(s, "suricataEngine", engine);
+      return s;
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("AnalysisService's constructor changed — update this test", e);
+    }
+  }
+
+  private static FileEntity file(boolean suricata, boolean extraction) {
+    FileEntity f = new FileEntity();
+    f.setEnableSuricata(suricata);
+    f.setEnableNdpi(true);
+    f.setEnableFileExtraction(extraction);
+    return f;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<?> plan(FileEntity f) {
+    try {
+      Method m = AnalysisService.class.getDeclaredMethod("buildStagePlan", FileEntity.class);
+      m.setAccessible(true);
+      return (List<Object>) m.invoke(service, f);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("buildStagePlan changed — update this test", e);
+    }
+  }
+
+  private int weightOf(Object step) {
+    return (int) ReflectionTestUtils.invokeGetterMethod(step, "weight");
+  }
+
+  private String labelOf(Object step) {
+    return (String) ReflectionTestUtils.invokeGetterMethod(step, "label");
+  }
+
+  private double shareOf(List<?> plan, String labelFragment) {
+    int total = plan.stream().mapToInt(this::weightOf).sum();
+    return plan.stream()
+            .filter(s -> labelOf(s).contains(labelFragment))
+            .mapToInt(this::weightOf)
+            .sum()
+        * 100.0
+        / total;
+  }
+
+  @Test
+  void onAColdEngineTheDetectionStageOwnsAlmostTheWholeBar() {
+    // Measured: 94.7% of a 47s first-run analysis is the ruleset build. Anything close to an
+    // even split here is what produced the 23%-for-95%-of-the-run stall.
+    when(engine.isWarm()).thenReturn(false);
+
+    assertThat(shareOf(plan(file(true, true)), "ruleset")).isGreaterThan(80.0);
+  }
+
+  @Test
+  void onAWarmEngineTheWorkIsSpreadAcrossStages() {
+    // Measured warm shares: parse 21%, detect 21%, classify 30%, extract-files 22%.
+    when(engine.isWarm()).thenReturn(true);
+    List<?> plan = plan(file(true, true));
+
+    assertThat(shareOf(plan, "Detecting")).isBetween(10.0, 35.0);
+    assertThat(shareOf(plan, "Classifying")).isBetween(15.0, 45.0);
+    assertThat(shareOf(plan, "Parsing")).isBetween(10.0, 35.0);
+  }
+
+  @Test
+  void theTwoProfilesAreActuallyDifferent() {
+    // The bug this fixes is one vector describing two very different jobs.
+    when(engine.isWarm()).thenReturn(false);
+    double cold = shareOf(plan(file(true, true)), "ruleset");
+    when(engine.isWarm()).thenReturn(true);
+    double warm = shareOf(plan(file(true, true)), "Detecting");
+
+    assertThat(cold - warm).isGreaterThan(40.0);
+  }
+
+  @Test
+  void aColdEngineSaysWhyItIsSlowAndThatItIsOneOff() {
+    // The bar cannot advance inside a stage, so this one is motionless for ~45s no matter how it
+    // is weighted. The label is what separates "hung" from "working on something known to be
+    // slow, once".
+    when(engine.isWarm()).thenReturn(false);
+
+    assertThat(plan(file(true, true)).stream().map(this::labelOf))
+        .anySatisfy(l -> assertThat(l).containsIgnoringCase("first run"));
+  }
+
+  @Test
+  void withSuricataOffTheColdPenaltyDoesNotApply() {
+    // No ruleset to build, so the first capture looks like every other one.
+    when(engine.isWarm()).thenReturn(false);
+
+    assertThat(shareOf(plan(file(false, true)), "Detecting")).isLessThan(35.0);
+    assertThat(plan(file(false, true)).stream().map(this::labelOf))
+        .noneSatisfy(l -> assertThat(l).containsIgnoringCase("first run"));
+  }
+
+  @Test
+  void theFileExtractionStageIsOnlyPlannedWhenItWillRun() {
+    when(engine.isWarm()).thenReturn(true);
+
+    assertThat(plan(file(true, false))).hasSize(6);
+    assertThat(plan(file(true, true))).hasSize(7);
+  }
+
+  @Test
+  void noStageIsWeightedZeroSoTheBarNeverStandsStill() {
+    // A zero-weight stage advances the bar by nothing while it runs, which reads as a hang.
+    when(engine.isWarm()).thenReturn(true);
+
+    assertThat(plan(file(true, true))).allSatisfy(s -> assertThat(weightOf(s)).isPositive());
+  }
+}

--- a/backend/src/test/java/com/tracepcap/config/JacksonConfigTest.java
+++ b/backend/src/test/java/com/tracepcap/config/JacksonConfigTest.java
@@ -1,0 +1,67 @@
+package com.tracepcap.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Guards against a regression of #792: Jackson's default 20MB max-string-length
+ * (StreamReadConstraints) rejected report-generation requests carrying a base64-encoded topology
+ * diagram once the capture was large enough, with the request failing before it reached the
+ * controller.
+ */
+class JacksonConfigTest {
+
+  // One character past jackson-databind's compiled-in default (StreamReadConstraints.DEFAULT_MAX_STRING_LEN).
+  private static final int OVER_JACKSON_DEFAULT = 20_000_001;
+
+  private static String jsonWithStringOfLength(int length) {
+    return "{\"value\":\"" + "a".repeat(length) + "\"}";
+  }
+
+  @Test
+  void unconfiguredObjectMapperRejectsAStringPastTheDefaultLimit() {
+    ObjectMapper mapper = new ObjectMapper();
+    String json = jsonWithStringOfLength(OVER_JACKSON_DEFAULT);
+
+    assertThatThrownBy(() -> mapper.readValue(json, Map.class))
+        .isInstanceOf(StreamConstraintsException.class);
+  }
+
+  @Test
+  void customizedObjectMapperAcceptsAStringPastTheDefaultLimit() throws Exception {
+    JacksonConfig config = new JacksonConfig();
+    ReflectionTestUtils.setField(config, "maxStringLength", 52_428_800);
+
+    Jackson2ObjectMapperBuilder builder = new Jackson2ObjectMapperBuilder();
+    config.streamReadConstraintsCustomizer().customize(builder);
+    ObjectMapper mapper = builder.build();
+
+    String json = jsonWithStringOfLength(OVER_JACKSON_DEFAULT);
+
+    Map<?, ?> parsed = (Map<?, ?>) mapper.readValue(json, Map.class);
+
+    assertThat(((String) parsed.get("value"))).hasSize(OVER_JACKSON_DEFAULT);
+  }
+
+  @Test
+  void customizedObjectMapperStillRejectsPastItsOwnConfiguredLimit() {
+    JacksonConfig config = new JacksonConfig();
+    ReflectionTestUtils.setField(config, "maxStringLength", 100);
+
+    Jackson2ObjectMapperBuilder builder = new Jackson2ObjectMapperBuilder();
+    config.streamReadConstraintsCustomizer().customize(builder);
+    ObjectMapper mapper = builder.build();
+
+    String json = jsonWithStringOfLength(101);
+
+    assertThatThrownBy(() -> mapper.readValue(json, Map.class))
+        .isInstanceOf(StreamConstraintsException.class);
+  }
+}

--- a/backend/src/test/java/com/tracepcap/file/mapper/AnalysisEtaTest.java
+++ b/backend/src/test/java/com/tracepcap/file/mapper/AnalysisEtaTest.java
@@ -63,8 +63,9 @@ class AnalysisEtaTest {
   @Test
   void doesNotUnderestimateASmallCapture() {
     // The failure seen live: a 45KB capture estimated at 10s took 49s. A tiny capture still pays
-    // the fixed costs, so the floor must not collapse toward zero.
-    assertThat(estimate(250, 45_760L, true)).isGreaterThanOrEqualTo(2);
+    // the fixed costs, so the floor must not collapse toward zero. FileMapper's MIN_ESTIMATE_SECONDS
+    // is 10 — assert that floor directly rather than a weaker bound a regression could slip under.
+    assertThat(estimate(250, 45_760L, true)).isGreaterThanOrEqualTo(10);
   }
 
   @Test

--- a/backend/src/test/java/com/tracepcap/file/mapper/AnalysisEtaTest.java
+++ b/backend/src/test/java/com/tracepcap/file/mapper/AnalysisEtaTest.java
@@ -1,0 +1,100 @@
+package com.tracepcap.file.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.tracepcap.common.stage.DetectionEngineStatus;
+import com.tracepcap.file.entity.FileEntity;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The analysis ETA (#758 follow-on).
+ *
+ * <p>The old model was seconds-per-packet with no fixed term, which read <b>91 minutes</b> for a job
+ * of roughly 36 and <b>10 seconds</b> for one that took 49 — the same missing constant, in opposite
+ * directions. Measured cost per 1000 packets fell ~8x between a 250-packet capture and a 45,000
+ * packet one, because a large fixed cost was being amortised as if it scaled.
+ *
+ * <p>Tolerances are wide on purpose: this is about the model having the right shape, not about
+ * freezing constants. Re-fit with {@code scripts/calibrate_analysis_eta.py} rather than nudging
+ * numbers until the test passes.
+ */
+class AnalysisEtaTest {
+
+  private final DetectionEngineStatus engine = mock(DetectionEngineStatus.class);
+  private final FileMapper mapper = new FileMapper(engine);
+
+  AnalysisEtaTest() {
+    ReflectionTestUtils.setField(mapper, "suricataEnabled", true);
+  }
+
+  private FileEntity capture(int packets, long sizeBytes, boolean allStages) {
+    FileEntity f = new FileEntity();
+    f.setId(UUID.randomUUID());
+    f.setPacketCount(packets);
+    f.setFileSize(sizeBytes);
+    f.setEnableNdpi(allStages);
+    f.setEnableSuricata(allStages);
+    f.setEnableFileExtraction(allStages);
+    f.setStatus(FileEntity.FileStatus.COMPLETED);
+    return f;
+  }
+
+  private Integer estimate(int packets, long sizeBytes, boolean warm) {
+    when(engine.isWarm()).thenReturn(warm);
+    return mapper.toMetadataDto(capture(packets, sizeBytes, true)).getEstimatedAnalysisSeconds();
+  }
+
+  @Test
+  void matchesAMeasuredMidSizedRun() {
+    // 20,000 packets / 17.4MB measured at 17.3s end to end.
+    assertThat(estimate(20_000, 17_445_184L, true)).isBetween(10, 30);
+  }
+
+  @Test
+  void matchesAMeasuredLargeRun() {
+    // 45,000 packets / 39MB measured at ~44s.
+    assertThat(estimate(45_000, 39_035_724L, true)).isBetween(25, 70);
+  }
+
+  @Test
+  void doesNotUnderestimateASmallCapture() {
+    // The failure seen live: a 45KB capture estimated at 10s took 49s. A tiny capture still pays
+    // the fixed costs, so the floor must not collapse toward zero.
+    assertThat(estimate(250, 45_760L, true)).isGreaterThanOrEqualTo(2);
+  }
+
+  @Test
+  void aColdEngineIsAMuchLongerJob() {
+    // ~45s of ruleset build, paid once per process (#569). Ignoring it made a 47s first run look
+    // like a 2s one.
+    assertThat(estimate(2_000, 1_717_040L, false) - estimate(2_000, 1_717_040L, true))
+        .isGreaterThan(30);
+  }
+
+  @Test
+  void theEstimateGrowsWithPackets() {
+    assertThat(estimate(45_000, 39_035_724L, true))
+        .isGreaterThan(estimate(2_000, 1_717_040L, true));
+  }
+
+  @Test
+  void aMillionPacketCaptureIsNoLongerPredictedAtNinetyMinutes() {
+    // The report that started this: 1.7M packets predicted at 91m36s. Asserted as a ceiling, not a
+    // target — the true figure at that size is unmeasured. This only pins that the old
+    // 3.23 s/kpkt rate, which was mostly a mis-modelled fixed cost, is gone.
+    assertThat(estimate(1_700_000, 468L * 1024 * 1024, true)).isLessThan(75 * 60);
+  }
+
+  @Test
+  void disablingStagesMakesTheEstimateSmaller() {
+    when(engine.isWarm()).thenReturn(true);
+    Integer bare =
+        mapper.toMetadataDto(capture(20_000, 17_445_184L, false)).getEstimatedAnalysisSeconds();
+
+    assertThat(bare).isLessThan(estimate(20_000, 17_445_184L, true));
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-346-ga91ca51}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-348-g183d380}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-354-g153560c}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-358-g074a635}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-350-gd5c4583}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-352-gf89e142}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-342-g399628a}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-344-g0395fe3}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-352-gf89e142}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-354-g153560c}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-358-g074a635}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-360-g1fe6984}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-348-g183d380}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-350-gd5c4583}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-344-g0395fe3}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-346-ga91ca51}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-336-gecab425}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-338-g2ded9ff}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-338-g2ded9ff}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-340-g0a30809}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
         # The default below is rewritten on every merge to main by
         # .github/workflows/app-version.yml — it is the version local builds bake in.
         # Export APP_VERSION to override (CI passes the live `git describe` for GHCR images).
-        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-340-g0a30809}
+        VITE_APP_VERSION: ${APP_VERSION:-v0.1.1-342-g399628a}
     container_name: tracepcap-nginx
     restart: unless-stopped
     deploy:

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -22,21 +22,22 @@ directly. Set ``APP_MEMORY_MB`` and everything else scales automatically.
      - Total RAM (in MB) allocated to the backend container — the default for
        the enforced container memory limit and the budget for derived settings.
        All derived values use the *effective* budget (the enforced cgroup limit
-       when one is set, else this value): JVM heap = 50%, max upload size = 25%,
-       nginx body limit = max upload + 50 MB multipart buffer, the max JSON
-       string length (report topology diagrams — see `Report Generation`_) =
-       2.5% clamped to 8-256 MB, and the proxy/analysis timeout scales with
-       memory (300–900 s). Examples:
-       ``2048`` → 512 MB max upload
-       (default), ``4096`` → 1 GB, ``8192`` → 2 GB. The heap is 50% rather than
-       75% because tshark/ndpi/Suricata allocate outside the JVM heap — see
+       when one is set, else this value): JVM heap = 50%, max upload size = 16%
+       (at most 1/3 of the heap — the parser holds the whole capture in memory,
+       see ``scripts/check_memory_budget.py``), nginx body limit = max upload +
+       50 MB multipart buffer, the max JSON string length (report topology
+       diagrams — see `Report Generation`_) = 2.5% clamped to 8-256 MB, and the
+       proxy/analysis timeout scales with memory (300–900 s). Examples:
+       ``2048`` → 327 MB max upload
+       (default), ``4096`` → 655 MB, ``8192`` → 1310 MB. The heap is 50% rather
+       than 75% because tshark/ndpi/Suricata allocate outside the JVM heap — see
        :doc:`../operations/production-hardening`.
    * - ``BACKEND_MEM_LIMIT``
      - ``APP_MEMORY_MB``
      - Enforced backend container memory limit. Tracks ``APP_MEMORY_MB`` by
        default. When set explicitly it becomes the **effective budget**: the JVM
        heap, max upload size and analysis timeout are all derived from it rather
-       than from ``APP_MEMORY_MB``, keeping the 50%/25% split coherent at any
+       than from ``APP_MEMORY_MB``, keeping the 50%/16% split coherent at any
        cap. Setting it lower therefore also lowers the max upload size.
    * - ``BACKEND_CPU_LIMIT``
      - ``4``

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -23,8 +23,10 @@ directly. Set ``APP_MEMORY_MB`` and everything else scales automatically.
        the enforced container memory limit and the budget for derived settings.
        All derived values use the *effective* budget (the enforced cgroup limit
        when one is set, else this value): JVM heap = 50%, max upload size = 25%,
-       nginx body limit = max upload + 50 MB multipart buffer, and the
-       proxy/analysis timeout scales with memory (300–900 s). Examples:
+       nginx body limit = max upload + 50 MB multipart buffer, the max JSON
+       string length (report topology diagrams — see `Report Generation`_) =
+       2.5% clamped to 8-256 MB, and the proxy/analysis timeout scales with
+       memory (300–900 s). Examples:
        ``2048`` → 512 MB max upload
        (default), ``4096`` → 1 GB, ``8192`` → 2 GB. The heap is 50% rather than
        75% because tshark/ndpi/Suricata allocate outside the JVM heap — see
@@ -494,6 +496,27 @@ limit is hit, a warning is shown on the Extracted Files tab. See
      - ``50``
      - Max size (MB) of a single extracted file that will be stored. Larger
        files are detected but skipped (shown with a "Too large" badge).
+
+Report Generation
+-----------------
+
+The PDF report request carries a base64-encoded PNG of the topology diagram
+(force-directed and hierarchical layouts) as a single JSON string field. Jackson
+caps any single JSON string token at 20 MB by default, purely as a memory-safety
+guard against unbounded allocation from one request — a dense topology's
+captured diagram can exceed that, which fails the request with
+``String length (...) exceeds the maximum length (...)`` before it reaches the
+controller.
+
+There is no separate variable for this. Like the upload limit in
+`Memory & Upload`_, it is **derived from** ``APP_MEMORY_MB`` by
+``backend/docker-entrypoint.sh``: 2.5% of the effective budget, clamped to
+8-256 MB. At the default ``APP_MEMORY_MB=2048`` that is ~51 MB — above
+Jackson's 20 MB default but still a small, heap-proportional ceiling rather
+than a flat one, so it doesn't threaten a small deployment's heap the way a
+fixed 50 MB default would. Raise ``APP_MEMORY_MB`` (see `Memory & Upload`_) if
+large/dense topology diagrams still fail to download. See
+:doc:`../features/report-export`.
 
 Frontend (build-time)
 ---------------------

--- a/scripts/calibrate_analysis_eta.py
+++ b/scripts/calibrate_analysis_eta.py
@@ -31,6 +31,27 @@ BASE = {2, 4, 5, 6}      # parse + classify/geo + save + DB insert
 EXTRACT = {3}            # nDPI + Suricata
 FILE_EXTRACTION = {7}
 
+# Above this, the detection stage is building the ruleset rather than inspecting packets.
+COLD_ENGINE_THRESHOLD_S = 20.0
+
+
+
+def fit(points: list[tuple[int, float]]) -> tuple[float, float]:
+    """Least squares of seconds = fixed + per_kpkt * kpkt.
+
+    Returns (fixed_seconds, seconds_per_kpkt). Both terms matter: a model with only the second
+    one is what produced a 91-minute estimate for a 36-minute job and a 10-second estimate for a
+    49-second one — the same missing constant, in opposite directions.
+    """
+    n = len(points)
+    xs = [p / 1000.0 for p, _ in points]
+    ys = [s for _, s in points]
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    denom = sum((x - mx) ** 2 for x in xs)
+    slope = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / denom if denom else 0.0
+    return my - slope * mx, slope
+
 
 def main() -> int:
     stages: dict[str, dict[int, int]] = defaultdict(dict)
@@ -52,6 +73,19 @@ def main() -> int:
         return 1
 
     runs.sort(key=lambda r: r[1])
+
+    # A cold-engine run is a different regime, not an outlier: Suricata's ruleset build is ~45s
+    # once per process, and mixing one into the fit drags the fixed term up and flattens the slope
+    # to zero. Detected by its own signature rather than a hardcoded file id.
+    cold = [r for r in runs if sum(r[2].get(i, 0) for i in EXTRACT) / 1000 > COLD_ENGINE_THRESHOLD_S]
+    runs = [r for r in runs if r not in cold]
+    if cold:
+        secs = [sum(r[2].get(i, 0) for i in EXTRACT) / 1000 for r in cold]
+        print(f"Excluded {len(cold)} cold-engine run(s) from the fit "
+              f"(detection stage {min(secs):.0f}-{max(secs):.0f}s — the one-time ruleset build).\n")
+    if not runs:
+        print("Only cold-engine runs found; nothing to fit.", file=sys.stderr)
+        return 1
     print(f"{'packets':>10} {'total s':>9} {'base':>8} {'extract':>9} {'file-ext':>9}   (s per 1000 packets)")
     agg = defaultdict(list)
     for _, pkts, st, total in runs:
@@ -76,6 +110,21 @@ def main() -> int:
         drift = (large_v / small_v) if small_v else float("inf")
         verdict = "looks per-packet" if 0.5 <= drift <= 2 else "NOT per-packet — fixed cost leaking in"
         print(f"  {key:>9}: {small_v:.3f} @ {small_n} -> {large_v:.3f} @ {large_n}  ({verdict})")
+    print("\nFitted model — seconds = fixed + per_kpkt * (packets/1000):\n")
+    absolute = defaultdict(list)
+    for _, pkts, st, _ in runs:
+        absolute["base"].append((pkts, sum(st.get(i, 0) for i in BASE) / 1000))
+        absolute["extract"].append((pkts, sum(st.get(i, 0) for i in EXTRACT) / 1000))
+        absolute["file-ext"].append((pkts, sum(st.get(i, 0) for i in FILE_EXTRACTION) / 1000))
+    for key, pts in absolute.items():
+        if len(pts) < 2:
+            print(f"  {key:>9}: needs at least two runs to fit")
+            continue
+        fixed, per = fit(pts)
+        print(f"  {key:>9}: fixed {max(fixed, 0.0):6.2f}s   per_kpkt {max(per, 0.0):6.3f}s"
+              f"   (from {len(pts)} runs, {pts[0][0]}..{pts[-1][0]} packets)")
+    print("\nA fit from clustered sizes extrapolates badly. Treat per_kpkt as trustworthy only")
+    print("across the range measured, and re-run this when a much larger capture completes.")
     return 0
 
 

--- a/scripts/calibrate_analysis_eta.py
+++ b/scripts/calibrate_analysis_eta.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Derive the analysis-ETA coefficients in FileMapper from real runs.
+
+The constants in `FileMapper` are seconds-per-1000-packets per stage, and they are only as good
+as the runs they were fitted to. They were fitted once, against a 21.4k-packet capture, before the
+warm Suricata engine (#569) removed the cost they were mostly describing — after which they said
+Suricata was the dominant term while it had become the cheapest.
+
+This reads the per-stage timings the pipeline already logs and prints measured coefficients, so a
+recalibration is a command rather than an afternoon with a calculator.
+
+Usage:
+    docker compose logs backend | python3 scripts/calibrate_analysis_eta.py
+
+Feed it logs covering at least two captures of very different sizes: a single point cannot tell a
+per-packet cost from a fixed one, which is exactly how the current constants went wrong.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import defaultdict
+
+STAGE = re.compile(r"\[([0-9a-f-]{36})\] \[(\d)/7\] ([A-Za-z +&-]+?): (\d+)ms")
+PARSE = re.compile(r"\[([0-9a-f-]{36})\] \[2/7\] PCAP parse: \d+ms\s+\((\d+) packets")
+DONE = re.compile(r"\[([0-9a-f-]{36})\] Analysis complete: total (\d+)ms")
+
+# Which stages make up each coefficient in FileMapper.
+BASE = {2, 4, 5, 6}      # parse + classify/geo + save + DB insert
+EXTRACT = {3}            # nDPI + Suricata
+FILE_EXTRACTION = {7}
+
+
+def main() -> int:
+    stages: dict[str, dict[int, int]] = defaultdict(dict)
+    packets: dict[str, int] = {}
+    totals: dict[str, int] = {}
+
+    for line in sys.stdin:
+        if (m := PARSE.search(line)):
+            packets[m.group(1)] = int(m.group(2))
+        if (m := STAGE.search(line)):
+            stages[m.group(1)][int(m.group(2))] = int(m.group(4))
+        if (m := DONE.search(line)):
+            totals[m.group(1)] = int(m.group(2))
+
+    runs = [(f, packets[f], stages[f], totals[f])
+            for f in totals if f in packets and packets[f] > 0]
+    if not runs:
+        print("No complete runs found in the input.", file=sys.stderr)
+        return 1
+
+    runs.sort(key=lambda r: r[1])
+    print(f"{'packets':>10} {'total s':>9} {'base':>8} {'extract':>9} {'file-ext':>9}   (s per 1000 packets)")
+    agg = defaultdict(list)
+    for _, pkts, st, total in runs:
+        k = pkts / 1000.0
+        row = {
+            "base": sum(st.get(i, 0) for i in BASE) / 1000 / k,
+            "extract": sum(st.get(i, 0) for i in EXTRACT) / 1000 / k,
+            "file-ext": sum(st.get(i, 0) for i in FILE_EXTRACTION) / 1000 / k,
+        }
+        for key, val in row.items():
+            agg[key].append((pkts, val))
+        print(f"{pkts:>10} {total/1000:>9.1f} {row['base']:>8.3f} {row['extract']:>9.3f} {row['file-ext']:>9.3f}")
+
+    print("\nPer-packet cost is only real if it holds across sizes. Compare the smallest and")
+    print("largest run below: a coefficient that shrinks as captures grow was a fixed cost")
+    print("wearing a per-packet costume.\n")
+    for key, points in agg.items():
+        if len(points) < 2:
+            print(f"  {key:>9}: one run only — cannot separate fixed from per-packet")
+            continue
+        (small_n, small_v), (large_n, large_v) = points[0], points[-1]
+        drift = (large_v / small_v) if small_v else float("inf")
+        verdict = "looks per-packet" if 0.5 <= drift <= 2 else "NOT per-packet — fixed cost leaking in"
+        print(f"  {key:>9}: {small_v:.3f} @ {small_n} -> {large_v:.3f} @ {large_n}  ({verdict})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_env_passthrough.py
+++ b/scripts/check_env_passthrough.py
@@ -64,6 +64,7 @@ STACKS = {
 EXEMPT = {
     "MAX_UPLOAD_SIZE_BYTES":   "passed as -D by backend/docker-entrypoint.sh, derived from the memory budget",
     "ANALYSIS_TIMEOUT_SECONDS": "passed as -D by backend/docker-entrypoint.sh, derived from the memory budget",
+    "JACKSON_MAX_STRING_LENGTH": "passed as -D by backend/docker-entrypoint.sh, derived from the memory budget",
     "SERVER_PORT":             "internal; fixed at 8080 behind nginx",
     "SPRING_PROFILES_ACTIVE":  "set per compose file to select the profile",
     "LOG_DIR":                 "set by backend/docker-entrypoint.sh",

--- a/scripts/check_env_passthrough.py
+++ b/scripts/check_env_passthrough.py
@@ -28,6 +28,7 @@ Usage: python3 scripts/check_env_passthrough.py
 Exit:  0 clean, 1 unreachable variables found
 """
 
+import pathlib
 import re
 import sys
 from pathlib import Path
@@ -100,8 +101,33 @@ def vars_passed(compose_files):
     return passed
 
 
+# Internal wiring rather than operator knobs: compose builds these from variables .env.example
+# does document (DATABASE_URL from POSTGRES_DB, MINIO_ACCESS_KEY from MINIO_ROOT_USER, and so on).
+# Documenting the derived name would invite someone to set it and wonder why the source still won.
+INTERNAL_WIRING = {
+    "DATABASE_URL",
+    "DATABASE_USERNAME",
+    "DATABASE_PASSWORD",
+    "MINIO_ENDPOINT",
+    "MINIO_ACCESS_KEY",
+    "MINIO_SECRET_KEY",
+    "MINIO_BUCKET",
+    "TZ",
+}
+
+
+def documented_vars(path="\u002eenv.example"):
+    """Variables .env.example mentions, commented-out ones included.
+
+    A commented default still documents that the knob exists, which is the point — an operator
+    reads this file to learn what is tunable.
+    """
+    text = pathlib.Path(".env.example").read_text() if pathlib.Path(".env.example").exists() else ""
+    return set(re.findall(r"^#?\s*([A-Z_][A-Z0-9_]*)=", text, re.M))
+
+
 def main():
-    unreachable, dead = [], []
+    unreachable, dead, undocumented = [], [], []
     for stack, (compose_files, profile_files) in sorted(STACKS.items()):
         reachable = vars_passed(compose_files)
         read = vars_read(profile_files)
@@ -119,8 +145,28 @@ def main():
             if var not in EXEMPT and var not in read and var not in PASSTHROUGH
         )
 
-    if not unreachable and not dead:
-        print("OK — backend environment and Spring config agree in both directions.")
+    # Third edge of the same triangle: compose <-> application.yml was already checked, but a
+    # variable can be wired end to end and still be invisible, because nothing tells the operator
+    # it exists. .env.example is the only place they look.
+    documented = documented_vars()
+    for stack, (compose_files, _) in sorted(STACKS.items()):
+        if stack != "prod":
+            continue  # one representative stack; the others are supersets of the same names
+        undocumented.extend(
+            var
+            for var in sorted(vars_passed(compose_files))
+            if var not in EXEMPT and var not in INTERNAL_WIRING and var not in documented
+        )
+
+    if undocumented:
+        print("Passed to the backend but absent from .env.example:\n")
+        for var in undocumented:
+            print(f"  {var}")
+        print("\nAdd each with a short note on what it does and its default. A setting nobody")
+        print("knows about is not configurable.\n")
+
+    if not unreachable and not dead and not undocumented:
+        print("OK — compose, Spring config and .env.example all agree.")
         return 0
 
     if unreachable:

--- a/scripts/check_env_passthrough.py
+++ b/scripts/check_env_passthrough.py
@@ -123,7 +123,10 @@ def documented_vars(path="\u002eenv.example"):
     A commented default still documents that the knob exists, which is the point — an operator
     reads this file to learn what is tunable.
     """
-    text = pathlib.Path(".env.example").read_text() if pathlib.Path(".env.example").exists() else ""
+    example = pathlib.Path(path)
+    if not example.is_absolute():
+        example = ROOT / example
+    text = example.read_text() if example.exists() else ""
     return set(re.findall(r"^#?\s*([A-Z_][A-Z0-9_]*)=", text, re.M))
 
 
@@ -150,14 +153,14 @@ def main():
     # variable can be wired end to end and still be invisible, because nothing tells the operator
     # it exists. .env.example is the only place they look.
     documented = documented_vars()
-    for stack, (compose_files, _) in sorted(STACKS.items()):
-        if stack != "prod":
-            continue  # one representative stack; the others are supersets of the same names
-        undocumented.extend(
-            var
-            for var in sorted(vars_passed(compose_files))
-            if var not in EXEMPT and var not in INTERNAL_WIRING and var not in documented
-        )
+    passed_by_any_stack = set()
+    for compose_files, _ in STACKS.values():
+        passed_by_any_stack |= vars_passed(compose_files)
+    undocumented.extend(
+        var
+        for var in sorted(passed_by_any_stack)
+        if var not in EXEMPT and var not in INTERNAL_WIRING and var not in documented
+    )
 
     if undocumented:
         print("Passed to the backend but absent from .env.example:\n")

--- a/scripts/check_memory_budget.py
+++ b/scripts/check_memory_budget.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""The accepted upload size must fit in the heap that has to parse it (#779).
+
+Stage 2 holds the whole capture in memory: every conversation, every packet, payloads included,
+released only during the database insert in stage 6. So the largest file we accept is bounded by
+the JVM heap, and those two numbers are derived separately —
+
+    docker-entrypoint.sh:  JVM heap    = APP_MEMORY_MB * JVM_HEAP_PERCENT / 100
+    docker-entrypoint.sh:  upload cap  = APP_MEMORY_MB * UPLOAD_PERCENT   / 100
+
+#92 set the upload cap at 25% when the heap was 75% — a file could be at most a third of the heap.
+#586 lowered the heap to 50% to make room for native subprocesses and did not revisit the upload
+cap, so the margin silently fell from 3x to 2x. A 468 MB capture was then accepted and died of
+OutOfMemoryError 25 minutes into parsing.
+
+Nothing connected the two numbers, so nothing noticed. This does.
+
+Usage: python3 scripts/check_memory_budget.py
+Exit 0 clean, 1 on a violation.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ENTRYPOINT = Path("backend/docker-entrypoint.sh")
+FILE_SERVICE = Path("backend/src/main/java/com/tracepcap/file/service/FileServiceImpl.java")
+
+# A capture must be at most this fraction of the heap. From #92's original design: 25% upload
+# against a 75% heap. It is a headroom rule, not a measurement — the parser's real multiplier
+# depends on packet size and payload retention — but it is the ratio the system was built around
+# and the one that quietly stopped holding.
+MAX_FILE_FRACTION_OF_HEAP = 1 / 3
+
+
+def read_percent(text: str, pattern: str, label: str) -> int:
+    m = re.search(pattern, text)
+    if not m:
+        print(f"Could not find {label} in {ENTRYPOINT} — this check needs updating.", file=sys.stderr)
+        raise SystemExit(1)
+    return int(m.group(1))
+
+
+def main() -> int:
+    if not ENTRYPOINT.exists():
+        print(f"{ENTRYPOINT} not found; run from the repository root.", file=sys.stderr)
+        return 1
+
+    text = ENTRYPOINT.read_text()
+    heap_pct = read_percent(text, r"JVM_HEAP_PERCENT=\$\{JVM_HEAP_PERCENT:-(\d+)\}", "JVM_HEAP_PERCENT")
+    upload_pct = read_percent(text, r"MAX_UPLOAD_BYTES=\$\(\(\s*EFFECTIVE_MEM_MB \* (\d+) / 100", "the upload percentage")
+
+    failures = []
+
+    allowed = heap_pct * MAX_FILE_FRACTION_OF_HEAP
+    if upload_pct > allowed:
+        failures.append(
+            f"Upload cap is {upload_pct}% of the memory budget, but the heap is only {heap_pct}%.\n"
+            f"    A capture may be at most 1/{int(1/MAX_FILE_FRACTION_OF_HEAP)} of the heap, so the cap\n"
+            f"    must not exceed {allowed:.1f}%. At APP_MEMORY_MB=2048 that is "
+            f"{int(2048 * allowed / 100)}MB, not {int(2048 * upload_pct / 100)}MB.\n"
+            f"    Lower the upload percentage, or raise the heap percentage and re-check that\n"
+            f"    native subprocesses still fit (see the entrypoint's budget comment)."
+        )
+
+    # The limit is only real if the code that rejects uploads actually consults it.
+    if FILE_SERVICE.exists():
+        service = FILE_SERVICE.read_text()
+        if re.search(r"MAX_FILE_SIZE\s*=\s*\d+\s*\*", service):
+            failures.append(
+                f"{FILE_SERVICE} hardcodes a maximum file size.\n"
+                f"    It must read app.max-file-size, or the number shown to the user by\n"
+                f"    /system/limits and the number actually enforced will drift apart again."
+            )
+
+    if failures:
+        print("Memory budget is inconsistent:\n")
+        for f in failures:
+            print(f"  - {f}\n")
+        return 1
+
+    budget = 2048
+    print(
+        f"Memory budget OK — heap {heap_pct}%, upload cap {upload_pct}% "
+        f"({int(budget * upload_pct / 100)}MB of a {int(budget * heap_pct / 100)}MB heap "
+        f"at APP_MEMORY_MB={budget})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Periodic dev -> main release PR per CONTRIBUTING.md. Bundles everything merged to `dev` since the last release, including:

- #793 fix: raise Jackson's 20MB JSON string cap for report topology diagrams
- #780 fix: make the upload cap fit the heap that has to parse it (#779)
- #777 fix: weight the progress bar from measurement, not estimate (#758)
- #782 fix: give the analysis ETA a fixed-cost term (#758 follow-on)
- #784 perf: share the strings every packet repeats (#779)
- #786 ci: run the tool-dependent tests for real, and notice when they cannot (#701)
- #788 docs: document every env var, and gate the third edge (#779 follow-on)
- version-stamp chores

CI re-runs the same gates as on `dev`; merging publishes updated container images via `publish-ghcr.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDyaaPSRNzNXRzJoS794C4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable warm detection-engine settings and improved first-run versus subsequent analysis progress estimates.
  * Added configuration options for tool-calling, network intelligence limits, authentication, resource limits, and application metadata.
  * Added memory-based limits for report-generated topology data.

* **Bug Fixes**
  * Reduced maximum upload allocation to improve stability on memory-constrained deployments.
  * Large reports and captures are now less likely to exhaust memory; services restart cleanly after memory exhaustion.
  * Analysis time estimates now better reflect capture size, enabled processing stages, and first-run overhead.

* **Documentation**
  * Updated environment-variable and memory-configuration documentation with new settings and capacity guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->