### PR TITLE
feat: actionable error + APP_MEMORY_MB recommendation when a report exceeds the JSON string cap

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -90,6 +90,9 @@ if [ "$TIMEOUT" -gt 900 ]; then TIMEOUT=900; fi
 # one JSON string only needs a small multiple of its own size in transient buffer growth (no
 # whole-capture object graph held alongside it), so this stays well under the heap fraction the
 # upload cap uses — see MAX_UPLOAD_BYTES above.
+#
+# GlobalExceptionHandler mirrors this formula (divisor 40, clamp 256) to recommend an
+# APP_MEMORY_MB when a request trips the cap — keep the two in sync if this changes.
 JACKSON_MAX_STRING_MB=$(( EFFECTIVE_MEM_MB / 40 ))
 if [ "$JACKSON_MAX_STRING_MB" -lt 8 ]; then JACKSON_MAX_STRING_MB=8; fi
 if [ "$JACKSON_MAX_STRING_MB" -gt 256 ]; then JACKSON_MAX_STRING_MB=256; fi

--- a/backend/src/main/java/com/tracepcap/common/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/tracepcap/common/dto/ErrorResponse.java
@@ -37,6 +37,16 @@ public class ErrorResponse {
 
   private Integer contextLength;
 
+  /** Size (MB, rounded up) of the JSON string that tripped Jackson's max-string-length guard. */
+  private Integer attemptedSizeMb;
+
+  /**
+   * APP_MEMORY_MB to set so this request's payload fits under the derived JSON string cap (see
+   * JacksonConfig, backend/docker-entrypoint.sh). Null when raising it would not help — the
+   * request exceeds JACKSON_MAX_STRING_MB's hard ceiling regardless of memory budget.
+   */
+  private Integer recommendedAppMemoryMb;
+
   /** Per-field validation messages, present only on 400 validation failures. */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, String> validationErrors;

--- a/backend/src/main/java/com/tracepcap/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tracepcap/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.tracepcap.common.exception;
 
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.tracepcap.common.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
@@ -7,9 +8,13 @@ import jakarta.validation.ConstraintViolationException;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -20,6 +25,24 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  private static final long BYTES_PER_MB = 1024L * 1024L;
+
+  // Mirrors backend/docker-entrypoint.sh's JACKSON_MAX_STRING_MB derivation exactly
+  // (EFFECTIVE_MEM_MB / 40, clamped to [8, 256]) so a recommended APP_MEMORY_MB actually produces
+  // a cap that fits the request that just failed. Keep these two in sync if that formula changes.
+  private static final int JACKSON_CAP_DIVISOR = 40;
+  private static final int JACKSON_CAP_MAX_MB = 256;
+
+  // Jackson's own message shape (StreamConstraintsException), e.g.
+  // "String length (20054016) exceeds the maximum length (20000000)". Stable across the
+  // jackson-core versions this app has used, but not a public API — a future upgrade could
+  // reword it, in which case this handler simply falls back to the generic message below.
+  private static final Pattern STRING_LENGTH_EXCEEDED =
+      Pattern.compile("String length \\((\\d+)\\) exceeds the maximum length \\((\\d+)\\)");
+
+  @Value("${tracepcap.jackson.max-string-length}")
+  private long currentMaxStringLength;
 
   @ExceptionHandler(ResourceNotFoundException.class)
   public ResponseEntity<ErrorResponse> handleResourceNotFoundException(
@@ -178,6 +201,83 @@ public class GlobalExceptionHandler {
             .build();
 
     return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(error);
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(
+      HttpMessageNotReadableException ex, HttpServletRequest request) {
+    Throwable cause = ex.getMostSpecificCause();
+    Matcher matcher =
+        cause instanceof StreamConstraintsException
+            ? STRING_LENGTH_EXCEEDED.matcher(cause.getMessage() == null ? "" : cause.getMessage())
+            : null;
+
+    if (matcher != null && matcher.find()) {
+      log.warn("Request field exceeded the JSON string length cap: {}", cause.getMessage());
+      return stringTooLargeResponse(Long.parseLong(matcher.group(1)), request);
+    }
+
+    log.warn("Malformed request body: {}", ex.getMessage());
+    ErrorResponse error =
+        ErrorResponse.builder()
+            .timestamp(LocalDateTime.now())
+            .status(HttpStatus.BAD_REQUEST.value())
+            .error(HttpStatus.BAD_REQUEST.getReasonPhrase())
+            .message("Malformed request body")
+            .path(request.getRequestURI())
+            .build();
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+  }
+
+  /**
+   * Builds the actionable response for a JSON string that exceeded {@link
+   * #currentMaxStringLength}: how big it was, and — unless it's past the derivation's own hard
+   * ceiling — what {@code APP_MEMORY_MB} would need to be for a request this size to fit.
+   */
+  private ResponseEntity<ErrorResponse> stringTooLargeResponse(
+      long attemptedBytes, HttpServletRequest request) {
+    long attemptedMb = ceilDiv(attemptedBytes, BYTES_PER_MB);
+    long currentCapMb = currentMaxStringLength / BYTES_PER_MB;
+
+    Integer recommendedAppMemoryMb = null;
+    String message;
+    if (attemptedMb > JACKSON_CAP_MAX_MB) {
+      message =
+          String.format(
+              "Request field is %d MB, past the %d MB maximum this deployment supports "
+                  + "regardless of memory settings. Reduce what's being sent (e.g. a "
+                  + "lower-resolution diagram capture) rather than raising APP_MEMORY_MB.",
+              attemptedMb, JACKSON_CAP_MAX_MB);
+    } else {
+      // +10% headroom so the same request doesn't land exactly on the new boundary, then round up
+      // to a clean step — operators think in round APP_MEMORY_MB numbers.
+      long withHeadroomMb = ceilDiv(attemptedMb * 11, 10);
+      long neededBudgetMb = withHeadroomMb * JACKSON_CAP_DIVISOR;
+      recommendedAppMemoryMb = (int) (ceilDiv(neededBudgetMb, 256) * 256);
+      message =
+          String.format(
+              "Request field is %d MB, over this deployment's current %d MB limit "
+                  + "(derived from APP_MEMORY_MB). Raise APP_MEMORY_MB to at least %d in "
+                  + "the backend's environment and restart it.",
+              attemptedMb, currentCapMb, recommendedAppMemoryMb);
+    }
+
+    ErrorResponse error =
+        ErrorResponse.builder()
+            .timestamp(LocalDateTime.now())
+            .status(HttpStatus.PAYLOAD_TOO_LARGE.value())
+            .error(HttpStatus.PAYLOAD_TOO_LARGE.getReasonPhrase())
+            .message(message)
+            .path(request.getRequestURI())
+            .errorCode("PAYLOAD_STRING_TOO_LARGE")
+            .attemptedSizeMb((int) attemptedMb)
+            .recommendedAppMemoryMb(recommendedAppMemoryMb)
+            .build();
+    return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(error);
+  }
+
+  private static long ceilDiv(long numerator, long denominator) {
+    return (numerator + denominator - 1) / denominator;
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/test/java/com/tracepcap/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/tracepcap/common/exception/GlobalExceptionHandlerTest.java
@@ -2,6 +2,7 @@ package com.tracepcap.common.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.tracepcap.common.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
@@ -10,9 +11,12 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -27,6 +31,24 @@ class GlobalExceptionHandlerTest {
 
   private static final GlobalExceptionHandler HANDLER = new GlobalExceptionHandler();
   private static final String PATH = "/api/v1/some/resource";
+
+  // Matches the default derived cap (APP_MEMORY_MB=2048 -> 51MB), same value application.yml
+  // falls back to when docker-entrypoint.sh isn't in the picture.
+  private static final long DEFAULT_MAX_STRING_LENGTH = 53_477_376L;
+
+  static {
+    ReflectionTestUtils.setField(HANDLER, "currentMaxStringLength", DEFAULT_MAX_STRING_LENGTH);
+  }
+
+  private static HttpMessageNotReadableException stringLengthExceeded(long attemptedBytes) {
+    return new HttpMessageNotReadableException(
+        "JSON parse error: String length (" + attemptedBytes + ") exceeds the maximum length ("
+            + DEFAULT_MAX_STRING_LENGTH + ")",
+        new StreamConstraintsException(
+            "String length (" + attemptedBytes + ") exceeds the maximum length ("
+                + DEFAULT_MAX_STRING_LENGTH + ")"),
+        null);
+  }
 
   private static HttpServletRequest request() {
     MockHttpServletRequest req = new MockHttpServletRequest();
@@ -113,6 +135,21 @@ class GlobalExceptionHandlerTest {
                 HANDLER.handleNoResourceFound(
                     new NoResourceFoundException(HttpMethod.GET, PATH), req)),
         new Case(
+            "HttpMessageNotReadable, unrelated cause -> 400",
+            400,
+            "Bad Request",
+            null,
+            req ->
+                HANDLER.handleHttpMessageNotReadable(
+                    new HttpMessageNotReadableException("garbled JSON", (HttpInputMessage) null),
+                    req)),
+        new Case(
+            "HttpMessageNotReadable, string-length cap -> 413",
+            413,
+            "Payload Too Large",
+            "PAYLOAD_STRING_TOO_LARGE",
+            req -> HANDLER.handleHttpMessageNotReadable(stringLengthExceeded(20_054_016L), req)),
+        new Case(
             "Unhandled -> 500",
             500,
             "Internal Server Error",
@@ -158,5 +195,41 @@ class GlobalExceptionHandlerTest {
     assertThat(body.getPromptTokens()).isEqualTo(9000);
     assertThat(body.getContextLength()).isEqualTo(8000);
     assertThat(body.getPromptText()).isEqualTo("the prompt");
+  }
+
+  @Test
+  void stringTooLarge_recommendsAnAppMemoryMbThatWouldActuallyFit() {
+    // The exact figures from the live report-download failure this handler exists for (#792):
+    // a 20,054,016-char diagram string against the old fixed 20MB Jackson default.
+    ResponseEntity<ErrorResponse> response =
+        HANDLER.handleHttpMessageNotReadable(stringLengthExceeded(20_054_016L), request());
+
+    ErrorResponse body = response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getErrorCode()).isEqualTo("PAYLOAD_STRING_TOO_LARGE");
+    assertThat(body.getAttemptedSizeMb()).isEqualTo(20);
+    // ceil(20 * 1.1) = 22MB needed cap -> 22 * 40 = 880MB budget -> rounded up to 1024MB.
+    assertThat(body.getRecommendedAppMemoryMb()).isEqualTo(1024);
+    assertThat(body.getMessage()).contains("APP_MEMORY_MB").contains("1024");
+
+    // The recommendation must actually mirror docker-entrypoint.sh's derivation: at the
+    // recommended budget, EFFECTIVE_MEM_MB / 40 must be >= the attempted size.
+    long derivedCapMbAtRecommendation = body.getRecommendedAppMemoryMb() / 40;
+    assertThat(derivedCapMbAtRecommendation).isGreaterThanOrEqualTo(body.getAttemptedSizeMb());
+  }
+
+  @Test
+  void stringTooLarge_pastTheHardCeiling_recommendsNothing() {
+    // 300MB is past JACKSON_CAP_MAX_MB (256) — no APP_MEMORY_MB raises the cap that high.
+    long attemptedBytes = 300L * 1024 * 1024;
+    ResponseEntity<ErrorResponse> response =
+        HANDLER.handleHttpMessageNotReadable(stringLengthExceeded(attemptedBytes), request());
+
+    ErrorResponse body = response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getErrorCode()).isEqualTo("PAYLOAD_STRING_TOO_LARGE");
+    assertThat(body.getAttemptedSizeMb()).isEqualTo(300);
+    assertThat(body.getRecommendedAppMemoryMb()).isNull();
+    assertThat(body.getMessage()).contains("regardless of memory settings");
   }
 }

--- a/frontend/e2e/llm-error.spec.ts
+++ b/frontend/e2e/llm-error.spec.ts
@@ -56,3 +56,37 @@ test('Filter Generator shows an error alert when filter generation returns 502',
   await expect(alert).toBeVisible();
   await expect(alert).toContainText(/LLM server is not responding/i);
 });
+
+test('Report download shows an actionable alert when the diagram exceeds the JSON string cap', async ({ page }) => {
+  // Regression guard for #792/the GlobalExceptionHandler PAYLOAD_STRING_TOO_LARGE branch: the
+  // report POST uses responseType: 'blob' (it's a PDF on success), so an error body comes back as
+  // a Blob, not a parsed object — the frontend has to read it out explicitly. Force that exact
+  // response via route interception rather than generating an actually-oversized diagram.
+  await page.route('**/api/v1/files/*/report', route =>
+    route.fulfill({
+      status: 413,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 413,
+        error: 'Payload Too Large',
+        message:
+          "Request field is 63 MB, over this deployment's current 51 MB limit "
+          + '(derived from APP_MEMORY_MB). Raise APP_MEMORY_MB to at least 2048 in '
+          + "the backend's environment and restart it.",
+        errorCode: 'PAYLOAD_STRING_TOO_LARGE',
+        attemptedSizeMb: 63,
+        recommendedAppMemoryMb: 2048,
+      }),
+    })
+  );
+
+  await page.goto(`/analysis/${fileId}`);
+  await page.getByRole('button', { name: /Download Report/i }).click();
+
+  const alert = page.locator('.alert-danger');
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText('Report Too Large for This Deployment');
+  await expect(alert).toContainText('63 MB');
+  await expect(alert).toContainText('APP_MEMORY_MB');
+  await expect(alert).toContainText('2048');
+});

--- a/frontend/src/pages/Analysis/AnalysisPage.tsx
+++ b/frontend/src/pages/Analysis/AnalysisPage.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from '@components/common/Spinner/Spinner';
+import { Alert } from '@components/common/Alert';
 import { useState, useEffect, useRef, useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
 import { Button, Card } from '@govtechsg/sgds-react';
 import { useParams, Outlet, useNavigate, useLocation } from 'react-router-dom';
@@ -97,6 +98,11 @@ export const AnalysisPage = () => {
   const [activeTab, setActiveTab] = useState('overview');
   const [reportLoading, setReportLoading] = useState(false);
   const [reportError, setReportError] = useState<string | null>(null);
+  const [reportMemoryError, setReportMemoryError] = useState<{
+    message: string;
+    attemptedSizeMb: number;
+    recommendedAppMemoryMb: number | null;
+  } | null>(null);
   const [reportStep, setReportStep] = useState<string | null>(null);
 
   // ── Story generation state (lifted here so it survives tab switches) ──────
@@ -285,6 +291,7 @@ export const AnalysisPage = () => {
     if (!fileId) return;
     setReportLoading(true);
     setReportError(null);
+    setReportMemoryError(null);
     setReportStep('Rendering network diagrams…');
     try {
       const { filteredNodes, filteredEdges, nodeLimitNote: refNodeLimitNote } = networkGraphStateRef.current;
@@ -365,7 +372,33 @@ export const AnalysisPage = () => {
       URL.revokeObjectURL(url);
     } catch (e) {
       console.error('Report generation failed', e);
-      setReportError('Report generation failed. Please try again.');
+
+      // This request uses responseType: 'blob' (it's a PDF on success), so axios applies that
+      // same responseType to an error body too — a JSON error comes back as a Blob, not a parsed
+      // object, and has to be read out explicitly before its fields are usable.
+      const raw = (e as { response?: { data?: unknown } })?.response?.data;
+      let data: Record<string, unknown> = {};
+      if (raw instanceof Blob) {
+        try {
+          data = JSON.parse(await raw.text());
+        } catch {
+          // Not a JSON body (e.g. an HTML error page from a proxy) — fall through below.
+        }
+      } else if (raw && typeof raw === 'object') {
+        data = raw as Record<string, unknown>;
+      }
+
+      if (data.errorCode === 'PAYLOAD_STRING_TOO_LARGE') {
+        setReportMemoryError({
+          message:
+            (data.message as string) ??
+            'The network topology diagram was too large to include in the report.',
+          attemptedSizeMb: (data.attemptedSizeMb as number) ?? 0,
+          recommendedAppMemoryMb: (data.recommendedAppMemoryMb as number | null) ?? null,
+        });
+      } else {
+        setReportError('Report generation failed. Please try again.');
+      }
     } finally {
       setReportLoading(false);
       setReportStep(null);
@@ -431,6 +464,30 @@ export const AnalysisPage = () => {
           {reportError && <small className="text-danger">{reportError}</small>}
         </div>
       </div>
+
+      {reportMemoryError && (
+        <Alert variant="danger" className="mb-3" onClose={() => setReportMemoryError(null)} dismissible>
+          <Alert.Heading>
+            <i className="bi bi-exclamation-triangle-fill me-2"></i>
+            Report Too Large for This Deployment
+          </Alert.Heading>
+          <p className="mb-2">
+            The network topology diagram was <strong>{reportMemoryError.attemptedSizeMb} MB</strong>,
+            over what this deployment currently accepts in a single request.
+          </p>
+          {reportMemoryError.recommendedAppMemoryMb ? (
+            <p className="mb-0">
+              Raise <code>APP_MEMORY_MB</code> to at least{' '}
+              <strong>{reportMemoryError.recommendedAppMemoryMb}</strong> in the backend's
+              environment and restart it, then try downloading the report again. (Everything else
+              in this app — the JVM heap, upload size, and analysis timeout — is derived from the
+              same setting, so this also gives the backend more headroom overall.)
+            </p>
+          ) : (
+            <p className="mb-0">{reportMemoryError.message}</p>
+          )}
+        </Alert>
+      )}
 
       {/* Navigation Tabs */}
       <div className="nav-tabs-scroll-wrapper">


### PR DESCRIPTION
## Summary

Follow-up to #793/#792. Even with the raised cap, a report can still exceed it (or exceed the pre-raise default on an unmigrated deployment) — and today that fails as a generic 500 "Report generation failed. Please try again.", with no indication of why or what to do.

- **Backend** (`GlobalExceptionHandler`): handles `HttpMessageNotReadableException` directly instead of letting it fall into the catch-all. When the cause is a `StreamConstraintsException` from the string-length cap, parses the attempted size out of Jackson's own exception message and computes a recommended `APP_MEMORY_MB` by inverting `docker-entrypoint.sh`'s derivation formula (divisor 40, clamp 256MB) — with a distinct message when the request is past that clamp entirely, since no amount of `APP_MEMORY_MB` would help there. Other malformed-JSON-body cases (unrelated to this cap) now get a proper 400 instead of the same 500 catch-all they silently fell into before.
- **Frontend** (`AnalysisPage.tsx`): reads the structured error and shows an actionable `Alert` with the attempted size and recommended value, instead of the generic failure text. Had to account for the report request's `responseType: 'blob'` applying to error bodies too — the error JSON comes back as a `Blob`, not a parsed object, and has to be read out explicitly. Follows this repo's existing `CONTEXT_LENGTH_EXCEEDED` pattern (LLM story generator) for structured, actionable error UX.

## Test plan
- [x] `GlobalExceptionHandlerTest` (new cases): unrelated malformed body → 400; string-length cap → 413 with `PAYLOAD_STRING_TOO_LARGE`; recommendation math verified against the real reported failure (20,054,016 chars → recommends 1024MB, and independently re-derives that 1024/40 ≥ the attempted size); past-the-hard-ceiling case → `recommendedAppMemoryMb` is null with the right message. `mvn test` — 473/474 passing (the one failure is a pre-existing local-environment gap, missing `tshark`, unrelated to this change).
- [x] `npx tsc --noEmit` — clean. `npm run build` — clean.
- [x] New Playwright e2e test (`llm-error.spec.ts`) forcing the 413 via route interception, run against a real rebuilt stack in a real browser — alert renders and is visible with the attempted size and recommended value. (This file specifically exists to catch SGDS `Alert` rendering `null` under React 19 when `defaultProps` aren't restored — real value in testing the actual DOM here, not just TypeScript types.)
- [x] End-to-end against the real backend (not mocked): rebuilt the stack, POSTed an oversized payload to `/api/v1/files/{fileId}/report` — got back `413` with `attemptedSizeMb: 52`, `recommendedAppMemoryMb: 2560`, confirming the real Jackson exception flows through this new handler correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDyaaPSRNzNXRzJoS794C4