### PR TITLE
fix: address CodeRabbit findings from the release PR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This makes it well-suited for:
 
 | Feature | Description |
 |---------|-------------|
-| **PCAP Upload & Management** | Upload and manage PCAP/PCAPNG/CAP files (upload limit derived from `APP_MEMORY_MB`, 512MB by default) with MinIO object storage; duplicate detection and configurable upload limits |
+| **PCAP Upload & Management** | Upload and manage PCAP/PCAPNG/CAP files (upload limit derived from `APP_MEMORY_MB`, 327MB by default) with MinIO object storage; duplicate detection and configurable upload limits |
 | **Network Visualization** | Interactive network topology using Sigma.js (WebGL) + graphology with ForceAtlas2 / ELK layouts, a rich filter panel (IP, port, device type, protocol, risk), fullscreen toggle, layout controls, and clickable node detail panels |
 | **nDPI Security Detection** | Deep packet inspection via nDPI v5: application identification, traffic categories, risk/alert flags, JA3/JA3S TLS fingerprints, SNI extraction, and TLS certificate metadata per conversation |
 | **Conversation Tracking** | Paginated conversation list with advanced filtering (IP, port, protocol, app, risk, custom rules, device type, country, payload pattern), multi-column sorting, column picker, and bulk PCAP export |
@@ -89,11 +89,12 @@ or internet-hosted API.
 | Storage | 10GB (database, PCAP files, object storage) | 50GB+ for large PCAP collections | 100GB+ SSD |
 
 **Comfortable** assumes Suricata enabled and routine work on large captures. Raise the
-`.env` defaults to match — the shipped `APP_MEMORY_MB=2048` caps uploads at 512MB, since
-max upload is 25% of the backend budget:
+`.env` defaults to match — the shipped `APP_MEMORY_MB=2048` caps uploads at 327MB, since
+max upload is 16% of the backend budget (at most 1/3 of the 50% heap, since the parser
+holds the whole capture in memory):
 
 ```ini
-APP_MEMORY_MB=8192      # 4 GB heap, 2 GB max upload
+APP_MEMORY_MB=8192      # 4 GB heap, ~1.3 GB max upload
 BACKEND_CPU_LIMIT=6
 POSTGRES_MEM_LIMIT=2g
 MINIO_MEM_LIMIT=1g
@@ -117,8 +118,8 @@ cp .env.example .env
 **2. Configure `.env`:**
 ```env
 # Memory & Upload Configuration
-# Upload limits are derived from this single value (max upload = 25% of it).
-APP_MEMORY_MB=2048  # 512MB max upload (default)
+# Upload limits are derived from this single value (max upload = 16% of it).
+APP_MEMORY_MB=2048  # 327MB max upload (default)
 
 # Nginx Port Configuration
 NGINX_PORT=80  # Change if port 80 is already in use
@@ -171,7 +172,7 @@ The Network Monitor lets you build a picture of an unknown network from multiple
 
 ### Supported File Formats
 
-PCAP, PCAPNG, CAP (max 512MB default, derived from `APP_MEMORY_MB`)
+PCAP, PCAPNG, CAP (max 327MB default, derived from `APP_MEMORY_MB`)
 
 ## How Network Monitor Works
 

--- a/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
+++ b/backend/src/main/java/com/tracepcap/analysis/service/SuricataEngine.java
@@ -227,6 +227,7 @@ public class SuricataEngine implements DetectionEngineStatus {
         String current = runCommand("pcap-current");
         if (current == null) {
           log.warn("Lost contact with the warm Suricata engine — falling back");
+          discardDaemon();
           return false;
         }
         if (current.contains("None") && Files.exists(eve)) return true;

--- a/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
+++ b/backend/src/main/java/com/tracepcap/file/mapper/FileMapper.java
@@ -95,7 +95,11 @@ public class FileMapper {
             + (ndpi ? NDPI_SECONDS_PER_MB : 0)
             + (suricata ? SURICATA_SECONDS_PER_MB : 0)
             + (fileExtraction ? EXTRACTION_SECONDS_PER_MB : 0);
-    return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(sizeMb * perMb));
+    double seconds = sizeMb * perMb;
+    if (suricata && !engineWarm) {
+      seconds += SURICATA_ENGINE_BUILD_SECONDS;
+    }
+    return Math.max(MIN_ESTIMATE_SECONDS, (int) Math.round(seconds));
   }
 
   public FileUploadResponse toUploadResponse(FileEntity entity) {

--- a/backend/src/test/java/com/tracepcap/file/mapper/AnalysisEtaTest.java
+++ b/backend/src/test/java/com/tracepcap/file/mapper/AnalysisEtaTest.java
@@ -63,8 +63,9 @@ class AnalysisEtaTest {
   @Test
   void doesNotUnderestimateASmallCapture() {
     // The failure seen live: a 45KB capture estimated at 10s took 49s. A tiny capture still pays
-    // the fixed costs, so the floor must not collapse toward zero.
-    assertThat(estimate(250, 45_760L, true)).isGreaterThanOrEqualTo(2);
+    // the fixed costs, so the floor must not collapse toward zero. FileMapper's MIN_ESTIMATE_SECONDS
+    // is 10 — assert that floor directly rather than a weaker bound a regression could slip under.
+    assertThat(estimate(250, 45_760L, true)).isGreaterThanOrEqualTo(10);
   }
 
   @Test

--- a/docs/configuration/environment-variables.rst
+++ b/docs/configuration/environment-variables.rst
@@ -22,21 +22,22 @@ directly. Set ``APP_MEMORY_MB`` and everything else scales automatically.
      - Total RAM (in MB) allocated to the backend container — the default for
        the enforced container memory limit and the budget for derived settings.
        All derived values use the *effective* budget (the enforced cgroup limit
-       when one is set, else this value): JVM heap = 50%, max upload size = 25%,
-       nginx body limit = max upload + 50 MB multipart buffer, the max JSON
-       string length (report topology diagrams — see `Report Generation`_) =
-       2.5% clamped to 8-256 MB, and the proxy/analysis timeout scales with
-       memory (300–900 s). Examples:
-       ``2048`` → 512 MB max upload
-       (default), ``4096`` → 1 GB, ``8192`` → 2 GB. The heap is 50% rather than
-       75% because tshark/ndpi/Suricata allocate outside the JVM heap — see
+       when one is set, else this value): JVM heap = 50%, max upload size = 16%
+       (at most 1/3 of the heap — the parser holds the whole capture in memory,
+       see ``scripts/check_memory_budget.py``), nginx body limit = max upload +
+       50 MB multipart buffer, the max JSON string length (report topology
+       diagrams — see `Report Generation`_) = 2.5% clamped to 8-256 MB, and the
+       proxy/analysis timeout scales with memory (300–900 s). Examples:
+       ``2048`` → 327 MB max upload
+       (default), ``4096`` → 655 MB, ``8192`` → 1310 MB. The heap is 50% rather
+       than 75% because tshark/ndpi/Suricata allocate outside the JVM heap — see
        :doc:`../operations/production-hardening`.
    * - ``BACKEND_MEM_LIMIT``
      - ``APP_MEMORY_MB``
      - Enforced backend container memory limit. Tracks ``APP_MEMORY_MB`` by
        default. When set explicitly it becomes the **effective budget**: the JVM
        heap, max upload size and analysis timeout are all derived from it rather
-       than from ``APP_MEMORY_MB``, keeping the 50%/25% split coherent at any
+       than from ``APP_MEMORY_MB``, keeping the 50%/16% split coherent at any
        cap. Setting it lower therefore also lowers the max upload size.
    * - ``BACKEND_CPU_LIMIT``
      - ``4``

--- a/scripts/check_env_passthrough.py
+++ b/scripts/check_env_passthrough.py
@@ -123,7 +123,10 @@ def documented_vars(path="\u002eenv.example"):
     A commented default still documents that the knob exists, which is the point — an operator
     reads this file to learn what is tunable.
     """
-    text = pathlib.Path(".env.example").read_text() if pathlib.Path(".env.example").exists() else ""
+    example = pathlib.Path(path)
+    if not example.is_absolute():
+        example = ROOT / example
+    text = example.read_text() if example.exists() else ""
     return set(re.findall(r"^#?\s*([A-Z_][A-Z0-9_]*)=", text, re.M))
 
 
@@ -150,14 +153,14 @@ def main():
     # variable can be wired end to end and still be invisible, because nothing tells the operator
     # it exists. .env.example is the only place they look.
     documented = documented_vars()
-    for stack, (compose_files, _) in sorted(STACKS.items()):
-        if stack != "prod":
-            continue  # one representative stack; the others are supersets of the same names
-        undocumented.extend(
-            var
-            for var in sorted(vars_passed(compose_files))
-            if var not in EXEMPT and var not in INTERNAL_WIRING and var not in documented
-        )
+    passed_by_any_stack = set()
+    for compose_files, _ in STACKS.values():
+        passed_by_any_stack |= vars_passed(compose_files)
+    undocumented.extend(
+        var
+        for var in sorted(passed_by_any_stack)
+        if var not in EXEMPT and var not in INTERNAL_WIRING and var not in documented
+    )
 
     if undocumented:
         print("Passed to the backend but absent from .env.example:\n")


### PR DESCRIPTION
## Summary

CodeRabbit reviewed PR #795 (the dev -> main release PR) and left 8 comments. Verified each against the current code before acting — not all of them held up:

- **False positive, no change**: `AnalysisService.java` — CodeRabbit wanted the Suricata progress-bar weighting to honor the global kill-switch, but the code's own comment already documents that as an intentional tradeoff ("the per-file flag, not the effective state... being wrong costs a slightly misshapen bar" — cosmetic only).
- **Real, but deferred**: `PcapParserService.java`'s unbounded per-parse string pool. Genuine edge case (high-cardinality captures could make memory usage *worse*, not better), but the right fix needs a benchmarked capacity choice and a dedicated test, not a same-release patch. Filed as #797.
- **Real and fixed here** (4 findings):
  - `SuricataEngine.java`: clear the warm flag when the control-socket check loses contact, not just when the process exits — a hung-but-alive daemon no longer keeps reporting warm to later captures.
  - `FileMapper.java`: the size-based ETA fallback was missing the cold-engine ruleset-build cost the packet-count path already includes.
  - `AnalysisEtaTest.java`: tightened `>= 2s` to `>= 10s` to actually match `MIN_ESTIMATE_SECONDS`.
  - `docs/configuration/environment-variables.rst` + `README.md`: corrected the stale 25%/512MB upload-cap figure to the real 16%/327MB (default budget) everywhere it was quoted — independently caught by CodeRabbit; matches a doc/code mismatch already flagged during #793's work.
- **In my own diff from #793** (2 findings, both in `check_env_passthrough.py`): `documented_vars()` was ignoring its own `path` argument (Ruff flagged the unused arg too); the undocumented-var check only validated the `prod` compose stack, missing `offline`/`offline-prod`.

## Test plan
- [x] `mvn test -Dtest=SuricataEngineTest,AnalysisEtaTest` — 14/14 passing.
- [x] `python3 scripts/check_env_passthrough.py` — still passes, now actually exercising the fixed code paths.
- [x] `python3 -m py_compile scripts/check_env_passthrough.py` — syntax OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDyaaPSRNzNXRzJoS794C4